### PR TITLE
Add role endpoint

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
@@ -6,6 +6,7 @@ import com.clerk.api.Clerk
 import com.clerk.api.network.api.ClientApi
 import com.clerk.api.network.api.DeviceAttestationApi
 import com.clerk.api.network.api.EnvironmentApi
+import com.clerk.api.network.api.OrganizationApi
 import com.clerk.api.network.api.SessionApi
 import com.clerk.api.network.api.SignInApi
 import com.clerk.api.network.api.SignUpApi
@@ -66,6 +67,10 @@ internal object ClerkApi {
   val deviceAttestationApi: DeviceAttestationApi
     get() = _deviceAttestationApi ?: error("ClerkApi is not configured.")
 
+  private var _organizationApi: OrganizationApi? = null
+  val organizationApi: OrganizationApi
+    get() = _organizationApi ?: error("ClerkApi is not configured.")
+
   /** Initializes the API client with the given [baseUrl]. */
   fun configure(baseUrl: String, context: Context) {
     val retrofit = buildRetrofit(baseUrl, context)
@@ -76,6 +81,7 @@ internal object ClerkApi {
     _signUp = retrofit.create(SignUpApi::class.java)
     _user = retrofit.create(UserApi::class.java)
     _deviceAttestationApi = retrofit.create(DeviceAttestationApi::class.java)
+    _organizationApi = retrofit.create(OrganizationApi::class.java)
   }
 
   /** Builds and configures the Retrofit instance. */

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
@@ -1,0 +1,19 @@
+package com.clerk.api.network.api
+
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.paths.Paths
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.organizations.Role
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface OrganizationApi {
+
+  @GET(Paths.Organizations.ROLES)
+  fun roles(
+    @Path("organization_id") organizationId: String,
+    @Query("limit") limit: Int? = null,
+    @Query("offset") offset: Int? = null,
+  ): ClerkResult<List<Role>, ClerkErrorResponse>
+}

--- a/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
@@ -170,6 +170,11 @@ internal object Paths {
     /** Backup codes endpoint */
     const val BACKUP_CODES = "${ME}/backup_codes"
   }
+
+  internal object Organizations {
+    const val ORGANIZATIONS = "organizations"
+    const val ROLES = "${ORGANIZATIONS}/{organization_id}/roles"
+  }
 }
 
 /**


### PR DESCRIPTION
This pull request adds support for organization roles to the Clerk API client. The main changes introduce a new `OrganizationApi` interface, update the API client to include it, and add the necessary endpoint paths for organization roles.

**Organization API support:**

* Added the new `OrganizationApi` interface with a `roles` method for fetching organization roles, including support for pagination via `limit` and `offset` query parameters. (`source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt`)
* Registered the `OrganizationApi` in the `ClerkApi` singleton, including initialization and getter logic. (`source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt`) [[1]](diffhunk://#diff-3829098cd41d785ef6bb33276e43aa2256c671c246d3cdd6553201db0481f176R9) [[2]](diffhunk://#diff-3829098cd41d785ef6bb33276e43aa2256c671c246d3cdd6553201db0481f176R70-R73) [[3]](diffhunk://#diff-3829098cd41d785ef6bb33276e43aa2256c671c246d3cdd6553201db0481f176R84)

**Endpoint path additions:**

* Added new organization-related paths, including the roles endpoint, to the `Paths` object. (`source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt`)