### PR TITLE
add api to OrganizationSuggestion.kt and move api methods paths

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
@@ -18,9 +18,15 @@ interface OrganizationApi {
     @Query("offset") offset: Int? = null,
   ): ClerkResult<List<Role>, ClerkErrorResponse>
 
-  @POST(Paths.Organizations.ACCEPT_USER_INVITATION)
+  @POST(Paths.UserPath.ACCEPT_ORGANIZATION_INVITATION)
   suspend fun acceptUserOrganizationInvitation(
     @Path("invitation_id") invitationId: String,
+    @Query("_clerk_session_id") sessionId: String? = null,
+  )
+
+  @POST(Paths.UserPath.ACCEPT_ORGANIZATION_SUGGESTION)
+  suspend fun acceptOrganizationSuggestion(
+    @Path("suggestion_id") suggestionId: String,
     @Query("_clerk_session_id") sessionId: String? = null,
   )
 }

--- a/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
@@ -101,6 +101,11 @@ internal object Paths {
     const val ME = "me"
     const val PROFILE_IMAGE = "${ME}/profile_image"
 
+    const val ACCEPT_ORGANIZATION_INVITATION =
+      "${ME}/organization_invitations/{invitation_id}/accept"
+    const val ACCEPT_ORGANIZATION_SUGGESTION =
+      "${ME}/organization_suggestions/{suggestion_id}/accept"
+
     /** Password management endpoints. */
     internal object Password {
       const val UPDATE = "${ME}/change_password"
@@ -174,9 +179,6 @@ internal object Paths {
   internal object Organizations {
     const val ORGANIZATIONS = "organizations"
     const val ROLES = "${ORGANIZATIONS}/{organization_id}/roles"
-
-    const val ACCEPT_USER_INVITATION =
-      "${ORGANIZATIONS}/organization_invitations/{invitation_id}/accept"
   }
 }
 

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationSuggestion.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationSuggestion.kt
@@ -1,5 +1,7 @@
 package com.clerk.api.organizations
 
+import com.clerk.api.Clerk
+import com.clerk.api.network.ClerkApi
 import kotlinx.serialization.Serializable
 
 /** An interface representing an organization suggestion. */
@@ -16,3 +18,15 @@ data class OrganizationSuggestion(
   /** The timestamp when the suggestion was last updated. */
   val updatedAt: Long,
 )
+
+/**
+ * Accepts this organization suggestion.
+ *
+ * @param invitationId The identifier of the invitation to accept.
+ */
+suspend fun OrganizationSuggestion.accept(invitationId: String) {
+  ClerkApi.organization.acceptOrganizationSuggestion(
+    suggestionId = invitationId,
+    sessionId = Clerk.session?.id,
+  )
+}

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/UserOrganizationInvitation.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/UserOrganizationInvitation.kt
@@ -37,7 +37,11 @@ data class UserOrganizationInvitation(
   }
 }
 
-/** Accepts the invitation to the organization. */
+/**
+ * Accepts this user organization invitation.
+ *
+ * @param invitationId The identifier of the invitation to accept.
+ */
 suspend fun UserOrganizationInvitation.accept(invitationId: String) {
   ClerkApi.organization.acceptUserOrganizationInvitation(
     invitationId = invitationId,


### PR DESCRIPTION
This pull request updates the organization invitation and suggestion acceptance flows to use new endpoint paths and introduces a new method for accepting organization suggestions. The changes improve consistency in API design, add support for organization suggestions, and update documentation for clarity.

**API endpoint updates:**

* Changed the endpoint for accepting user organization invitations to use `Paths.UserPath.ACCEPT_ORGANIZATION_INVITATION` instead of the previous organization-based path. [[1]](diffhunk://#diff-c6d2a45dc5f1cfacf52749c63564bd6b1eb2f600d5375c1fc3ac79f69f60166bL21-R31) [[2]](diffhunk://#diff-e63c50f7390358a0fe615f12529eff9678419c871d774262d555a5cec7c8699eR104-R108) [[3]](diffhunk://#diff-e63c50f7390358a0fe615f12529eff9678419c871d774262d555a5cec7c8699eL177-L179)
* Added a new endpoint path `Paths.UserPath.ACCEPT_ORGANIZATION_SUGGESTION` for accepting organization suggestions.

**New feature: Organization suggestion acceptance**

* Added the `acceptOrganizationSuggestion` method to `OrganizationApi`, enabling users to accept organization suggestions.
* Introduced an extension function `OrganizationSuggestion.accept(invitationId: String)` to call the new API endpoint for accepting organization suggestions. [[1]](diffhunk://#diff-fc8381dbfdd2a803bdf667d7d0b537b47a3f000bb706345f968849f8bbfa464cR21-R32) [[2]](diffhunk://#diff-fc8381dbfdd2a803bdf667d7d0b537b47a3f000bb706345f968849f8bbfa464cR3-R4)

**Documentation improvements:**

* Enhanced KDoc comments for the `accept` extension functions in both `UserOrganizationInvitation` and `OrganizationSuggestion` to clarify their purpose and parameters. [[1]](diffhunk://#diff-3585791f49117f6426d4caa125024120c3b34426021e5cd9c8770c04c0a9bd50L40-R44) [[2]](diffhunk://#diff-fc8381dbfdd2a803bdf667d7d0b537b47a3f000bb706345f968849f8bbfa464cR21-R32)