### PR TITLE
Add password field to `Password` strategy in SignIn Create params

### DIFF
--- a/source/src/main/kotlin/com/clerk/signin/SignIn.kt
+++ b/source/src/main/kotlin/com/clerk/signin/SignIn.kt
@@ -512,8 +512,11 @@ data class SignIn(
        */
       @AutoMap
       @Serializable
-      data class Password(val identifier: String, override val strategy: String = PASSWORD) :
-        Strategy
+      data class Password(
+        val identifier: String,
+        val password: String,
+        override val strategy: String = PASSWORD,
+      ) : Strategy
 
       /**
        * Transfer strategy for account transfer scenarios.


### PR DESCRIPTION
This pull request makes an important update to the `Password` data class in the `SignIn.kt` file. The change introduces a new `password` field to the class, which will likely play a role in enhancing the sign-in functionality.

### Changes to the `Password` data class:

* [`source/src/main/kotlin/com/clerk/signin/SignIn.kt`](diffhunk://#diff-95619bd066f2e93b1c16b51e3e5e3406d7f540d0aac490f00a564bfa6099fc3dL515-R519): Added a new `password` field to the `Password` data class, which now includes `identifier`, `password`, and `strategy` fields. This change enhances the representation of the password-based sign-in strategy.