### PR TITLE
Fix dokka docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,17 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v3
+      with:
+        gradle-version: wrapper
+        build-root-directory: main
+    - name: Grant execute permission for gradlew
+      working-directory: main
+      run: chmod +x gradlew
     - name: Generate docs
       working-directory: main
-      run: ./gradlew dokkaHtmlMultiModule
+      run: ./gradlew dokkaHtmlMultiModule --no-daemon --stacktrace
     - name: Zip docs site
       run: |
         cd main/docs
@@ -50,15 +58,16 @@ jobs:
       with:
         ref: docs
         path: docs
-    - uses: actions/download-artifact@v5.0.0
+    - uses: actions/download-artifact@v4
       with:
+        name: "main"
         path: artifacts
     - name: Unzip
       run: |
         mkdir unzipped-docs
         unzipped_path="unzipped-docs/main"
         mkdir -p "$unzipped_path"
-        unzip "artifacts/main/Docs.zip" -d "$unzipped_path"
+        unzip "artifacts/Docs.zip" -d "$unzipped_path"
         echo "extracting to root"
         rsync -a "$unzipped_path/" docs/docs
     - name: Update git config
@@ -67,8 +76,9 @@ jobs:
         git config --local user.name "swolfand"
         git config --local user.email "sam@clerk.dev"
     - name: Commit
-      working-directory: main
+      working-directory: docs
       run: |
+        cd ../main
         current_sha="$(git rev-parse @)"
         cd ../docs
         if [[ -z $(git status --porcelain) ]]; then exit 0; fi


### PR DESCRIPTION
## What
Updated the `docs.yml` GitHub Actions workflow to fix issues with Dokka documentation generation and deployment.

## Why
The docs action was broken due to several issues, including:
- A version mismatch between `upload-artifact@v4` and `download-artifact@v5`.
- Missing Gradle setup and caching.
- Incorrect artifact download paths and working directory logic.
- The changes ensure the Dokka documentation builds, zips, and deploys correctly to the `docs` branch.

## Ticket
N/A

---
[Slack Thread](https://clerkinc.slack.com/archives/C08SE0321GR/p1754694121153189?thread_ts=1754694121.153189&cid=C08SE0321GR)

<a href="https://cursor.com/background-agent?bcId=bc-01dfbf82-b4ff-4001-b881-945df56094be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01dfbf82-b4ff-4001-b881-945df56094be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

