### PR TITLE
Fix sign in

### DIFF
--- a/source/sdk/src/main/kotlin/com/clerk/sdk/model/signin/SignIn.kt
+++ b/source/sdk/src/main/kotlin/com/clerk/sdk/model/signin/SignIn.kt
@@ -50,7 +50,7 @@ data class SignIn(
   val status: Status,
 
   /** Array of all the authentication identifiers that are supported for this sign in. */
-  val supportedIdentifiers: List<Requests.SignInRequest.Identifier>? = null,
+  @SerialName("supported_identifiers") val supportedIdentifiers: List<String>? = null,
 
   /** The authentication identifier value for the current sign-in. */
   val identifier: String? = null,
@@ -60,7 +60,7 @@ data class SignIn(
    *
    * Each factor contains information about the verification strategy that can be used.
    */
-  val supportedFirstFactors: List<Factor>? = null,
+  @SerialName("supported_first_factors") val supportedFirstFactors: List<Factor>? = null,
 
   /**
    * Array of the second factors that are supported in the current sign-in.
@@ -68,7 +68,7 @@ data class SignIn(
    * Each factor contains information about the verification strategy that can be used. This
    * property is populated only when the first factor is verified.
    */
-  val supportedSecondFactors: List<Factor>? = null,
+  @SerialName("supported_second_factors") val supportedSecondFactors: List<Factor>? = null,
 
   /**
    * The state of the verification process for the selected first factor.
@@ -77,7 +77,7 @@ data class SignIn(
    * selected. You need to call the `prepareFirstFactor` method in order to start the verification
    * process.
    */
-  val firstFactorVerification: Verification? = null,
+  @SerialName("first_factor_verification") val firstFactorVerification: Verification? = null,
 
   /**
    * The state of the verification process for the selected second factor.
@@ -86,21 +86,21 @@ data class SignIn(
    * selected. For the `phone_code` strategy, you need to call the `prepareSecondFactor` method in
    * order to start the verification process. For the `totp` strategy, you can directly attempt.
    */
-  val secondFactorVerification: Verification? = null,
+  @SerialName("second_factor_verification") val secondFactorVerification: Verification? = null,
 
   /**
    * An object containing information about the user of the current sign-in.
    *
    * This property is populated only once an identifier is given to the SignIn object.
    */
-  val userData: UserData? = null,
+  @SerialName("user_data") val userData: UserData? = null,
 
   /**
    * The identifier of the session that was created upon completion of the current sign-in.
    *
    * The value of this property is null if the sign-in status is not `complete`.
    */
-  val createdSessionId: String? = null,
+  @SerialName("created_session_id") val createdSessionId: String? = null,
 ) {
 
   /**


### PR DESCRIPTION
This pull request updates the `SignIn` data class in the `Clerk SDK` to align with serialized naming conventions. The changes ensure that the serialized field names match the expected backend API format by using the `@SerialName` annotation.

### Serialization Improvements:

* Updated `supportedIdentifiers` to use `@SerialName("supported_identifiers")` and changed its type from `List<Requests.SignInRequest.Identifier>` to `List<String>` to align with API expectations.
* Added `@SerialName("supported_first_factors")` and `@SerialName("supported_second_factors")` annotations to `supportedFirstFactors` and `supportedSecondFactors`, respectively, for consistent serialized naming.
* Applied `@SerialName("first_factor_verification")` and `@SerialName("second_factor_verification")` annotations to the `firstFactorVerification` and `secondFactorVerification` fields for proper serialization. [[1]](diffhunk://#diff-1a22e1118664c98ac22cd01b7fd3b34455905d4bdb20461f8c964aeb29f302f3L80-R80) [[2]](diffhunk://#diff-1a22e1118664c98ac22cd01b7fd3b34455905d4bdb20461f8c964aeb29f302f3L89-R103)
* Annotated `userData` with `@SerialName("user_data")` and `createdSessionId` with `@SerialName("created_session_id")` to ensure serialized names match the API format.## What
[Brief description of changes]

## Why
[Reason for changes]

## Ticket
[Ticket/Issue reference]