### PR TITLE
Add accept to UserInvitation

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/attestation/DeviceAttestationHelper.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/attestation/DeviceAttestationHelper.kt
@@ -215,7 +215,7 @@ internal object DeviceAttestationHelper {
 
     return try {
       ClerkLog.d("Performing device assertion with token")
-      val result = ClerkApi.deviceAttestationApi.verify(packageName = applicationId, token = token)
+      val result = ClerkApi.deviceAttestation.verify(packageName = applicationId, token = token)
 
       when (result) {
         is ClerkResult.Success -> {

--- a/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
@@ -63,13 +63,13 @@ internal object ClerkApi {
   val user: UserApi
     get() = _user ?: error("ClerkApi is not configured.")
 
-  private var _deviceAttestationApi: DeviceAttestationApi? = null
-  val deviceAttestationApi: DeviceAttestationApi
-    get() = _deviceAttestationApi ?: error("ClerkApi is not configured.")
+  private var _deviceAttestation: DeviceAttestationApi? = null
+  val deviceAttestation: DeviceAttestationApi
+    get() = _deviceAttestation ?: error("ClerkApi is not configured.")
 
-  private var _organizationApi: OrganizationApi? = null
-  val organizationApi: OrganizationApi
-    get() = _organizationApi ?: error("ClerkApi is not configured.")
+  private var _organization: OrganizationApi? = null
+  val organization: OrganizationApi
+    get() = _organization ?: error("ClerkApi is not configured.")
 
   /** Initializes the API client with the given [baseUrl]. */
   fun configure(baseUrl: String, context: Context) {
@@ -80,8 +80,8 @@ internal object ClerkApi {
     _signIn = retrofit.create(SignInApi::class.java)
     _signUp = retrofit.create(SignUpApi::class.java)
     _user = retrofit.create(UserApi::class.java)
-    _deviceAttestationApi = retrofit.create(DeviceAttestationApi::class.java)
-    _organizationApi = retrofit.create(OrganizationApi::class.java)
+    _deviceAttestation = retrofit.create(DeviceAttestationApi::class.java)
+    _organization = retrofit.create(OrganizationApi::class.java)
   }
 
   /** Builds and configures the Retrofit instance. */

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
@@ -5,15 +5,22 @@ import com.clerk.api.network.paths.Paths
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.organizations.Role
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface OrganizationApi {
 
   @GET(Paths.Organizations.ROLES)
-  fun roles(
+  suspend fun getRoles(
     @Path("organization_id") organizationId: String,
     @Query("limit") limit: Int? = null,
     @Query("offset") offset: Int? = null,
   ): ClerkResult<List<Role>, ClerkErrorResponse>
+
+  @POST(Paths.Organizations.ACCEPT_USER_INVITATION)
+  suspend fun acceptUserOrganizationInvitation(
+    @Path("invitation_id") invitationId: String,
+    @Query("_clerk_session_id") sessionId: String? = null,
+  )
 }

--- a/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
@@ -174,6 +174,9 @@ internal object Paths {
   internal object Organizations {
     const val ORGANIZATIONS = "organizations"
     const val ROLES = "${ORGANIZATIONS}/{organization_id}/roles"
+
+    const val ACCEPT_USER_INVITATION =
+      "${ORGANIZATIONS}/organization_invitations/{invitation_id}/accept"
   }
 }
 

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/UserOrganizationInvitation.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/UserOrganizationInvitation.kt
@@ -1,5 +1,7 @@
 package com.clerk.api.organizations
 
+import com.clerk.api.Clerk
+import com.clerk.api.network.ClerkApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 
@@ -27,11 +29,20 @@ data class UserOrganizationInvitation(
   val updatedAt: Long,
   val createdAt: Long,
 ) {
+  @Serializable
   enum class Status {
     Pending,
     Accepted,
     Revoked,
   }
+}
+
+/** Accepts the invitation to the organization. */
+suspend fun UserOrganizationInvitation.accept(invitationId: String) {
+  ClerkApi.organization.acceptUserOrganizationInvitation(
+    invitationId = invitationId,
+    sessionId = Clerk.session?.id,
+  )
 }
 
 @Serializable

--- a/source/api/src/test/java/com/clerk/api/attestation/DeviceAttestationHelperTest.kt
+++ b/source/api/src/test/java/com/clerk/api/attestation/DeviceAttestationHelperTest.kt
@@ -39,7 +39,7 @@ class DeviceAttestationHelperTest {
 
     // Set up default behavior
     every { IntegrityManagerFactory.createStandard(any()) } returns mockIntegrityManager
-    every { ClerkApi.deviceAttestationApi } returns mockDeviceAttestationApi
+    every { ClerkApi.deviceAttestation } returns mockDeviceAttestationApi
 
     // Reset the helper state
     DeviceAttestationHelper.integrityManager = null


### PR DESCRIPTION
This pull request refactors the `ClerkApi` object to standardize API property naming, introduces new organization invitation functionality, and updates related usage throughout the codebase. The most important changes are grouped below:

**API Property Renaming and Refactoring:**

* Renamed properties in `ClerkApi` from `deviceAttestationApi` and `organizationApi` to `deviceAttestation` and `organization`, including corresponding internal variables and initialization logic. This affects both the implementation and any code referencing these properties. [[1]](diffhunk://#diff-3829098cd41d785ef6bb33276e43aa2256c671c246d3cdd6553201db0481f176L66-R72) [[2]](diffhunk://#diff-3829098cd41d785ef6bb33276e43aa2256c671c246d3cdd6553201db0481f176L83-R84) [[3]](diffhunk://#diff-131ab6190d8a73a2fc953b4ecc96440839e80b6d81e16f9e2d6b3c2d238dde00L218-R218) [[4]](diffhunk://#diff-14d6d753f1e195dfc469f467fa4e71e7cdda0a18610cb3709edd28297e90a48dL42-R42)

**Organization Invitation Feature:**

* Added a new `acceptUserOrganizationInvitation` suspend function to `OrganizationApi`, allowing users to accept organization invitations via a POST endpoint.
* Updated `Paths` to include the new `ACCEPT_USER_INVITATION` endpoint for organization invitations.
* Added an extension function `accept` to `UserOrganizationInvitation` to call the new API method, passing the invitation ID and session ID.
* Updated imports in `UserOrganizationInvitation.kt` to support the new functionality.