### PR TITLE
use material theme

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/core/button/ButtonStyleTokens.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/button/ButtonStyleTokens.kt
@@ -1,14 +1,13 @@
 package com.clerk.ui.core.button
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.clerk.api.ui.ClerkColors
 import com.clerk.api.ui.ClerkDesign
-import com.clerk.api.ui.ClerkTypography
 import com.clerk.ui.colors.ComputedColors
 
 @Immutable
@@ -27,16 +26,14 @@ internal data class ButtonStyleTokens(
 internal fun buildButtonTokens(
   style: ButtonStyle,
   config: ClerkButtonConfig,
-  colors: ClerkColors,
   computed: ComputedColors,
-  typography: ClerkTypography,
   design: ClerkDesign,
   isPressed: Boolean,
 ): ButtonStyleTokens {
   val text =
     when (config.size) {
-      ClerkButtonConfig.Size.Small -> typography.titleSmall!!
-      ClerkButtonConfig.Size.Large -> typography.bodyLarge!!
+      ClerkButtonConfig.Size.Small -> MaterialTheme.typography.titleSmall
+      ClerkButtonConfig.Size.Large -> MaterialTheme.typography.bodyLarge
     }
 
   val height =
@@ -66,8 +63,8 @@ internal fun buildButtonTokens(
       ClerkButtonConfig.Emphasis.High -> computed.buttonBorder
     }
 
-  val foreground = generateForeground(style, config, colors, isPressed)
-  val background = generateBackground(style, config, colors, isPressed, computed)
+  val foreground = generateForeground(style, config, isPressed)
+  val background = generateBackground(style, config, isPressed, computed)
 
   return ButtonStyleTokens(
     textStyle = text,
@@ -81,40 +78,41 @@ internal fun buildButtonTokens(
   )
 }
 
+@Composable
 private fun generateForeground(
   style: ButtonStyle,
   config: ClerkButtonConfig,
-  colors: ClerkColors,
   isPressed: Boolean,
 ): Color =
   when (style) {
     ButtonStyle.Primary ->
       when (config.emphasis) {
-        ClerkButtonConfig.Emphasis.High -> colors.primaryForeground!!
+        ClerkButtonConfig.Emphasis.High -> MaterialTheme.colorScheme.onPrimary
         ClerkButtonConfig.Emphasis.Low,
-        ClerkButtonConfig.Emphasis.None -> colors.primary!!
+        ClerkButtonConfig.Emphasis.None -> MaterialTheme.colorScheme.primary
       }
 
     ButtonStyle.Secondary ->
       when (config.emphasis) {
         ClerkButtonConfig.Emphasis.None ->
-          if (isPressed) colors.foreground!! else colors.mutedForeground!!
+          if (isPressed) MaterialTheme.colorScheme.primary
+          else MaterialTheme.colorScheme.onSurfaceVariant
         ClerkButtonConfig.Emphasis.Low,
-        ClerkButtonConfig.Emphasis.High -> colors.foreground!!
+        ClerkButtonConfig.Emphasis.High -> MaterialTheme.colorScheme.onBackground
       }
 
     ButtonStyle.Negative ->
       when (config.emphasis) {
-        ClerkButtonConfig.Emphasis.High -> colors.primaryForeground!!
+        ClerkButtonConfig.Emphasis.High -> MaterialTheme.colorScheme.onPrimary
         ClerkButtonConfig.Emphasis.Low,
-        ClerkButtonConfig.Emphasis.None -> colors.danger!!
+        ClerkButtonConfig.Emphasis.None -> MaterialTheme.colorScheme.error
       }
   }
 
+@Composable
 private fun generateBackground(
   style: ButtonStyle,
   config: ClerkButtonConfig,
-  colors: ClerkColors,
   isPressed: Boolean,
   computed: ComputedColors,
 ): Color =
@@ -122,24 +120,28 @@ private fun generateBackground(
     ButtonStyle.Primary ->
       when (config.emphasis) {
         ClerkButtonConfig.Emphasis.High ->
-          if (isPressed) computed.primaryPressed else colors.primary!!
+          if (isPressed) computed.primaryPressed else MaterialTheme.colorScheme.primary
         ClerkButtonConfig.Emphasis.Low,
-        ClerkButtonConfig.Emphasis.None -> if (isPressed) colors.muted!! else colors.background!!
+        ClerkButtonConfig.Emphasis.None ->
+          if (isPressed) MaterialTheme.colorScheme.secondary
+          else MaterialTheme.colorScheme.background
       }
 
     ButtonStyle.Secondary ->
       when (config.emphasis) {
         ClerkButtonConfig.Emphasis.None,
         ClerkButtonConfig.Emphasis.Low,
-        ClerkButtonConfig.Emphasis.High -> if (isPressed) colors.muted!! else colors.background!!
+        ClerkButtonConfig.Emphasis.High ->
+          if (isPressed) MaterialTheme.colorScheme.secondary
+          else MaterialTheme.colorScheme.background
       }
 
     ButtonStyle.Negative ->
       when (config.emphasis) {
         ClerkButtonConfig.Emphasis.High ->
-          if (isPressed) computed.backgroundDanger else colors.danger!!
+          if (isPressed) computed.backgroundDanger else MaterialTheme.colorScheme.error
         ClerkButtonConfig.Emphasis.Low,
         ClerkButtonConfig.Emphasis.None ->
-          if (isPressed) computed.backgroundDanger else colors.background!!
+          if (isPressed) computed.backgroundDanger else MaterialTheme.colorScheme.background
       }
   }

--- a/source/ui/src/main/java/com/clerk/ui/core/button/ClerkButton.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/button/ClerkButton.kt
@@ -72,9 +72,7 @@ fun ClerkButton(
       buildButtonTokens(
         style = buttonStyle,
         config = buttonConfig,
-        colors = ClerkThemeAccess.colors,
         computed = ClerkThemeAccess.computed,
-        typography = ClerkThemeAccess.typography,
         design = ClerkThemeAccess.design,
         isPressed = pressed,
       )

--- a/source/ui/src/main/java/com/clerk/ui/theme/ClerkComposeTheme.kt
+++ b/source/ui/src/main/java/com/clerk/ui/theme/ClerkComposeTheme.kt
@@ -139,9 +139,6 @@ private fun computeColorScheme(colors: ClerkColors): ColorScheme {
       outline = colors.border!!,
       secondary = colors.muted!!,
       tertiary = colors.neutral!!,
-      surfaceVariant = colors.muted!!,
-      onSecondary = colors.foreground!!,
-      onTertiary = colors.foreground!!,
       onSurfaceVariant = colors.mutedForeground!!,
     )
   } else {
@@ -156,9 +153,6 @@ private fun computeColorScheme(colors: ClerkColors): ColorScheme {
       outline = colors.border!!,
       secondary = colors.muted!!,
       tertiary = colors.neutral!!,
-      surfaceVariant = colors.muted!!,
-      onSecondary = colors.foreground!!,
-      onTertiary = colors.foreground!!,
       onSurfaceVariant = colors.mutedForeground!!,
     )
   }


### PR DESCRIPTION
This pull request refactors how button colors and typography are sourced in the UI codebase, shifting from custom theme objects to using Material Design 3's `MaterialTheme`. This change improves consistency with the Material Design system and simplifies theme management. The most important changes are grouped below:

**Migration to MaterialTheme for Button Styling:**

* Button foreground and background colors, as well as text styles, now use values from `MaterialTheme.colorScheme` and `MaterialTheme.typography` instead of custom `ClerkColors` and `ClerkTypography` objects in `ButtonStyleTokens.kt`. This affects both the logic for color selection and the parameters passed to helper functions. [[1]](diffhunk://#diff-2464c873a0a36062988c6f0b2994bd9f0a4241c14c20160436683ced2ff44138L30-R36) [[2]](diffhunk://#diff-2464c873a0a36062988c6f0b2994bd9f0a4241c14c20160436683ced2ff44138L69-R67) [[3]](diffhunk://#diff-2464c873a0a36062988c6f0b2994bd9f0a4241c14c20160436683ced2ff44138R81-R145) [[4]](diffhunk://#diff-78959873b1af8a747fd154677463bf3a9b822daacdaf6772cdbb60e1dff6e2f7L75-L77)

**Simplification of Theme Color Scheme:**

* Several unused or redundant color scheme properties (`onSecondary`, `onTertiary`, `surfaceVariant`) were removed from the `computeColorScheme` function in `ClerkComposeTheme.kt`, further aligning the theme with Material Design conventions. [[1]](diffhunk://#diff-488d12db698e0f8e91efa91c98d8995c2761e90a2590faabd3f646b3db269d19L142-L144) [[2]](diffhunk://#diff-488d12db698e0f8e91efa91c98d8995c2761e90a2590faabd3f646b3db269d19L159-L161)