### PR TITLE
Add entry points to the objects themselves

### DIFF
--- a/source/src/main/kotlin/com/clerk/emailaddress/EmailAddress.kt
+++ b/source/src/main/kotlin/com/clerk/emailaddress/EmailAddress.kt
@@ -46,6 +46,22 @@ data class EmailAddress(
       @SerialName("action_complete_redirect_url") val actionCompleteRedirectUrl: String? = null,
     ) : PrepareVerificationParams
   }
+
+  companion object {
+    /**
+     * Creates a new email address for the current user or the user with the given session ID.
+     *
+     * The newly created email address will be unverified initially. The user will need to complete
+     * the verification process before the email address can be used for authentication.
+     *
+     * @param email The email address to add to the user's account
+     * @return A [ClerkResult] containing the created [EmailAddress] object on success, or a
+     *   [ClerkErrorResponse] on failure
+     */
+    suspend fun create(email: String): ClerkResult<EmailAddress, ClerkErrorResponse> {
+      return ClerkApi.user.createEmailAddress(emailAddress = email)
+    }
+  }
 }
 
 /**

--- a/source/src/main/kotlin/com/clerk/passkeys/Passkey.kt
+++ b/source/src/main/kotlin/com/clerk/passkeys/Passkey.kt
@@ -36,7 +36,24 @@ data class Passkey(
 
   /** The date when the passkey was last used. */
   val lastUsedAt: Long? = null,
-)
+) {
+
+  companion object {
+    /**
+     * Creates a new passkey for the current user or the user with the given session ID.
+     *
+     * Passkeys are a modern, secure authentication method that uses cryptographic key pairs. The
+     * creation process will typically prompt the user to use their device's biometric
+     * authentication (fingerprint, face recognition) or device PIN to create the passkey.
+     *
+     * @return A [ClerkResult] containing the created [Passkey] object on success, or a
+     *   [ClerkErrorResponse] on failure
+     */
+    suspend fun create(): ClerkResult<Passkey, ClerkErrorResponse> {
+      return PasskeyService.createPasskey()
+    }
+  }
+}
 
 /**
  * Updates the properties of this passkey.

--- a/source/src/main/kotlin/com/clerk/phonenumber/PhoneNumber.kt
+++ b/source/src/main/kotlin/com/clerk/phonenumber/PhoneNumber.kt
@@ -60,7 +60,26 @@ data class PhoneNumber(
 
   /** A list of backup codes in case of lost phone number access. */
   val backupCodes: List<String>? = null,
-)
+) {
+
+  companion object {
+    /**
+     * Creates a new phone number for the current user or the user with the given session ID.
+     *
+     * The newly created phone number will be unverified initially. The user will need to complete
+     * the verification process (typically via SMS) before the phone number can be used for
+     * authentication or two-factor authentication.
+     *
+     * @param phoneNumber The phone number to add to the user's account (should include country
+     *   code)
+     * @return A [ClerkResult] containing the created [PhoneNumber] object on success, or a
+     *   [ClerkErrorResponse] on failure
+     */
+    suspend fun create(phoneNumber: String): ClerkResult<PhoneNumber, ClerkErrorResponse> {
+      return ClerkApi.user.createPhoneNumber(phoneNumber)
+    }
+  }
+}
 
 /**
  * Attempts to verify this phone number using the provided verification code.


### PR DESCRIPTION
This pull request introduces new `create` methods to the `EmailAddress`, `Passkey`, and `PhoneNumber` data classes, enabling the creation of these objects via their respective companion objects. These methods streamline the process of adding new authentication factors for users.

### New `create` methods added:

* **Email Address Creation**:
  - Added a `create` method in the companion object of `EmailAddress` to allow the creation of a new email address. The created email address will initially be unverified, requiring the user to complete the verification process.

* **Passkey Creation**:
  - Added a `create` method in the companion object of `Passkey` to enable the creation of a new passkey. This method facilitates secure authentication using cryptographic key pairs and typically involves biometric or PIN-based verification.

* **Phone Number Creation**:
  - Added a `create` method in the companion object of `PhoneNumber` to allow users to add a new phone number. Like email addresses, the phone number will initially be unverified and require verification via SMS.