### PR TITLE
Add organization domain endpoints and setActive

### DIFF
--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -9,6 +9,7 @@
     <ID>SwallowedException:PasskeyCredentialManagerTest.kt$PasskeyCredentialManagerTest$e: Exception</ID>
     <ID>TooGenericExceptionThrown:DeviceAttestationHelper.kt$DeviceAttestationHelper$throw RuntimeException("Failed to hash clientId", e)</ID>
     <ID>TooManyFunctions:ConfigurationManager.kt$ConfigurationManager</ID>
+    <ID>TooManyFunctions:OrganizationApi.kt$OrganizationApi</ID>
     <ID>TooManyFunctions:User.kt$com.clerk.api.user.User.kt</ID>
     <ID>UnusedPrivateClass:ClerkApiResultCallAdapterFactory.kt$ApiException : Exception</ID>
     <ID>UnusedPrivateProperty:build.gradle.kts$val detektProjectBaseline by tasks.registering(DetektCreateBaselineTask::class) { description = "Overrides current baseline." buildUponDefaultConfig.set(true) ignoreFailures.set(true) parallel.set(true) setSource(files(rootDir)) config.setFrom(files("$rootDir/config/detekt/detekt.yml")) baseline.set(file("$rootDir/config/detekt/detekt-baseline.xml")) include("**/*.kt") include("**/*.kts") exclude("**/resources/**") exclude("**/build/**") }</ID>

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -192,8 +192,11 @@ object Clerk {
    * @param organizationId The organization ID to be as active in the current session. If null, the
    *   currently active organization is removed as active.
    */
-  suspend fun setActive(sessionId: String, organizationId: String? = null) {
-    ClerkApi.client.setActive(sessionId, organizationId)
+  suspend fun setActive(
+    sessionId: String,
+    organizationId: String? = null,
+  ): ClerkResult<Session, ClerkErrorResponse> {
+    return ClerkApi.client.setActive(sessionId, organizationId)
   }
 
   // region Sign In/Sign Up

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -3,6 +3,7 @@ package com.clerk.api
 import android.content.Context
 import com.clerk.api.configuration.ConfigurationManager
 import com.clerk.api.log.ClerkLog
+import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.environment.Environment
 import com.clerk.api.network.model.environment.UserSettings
@@ -134,7 +135,8 @@ object Clerk {
   val userFlow: StateFlow<User?> = _userFlow.asStateFlow()
 
   /** The current user for the active session. */
-  val user: User? = session?.user
+  val user: User?
+    get() = session?.user
 
   // endregion
 
@@ -182,6 +184,17 @@ object Clerk {
     get() = if (::environment.isInitialized) environment.lastNameIsEnabled else false
 
   // endregion
+
+  /**
+   * Sets the active session, useful for multi-session applications.
+   *
+   * @param sessionId The session ID to be set as active
+   * @param organizationId The organization ID to be as active in the current session. If null, the
+   *   currently active organization is removed as active.
+   */
+  suspend fun setActive(sessionId: String, organizationId: String? = null) {
+    ClerkApi.client.setActive(sessionId, organizationId)
+  }
 
   // region Sign In/Sign Up
 

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/ClientApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/ClientApi.kt
@@ -4,7 +4,11 @@ import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.paths.Paths
 import com.clerk.api.network.serialization.ClerkResult
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
 
 /**
  * Internal API interface for client-related operations.
@@ -27,4 +31,23 @@ internal interface ClientApi {
    *   failure
    */
   @GET(Paths.ClientPath.CLIENT) suspend fun get(): ClerkResult<Client, ClerkErrorResponse>
+
+  /**
+   * Sets a session as active for this client.
+   *
+   * This method activates a specific session on the current client, making it the primary
+   * authenticated session. When a session is set as active, it becomes the session used for
+   * subsequent API requests and authentication operations.
+   *
+   * @param sessionId The unique identifier of the session to activate
+   * @param organizationId Optional organization ID to set as the active organization context for
+   *   the session. If provided, the session will be scoped to this organization.
+   * @return A [ClerkResult] with [Unit] on success, or a [ClerkErrorResponse] on failure
+   */
+  @FormUrlEncoded
+  @POST(Paths.ClientPath.Sessions.WithId.SET_ACTIVE)
+  suspend fun setActive(
+    @Path("id") sessionId: String,
+    @Field("active_organization_id") organizationId: String?,
+  ): ClerkResult<Unit, ClerkErrorResponse>
 }

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/ClientApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/ClientApi.kt
@@ -4,6 +4,7 @@ import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.paths.Paths
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
@@ -49,5 +50,5 @@ internal interface ClientApi {
   suspend fun setActive(
     @Path("id") sessionId: String,
     @Field("active_organization_id") organizationId: String?,
-  ): ClerkResult<Unit, ClerkErrorResponse>
+  ): ClerkResult<Session, ClerkErrorResponse>
 }

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
@@ -22,8 +22,26 @@ import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
 
+/**
+ * Retrofit API interface for organization-related operations in the Clerk system.
+ *
+ * This interface defines all HTTP endpoints for managing organizations, domains, invitations,
+ * roles, and other organization-related functionality.
+ *
+ * @see com.clerk.api.organizations
+ */
 interface OrganizationApi {
 
+  /**
+   * Retrieves roles for a specific organization.
+   *
+   * @param organizationId The unique identifier of the organization
+   * @param limit Maximum number of roles to return (optional)
+   * @param offset Number of roles to skip for pagination (optional)
+   * @return A [ClerkResult] containing either a list of [Role]s on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.getRoles
+   */
   @GET(Paths.Organizations.ROLES)
   suspend fun getRoles(
     @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
@@ -31,29 +49,73 @@ interface OrganizationApi {
     @Query("offset") offset: Int? = null,
   ): ClerkResult<List<Role>, ClerkErrorResponse>
 
+  /**
+   * Accepts a user organization invitation.
+   *
+   * @param invitationId The unique identifier of the invitation to accept
+   * @param sessionId Optional session ID for the operation
+   * @return A [ClerkResult] containing either the accepted [OrganizationInvitation] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.acceptInvitation
+   */
   @POST(Paths.UserPath.ACCEPT_ORGANIZATION_INVITATION)
   suspend fun acceptUserOrganizationInvitation(
     @Path("invitation_id") invitationId: String,
     @Query("_clerk_session_id") sessionId: String? = null,
   ): ClerkResult<OrganizationInvitation, ClerkErrorResponse>
 
+  /**
+   * Accepts an organization suggestion for a user.
+   *
+   * @param suggestionId The unique identifier of the suggestion to accept
+   * @param sessionId Optional session ID for the operation
+   * @return A [ClerkResult] containing either the accepted [OrganizationSuggestion] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.acceptSuggestion
+   */
   @POST(Paths.UserPath.ACCEPT_ORGANIZATION_SUGGESTION)
   suspend fun acceptOrganizationSuggestion(
     @Path("suggestion_id") suggestionId: String,
     @Query("_clerk_session_id") sessionId: String? = null,
   ): ClerkResult<OrganizationSuggestion, ClerkErrorResponse>
 
+  /**
+   * Creates a new organization.
+   *
+   * @param name The name of the organization to create
+   * @return A [ClerkResult] containing either the created [Organization] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.create
+   */
   @FormUrlEncoded
   @POST(Paths.Organizations.ORGANIZATIONS)
   suspend fun createOrganization(
     @Field("name") name: String
   ): ClerkResult<Organization, ClerkErrorResponse>
 
+  /**
+   * Retrieves a specific organization by its ID.
+   *
+   * @param organizationId The unique identifier of the organization
+   * @return A [ClerkResult] containing either the [Organization] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.get
+   */
   @GET(Paths.Organizations.WithId.ORGANIZATIONS_WITH_ID)
   suspend fun getOrganization(
     @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String
   ): ClerkResult<Organization, ClerkErrorResponse>
 
+  /**
+   * Updates an existing organization.
+   *
+   * @param organizationId The unique identifier of the organization to update
+   * @param name The new name for the organization (optional)
+   * @param slug The new slug for the organization (optional)
+   * @return A [ClerkResult] containing either the updated [Organization] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.update
+   */
   @FormUrlEncoded
   @PATCH(Paths.Organizations.WithId.ORGANIZATIONS_WITH_ID)
   suspend fun updateOrganization(
@@ -62,11 +124,28 @@ interface OrganizationApi {
     @Field("slug") slug: String? = null,
   ): ClerkResult<Organization, ClerkErrorResponse>
 
+  /**
+   * Deletes an organization.
+   *
+   * @param organizationId The unique identifier of the organization to delete
+   * @return A [ClerkResult] containing either a [DeletedObject] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.delete
+   */
   @DELETE(Paths.Organizations.WithId.ORGANIZATIONS_WITH_ID)
   suspend fun deleteOrganization(
     @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String
   ): ClerkResult<DeletedObject, ClerkErrorResponse>
 
+  /**
+   * Updates the logo for an organization.
+   *
+   * @param organizationId The unique identifier of the organization
+   * @param file The logo file to upload as a multipart body
+   * @return A [ClerkResult] containing either the updated [Organization] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.updateLogo
+   */
   @Multipart
   @PUT(Paths.Organizations.WithId.LOGO)
   suspend fun updateOrganizationLogo(
@@ -74,11 +153,28 @@ interface OrganizationApi {
     @Part file: MultipartBody.Part,
   ): ClerkResult<Organization, ClerkErrorResponse>
 
+  /**
+   * Deletes the logo for an organization.
+   *
+   * @param organizationId The unique identifier of the organization
+   * @return A [ClerkResult] containing either the updated [Organization] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.deleteLogo
+   */
   @DELETE(Paths.Organizations.WithId.LOGO)
   suspend fun deleteOrganizationLogo(
     @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String
   ): ClerkResult<Organization, ClerkErrorResponse>
 
+  /**
+   * Creates a new domain for an organization.
+   *
+   * @param organizationId The unique identifier of the organization
+   * @param name The domain name to create
+   * @return A [ClerkResult] containing either the created [OrganizationDomain] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.createDomain
+   */
   @FormUrlEncoded
   @POST(Paths.Organizations.WithId.DomainPath.DOMAINS)
   suspend fun createOrganizationDomain(
@@ -86,6 +182,18 @@ interface OrganizationApi {
     @Field("name") name: String,
   ): ClerkResult<OrganizationDomain, ClerkErrorResponse>
 
+  /**
+   * Retrieves all domains for an organization with optional filtering and pagination.
+   *
+   * @param organizationId The unique identifier of the organization
+   * @param limit Maximum number of domains to return (optional)
+   * @param offset Number of domains to skip for pagination (optional)
+   * @param verified Filter by verification status (optional)
+   * @param enrollmentMode Filter by enrollment mode (optional)
+   * @return A [ClerkResult] containing either a list of [OrganizationDomain]s on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.getDomains
+   */
   @GET(Paths.Organizations.WithId.DomainPath.DOMAINS)
   suspend fun getAllOrganizationDomains(
     @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
@@ -95,18 +203,47 @@ interface OrganizationApi {
     @Query("enrollment_mode") enrollmentMode: String? = null,
   ): ClerkResult<List<OrganizationDomain>, ClerkErrorResponse>
 
+  /**
+   * Retrieves a specific organization domain by its ID.
+   *
+   * @param organizationId The unique identifier of the organization
+   * @param domainId The unique identifier of the domain
+   * @return A [ClerkResult] containing either the [OrganizationDomain] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.getDomain
+   */
   @GET(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
   suspend fun getOrganizationDomain(
     @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
     @Path(Paths.Organizations.DOMAIN_ID) domainId: String,
   ): ClerkResult<OrganizationDomain, ClerkErrorResponse>
 
+  /**
+   * Deletes an organization domain.
+   *
+   * @param organizationId The unique identifier of the organization
+   * @param domainId The unique identifier of the domain to delete
+   * @return A [ClerkResult] containing either a [DeletedObject] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.deleteDomain
+   */
   @DELETE(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
   suspend fun deleteOrganizationDomain(
     @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
     @Path(Paths.Organizations.DOMAIN_ID) domainId: String,
   ): ClerkResult<DeletedObject, ClerkErrorResponse>
 
+  /**
+   * Updates the enrollment mode for an organization domain.
+   *
+   * @param organizationId The unique identifier of the organization
+   * @param domainId The unique identifier of the domain
+   * @param enrollmentMode The new enrollment mode to set
+   * @param deletePending Whether to delete pending invitations (optional)
+   * @return A [ClerkResult] containing either the updated [OrganizationDomain] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.updateEnrollmentMode
+   */
   @FormUrlEncoded
   @POST(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
   suspend fun updateEnrollmentMode(
@@ -116,6 +253,16 @@ interface OrganizationApi {
     @Field("delete_pending") deletePending: Boolean? = null,
   ): ClerkResult<OrganizationDomain, ClerkErrorResponse>
 
+  /**
+   * Prepares affiliation verification for an organization domain by sending a verification email.
+   *
+   * @param organizationId The unique identifier of the organization
+   * @param domainId The unique identifier of the domain
+   * @param affiliationEmailAddress The email address to send the verification code to
+   * @return A [ClerkResult] containing either the updated [OrganizationDomain] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.prepareAffiliationVerification
+   */
   @FormUrlEncoded
   @POST(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
   suspend fun prepareAffiliationVerification(
@@ -124,6 +271,20 @@ interface OrganizationApi {
     @Field("affiliation_email_address") affiliationEmailAddress: String,
   ): ClerkResult<OrganizationDomain, ClerkErrorResponse>
 
+  /**
+   * Attempts to verify the affiliation of an organization domain using a verification code.
+   *
+   * **Note:** You must call [prepareAffiliationVerification] first to receive the verification code
+   * via email.
+   *
+   * @param organizationId The unique identifier of the organization
+   * @param domainId The unique identifier of the domain
+   * @param code The verification code received via email after calling
+   *   [prepareAffiliationVerification]
+   * @return A [ClerkResult] containing either the updated [OrganizationDomain] on success or a
+   *   [ClerkErrorResponse] on failure
+   * @see com.clerk.api.organizations.attemptAffiliationVerification
+   */
   @FormUrlEncoded
   @POST(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
   suspend fun attemptAffiliationVerification(

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
@@ -5,6 +5,7 @@ import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.paths.Paths
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.organizations.Organization
+import com.clerk.api.organizations.OrganizationDomain
 import com.clerk.api.organizations.OrganizationInvitation
 import com.clerk.api.organizations.OrganizationSuggestion
 import com.clerk.api.organizations.Role
@@ -77,4 +78,57 @@ interface OrganizationApi {
   suspend fun deleteOrganizationLogo(
     @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String
   ): ClerkResult<Organization, ClerkErrorResponse>
+
+  @FormUrlEncoded
+  @POST(Paths.Organizations.WithId.DomainPath.DOMAINS)
+  suspend fun createOrganizationDomain(
+    @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
+    @Field("name") name: String,
+  ): ClerkResult<OrganizationDomain, ClerkErrorResponse>
+
+  @GET(Paths.Organizations.WithId.DomainPath.DOMAINS)
+  suspend fun getAllOrganizationDomains(
+    @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
+    @Query("limit") limit: Int? = null,
+    @Query("offset") offset: Int? = null,
+    @Query("verified") verified: Boolean? = null,
+    @Query("enrollment_mode") enrollmentMode: String? = null,
+  ): ClerkResult<List<OrganizationDomain>, ClerkErrorResponse>
+
+  @GET(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
+  suspend fun getOrganizationDomain(
+    @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
+    @Path(Paths.Organizations.DOMAIN_ID) domainId: String,
+  ): ClerkResult<OrganizationDomain, ClerkErrorResponse>
+
+  @DELETE(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
+  suspend fun deleteOrganizationDomain(
+    @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
+    @Path(Paths.Organizations.DOMAIN_ID) domainId: String,
+  ): ClerkResult<DeletedObject, ClerkErrorResponse>
+
+  @FormUrlEncoded
+  @POST(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
+  suspend fun updateEnrollmentMode(
+    @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
+    @Path(Paths.Organizations.DOMAIN_ID) domainId: String,
+    @Field("enrollment_mode") enrollmentMode: String,
+    @Field("delete_pending") deletePending: Boolean? = null,
+  ): ClerkResult<OrganizationDomain, ClerkErrorResponse>
+
+  @FormUrlEncoded
+  @POST(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
+  suspend fun prepareAffiliationVerification(
+    @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
+    @Path(Paths.Organizations.DOMAIN_ID) domainId: String,
+    @Field("affiliation_email_address") affiliationEmailAddress: String,
+  ): ClerkResult<OrganizationDomain, ClerkErrorResponse>
+
+  @FormUrlEncoded
+  @POST(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
+  suspend fun attemptAffiliationVerification(
+    @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
+    @Path(Paths.Organizations.DOMAIN_ID) domainId: String,
+    @Field("code") code: String,
+  ): ClerkResult<OrganizationDomain, ClerkErrorResponse>
 }

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
@@ -6,6 +6,7 @@ import com.clerk.api.network.paths.Paths
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.organizations.Organization
 import com.clerk.api.organizations.OrganizationDomain
+import com.clerk.api.organizations.OrganizationDomainCollection
 import com.clerk.api.organizations.OrganizationInvitation
 import com.clerk.api.organizations.OrganizationSuggestion
 import com.clerk.api.organizations.Role
@@ -201,7 +202,7 @@ interface OrganizationApi {
     @Query("offset") offset: Int? = null,
     @Query("verified") verified: Boolean? = null,
     @Query("enrollment_mode") enrollmentMode: String? = null,
-  ): ClerkResult<List<OrganizationDomain>, ClerkErrorResponse>
+  ): ClerkResult<OrganizationDomainCollection, ClerkErrorResponse>
 
   /**
    * Retrieves a specific organization domain by its ID.

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/OrganizationApi.kt
@@ -246,7 +246,7 @@ interface OrganizationApi {
    * @see com.clerk.api.organizations.updateEnrollmentMode
    */
   @FormUrlEncoded
-  @POST(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
+  @POST(Paths.Organizations.WithId.DomainPath.WithId.UPDATE_ENROLLMENT_MODE)
   suspend fun updateEnrollmentMode(
     @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
     @Path(Paths.Organizations.DOMAIN_ID) domainId: String,
@@ -265,7 +265,7 @@ interface OrganizationApi {
    * @see com.clerk.api.organizations.prepareAffiliationVerification
    */
   @FormUrlEncoded
-  @POST(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
+  @POST(Paths.Organizations.WithId.DomainPath.WithId.PREPARE_AFFILIATION)
   suspend fun prepareAffiliationVerification(
     @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
     @Path(Paths.Organizations.DOMAIN_ID) domainId: String,
@@ -287,7 +287,7 @@ interface OrganizationApi {
    * @see com.clerk.api.organizations.attemptAffiliationVerification
    */
   @FormUrlEncoded
-  @POST(Paths.Organizations.WithId.DomainPath.WithId.DOMAIN_WITH_ID)
+  @POST(Paths.Organizations.WithId.DomainPath.WithId.ATTEMPT_AFFILIATION)
   suspend fun attemptAffiliationVerification(
     @Path(Paths.Organizations.ORGANIZATION_ID) organizationId: String,
     @Path(Paths.Organizations.DOMAIN_ID) domainId: String,

--- a/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
@@ -194,8 +194,12 @@ internal object Paths {
         const val DOMAINS = "$ORGANIZATIONS_WITH_ID/domains"
 
         internal object WithId {
-
           const val DOMAIN_WITH_ID = "${DOMAINS}/{$DOMAIN_ID}"
+
+          const val UPDATE_ENROLLMENT_MODE = "${DOMAIN_WITH_ID}/update_enrollment_mode"
+
+          const val PREPARE_AFFILIATION = "${DOMAIN_WITH_ID}/prepare_affiliation_verification"
+          const val ATTEMPT_AFFILIATION = "${DOMAIN_WITH_ID}/attempt_affiliation_verification"
         }
       }
     }

--- a/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
@@ -48,6 +48,8 @@ internal object Paths {
         internal const val REMOVE = "${SESSIONS_WITH_ID}/remove"
         internal const val TOKENS = "${SESSIONS_WITH_ID}/tokens"
         internal const val TEMPLATE = "${TOKENS}/{template}"
+
+        internal const val SET_ACTIVE = "$SESSIONS_WITH_ID/touch"
       }
     }
 

--- a/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/paths/Paths.kt
@@ -179,12 +179,23 @@ internal object Paths {
   internal object Organizations {
     const val ORGANIZATIONS = "organizations"
     const val ORGANIZATION_ID = "organization_id"
+
+    const val DOMAIN_ID = "domain_id"
     const val ROLES = "${ORGANIZATIONS}/{organization_id}/roles"
 
     internal object WithId {
       const val ORGANIZATIONS_WITH_ID = "${ORGANIZATIONS}/{$ORGANIZATION_ID}"
 
       const val LOGO = "$ORGANIZATIONS_WITH_ID/logo"
+
+      internal object DomainPath {
+        const val DOMAINS = "$ORGANIZATIONS_WITH_ID/domains"
+
+        internal object WithId {
+
+          const val DOMAIN_WITH_ID = "${DOMAINS}/{$DOMAIN_ID}"
+        }
+      }
     }
   }
 }

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/Organization.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/Organization.kt
@@ -161,7 +161,7 @@ suspend fun Organization.getDomains(
   limit: Int = 20,
   offset: Int = 0,
   enrollmentMode: String? = null,
-): ClerkResult<List<OrganizationDomain>, ClerkErrorResponse> {
+): ClerkResult<OrganizationDomainCollection, ClerkErrorResponse> {
   return ClerkApi.organization.getAllOrganizationDomains(
     organizationId = this.id,
     limit = limit,

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/Organization.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/Organization.kt
@@ -150,3 +150,37 @@ suspend fun Organization.getRoles(
 ): ClerkResult<List<Role>, ClerkErrorResponse> {
   return ClerkApi.organization.getRoles(organizationId = this.id, limit = limit, offset = offset)
 }
+
+suspend fun Organization.createDomain(
+  name: String
+): ClerkResult<OrganizationDomain, ClerkErrorResponse> {
+  return ClerkApi.organization.createOrganizationDomain(organizationId = this.id, name = name)
+}
+
+suspend fun Organization.getDomains(
+  limit: Int = 20,
+  offset: Int = 0,
+  enrollmentMode: String? = null,
+): ClerkResult<List<OrganizationDomain>, ClerkErrorResponse> {
+  return ClerkApi.organization.getAllOrganizationDomains(
+    organizationId = this.id,
+    limit = limit,
+    offset = offset,
+    enrollmentMode = enrollmentMode,
+  )
+}
+
+suspend fun Organization.getDomain(
+  domainId: String
+): ClerkResult<OrganizationDomain, ClerkErrorResponse> {
+  return ClerkApi.organization.getOrganizationDomain(organizationId = this.id, domainId = domainId)
+}
+
+suspend fun Organization.deleteDomain(
+  domainId: String
+): ClerkResult<DeletedObject, ClerkErrorResponse> {
+  return ClerkApi.organization.deleteOrganizationDomain(
+    organizationId = this.id,
+    domainId = domainId,
+  )
+}

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
@@ -32,11 +32,13 @@ data class OrganizationDomain(
   val name: String,
   val organizationId: String,
   val enrollmentMode: String,
-  val verification: Verification,
+  val verification: Verification? = null,
   val affiliationEmailAddress: String? = null,
   val totalPendingInvitations: Int,
   val createdAt: Long,
   val updatedAt: Long,
+  val publicOrganizationData: PublicOrganizationData? = null,
+  val totalPendingSuggestions: Int,
 ) {
   /**
    * Represents the verification details for an organization domain.

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
@@ -25,6 +25,8 @@ import kotlinx.serialization.Serializable
  *   milliseconds)
  * @property updatedAt The date when the organization domain was last updated (Unix timestamp in
  *   milliseconds)
+ * @property totalPendingSuggestions The number of pending suggestions for the organization domain.
+ * @property publicOrganizationData The data's public organization.
  */
 @Serializable
 data class OrganizationDomain(
@@ -45,7 +47,7 @@ data class OrganizationDomain(
    *
    * @property status The current verification status of the domain
    * @property strategy The verification strategy being used
-   * @property attempt The current attempt number for verification
+   * @property attempts The current attempt number for verification
    * @property expireAt The expiration time for the verification attempt (Unix timestamp in
    *   milliseconds), null if no expiration
    */
@@ -53,7 +55,7 @@ data class OrganizationDomain(
   data class Verification(
     val status: String,
     val strategy: String,
-    val attempt: Int,
+    val attempts: Int,
     val expireAt: Long? = null,
   )
 }

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
@@ -56,6 +56,8 @@ data class OrganizationDomain(
   )
 }
 
+private val organizationApi by lazy { ClerkApi.organization }
+
 /**
  * Deletes this organization domain.
  *
@@ -63,7 +65,7 @@ data class OrganizationDomain(
  *   on failure
  */
 suspend fun OrganizationDomain.delete(): ClerkResult<DeletedObject, ClerkErrorResponse> {
-  return ClerkApi.organization.deleteOrganizationDomain(
+  return organizationApi.deleteOrganizationDomain(
     organizationId = this.organizationId,
     domainId = this.id,
   )
@@ -79,7 +81,7 @@ suspend fun OrganizationDomain.delete(): ClerkResult<DeletedObject, ClerkErrorRe
 suspend fun OrganizationDomain.prepareAffiliationVerification(
   affiliationEmailAddress: String
 ): ClerkResult<OrganizationDomain, ClerkErrorResponse> {
-  return ClerkApi.organization.prepareAffiliationVerification(
+  return organizationApi.prepareAffiliationVerification(
     organizationId = this.organizationId,
     domainId = this.id,
     affiliationEmailAddress = affiliationEmailAddress,
@@ -100,9 +102,21 @@ suspend fun OrganizationDomain.prepareAffiliationVerification(
 suspend fun OrganizationDomain.attemptAffiliationVerification(
   code: String
 ): ClerkResult<OrganizationDomain, ClerkErrorResponse> {
-  return ClerkApi.organization.attemptAffiliationVerification(
+  return organizationApi.attemptAffiliationVerification(
     organizationId = this.organizationId,
     domainId = this.id,
     code = code,
+  )
+}
+
+suspend fun OrganizationDomain.updateEnrollmentMode(
+  enrollmentMode: String,
+  deletePending: Boolean? = null,
+): ClerkResult<OrganizationDomain, ClerkErrorResponse> {
+  return organizationApi.updateEnrollmentMode(
+    organizationId = this.organizationId,
+    domainId = this.id,
+    enrollmentMode = enrollmentMode,
+    deletePending = deletePending,
   )
 }

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
@@ -122,3 +122,12 @@ suspend fun OrganizationDomain.updateEnrollmentMode(
     deletePending = deletePending,
   )
 }
+
+/**
+ * When the Clerk API returns a collection of objects it uses a top level data tag in the JSON. This
+ * class represents that JSON structure since we can't pass the list type to the clerk result.
+ *
+ * EX: Invalid: ClerkResult<List<OrganizationDomain>, ClerkErrorResponse> Valid:
+ * ClerkResult<OrganizationMembershipCollection, ClerkErrorResponse>
+ */
+@Serializable data class OrganizationDomainCollection(val data: List<OrganizationDomain>)

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
@@ -1,33 +1,108 @@
 package com.clerk.api.organizations
 
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.deleted.DeletedObject
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
 import kotlinx.serialization.Serializable
 
+/**
+ * Represents an organization domain in the Clerk system.
+ *
+ * Organization domains allow organizations to automatically enroll users based on their email
+ * domain and manage domain verification.
+ *
+ * @property id Unique identifier for this organization domain
+ * @property name Name for this organization domain
+ * @property organizationId The organization id of the organization this domain is for
+ * @property enrollmentMode The enrollment mode for new users joining the organization
+ * @property verification The verification status and details of the domain
+ * @property affiliationEmailAddress The email address that was used to verify this organization
+ *   domain, null if not verified
+ * @property totalPendingInvitations The number of total pending invitations sent to emails that
+ *   match the domain name
+ * @property createdAt The date when the organization domain was created (Unix timestamp in
+ *   milliseconds)
+ * @property updatedAt The date when the organization domain was last updated (Unix timestamp in
+ *   milliseconds)
+ */
 @Serializable
 data class OrganizationDomain(
-  /** Unique identifier for this organization domain */
   val id: String,
-  /** Name for this organization domain */
   val name: String,
-  /** The organization id of the organization this domain is for. */
   val organizationId: String,
-  /** The enrollment mode for new users joining the organization */
   val enrollmentMode: String,
-  /** The verification status of the domain */
   val verification: Verification,
-  /** The email address that was used to verify this organization domain. */
   val affiliationEmailAddress: String? = null,
-  /** The number of total pending invitations sent to emails that match the domain name. */
   val totalPendingInvitations: Int,
-  /** The date when the organization domain was created */
   val createdAt: Long,
-  /** The date when the organization was last updated */
   val updatedAt: Long,
 ) {
+  /**
+   * Represents the verification details for an organization domain.
+   *
+   * @property status The current verification status of the domain
+   * @property strategy The verification strategy being used
+   * @property attempt The current attempt number for verification
+   * @property expireAt The expiration time for the verification attempt (Unix timestamp in
+   *   milliseconds), null if no expiration
+   */
   @Serializable
   data class Verification(
     val status: String,
     val strategy: String,
     val attempt: Int,
     val expireAt: Long? = null,
+  )
+}
+
+/**
+ * Deletes this organization domain.
+ *
+ * @return A [ClerkResult] containing either a [DeletedObject] on success or a [ClerkErrorResponse]
+ *   on failure
+ */
+suspend fun OrganizationDomain.delete(): ClerkResult<DeletedObject, ClerkErrorResponse> {
+  return ClerkApi.organization.deleteOrganizationDomain(
+    organizationId = this.organizationId,
+    domainId = this.id,
+  )
+}
+
+/**
+ * Prepares affiliation verification for this organization domain by sending a verification email.
+ *
+ * @param affiliationEmailAddress The email address to send the verification code to
+ * @return A [ClerkResult] containing either the updated [OrganizationDomain] on success or a
+ *   [ClerkErrorResponse] on failure
+ */
+suspend fun OrganizationDomain.prepareAffiliationVerification(
+  affiliationEmailAddress: String
+): ClerkResult<OrganizationDomain, ClerkErrorResponse> {
+  return ClerkApi.organization.prepareAffiliationVerification(
+    organizationId = this.organizationId,
+    domainId = this.id,
+    affiliationEmailAddress = affiliationEmailAddress,
+  )
+}
+
+/**
+ * Attempts to verify the affiliation of this organization domain using a verification code.
+ *
+ * **Note:** You must call [prepareAffiliationVerification] first to receive the verification code
+ * via email.
+ *
+ * @param code The verification code received via email after calling
+ *   [prepareAffiliationVerification]
+ * @return A [ClerkResult] containing either the updated [OrganizationDomain] on success or a
+ *   [ClerkErrorResponse] on failure
+ */
+suspend fun OrganizationDomain.attemptAffiliationVerification(
+  code: String
+): ClerkResult<OrganizationDomain, ClerkErrorResponse> {
+  return ClerkApi.organization.attemptAffiliationVerification(
+    organizationId = this.organizationId,
+    domainId = this.id,
+    code = code,
   )
 }

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -1,0 +1,8 @@
+# Workbench
+
+⚠️ **Internal Use Only** ⚠️
+
+This directory is for internal development and testing purposes only. It should not be used in
+production or distributed applications.
+
+Please do not rely on any code or configurations in this workbench directory.

--- a/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
+++ b/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
@@ -71,8 +71,8 @@ class MainActivity : ComponentActivity() {
         MainContent(
           onSave = { StorageHelper.saveValue(StorageKey.PUBLIC_KEY, it) },
           onClear = { StorageHelper.deleteValue(StorageKey.PUBLIC_KEY) },
-          onClickFirstItem = { viewModel.createOrgDomain() },
-          onClickSecondItem = { viewModel.getAllDomains() },
+          onClickFirstItem = {},
+          onClickSecondItem = {},
         )
       }
     }

--- a/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
+++ b/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
@@ -1,12 +1,10 @@
 package com.clerk.workbench
 
-import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -47,23 +45,12 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.clerk.workbench.ui.theme.Clerk
 import com.clerk.workbench.ui.theme.ClerkTheme
-import java.io.File
-import java.io.FileOutputStream
+import com.clerk.workbench.viewmodels.OrgDomainViewModel
+import com.clerk.workbench.viewmodels.OrgViewModel
 
 class MainActivity : ComponentActivity() {
-  val viewModel: MainViewModel by viewModels()
-
-  private val filePickerLauncher =
-    registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-      uri?.let { selectedUri ->
-        val inputStream = contentResolver.openInputStream(selectedUri)
-        inputStream?.let { stream ->
-          val file = File(cacheDir, "selected_image.jpg")
-          FileOutputStream(file).use { output -> stream.copyTo(output) }
-          viewModel.updateOrgLogo(file)
-        }
-      }
-    }
+  val viewModel: OrgDomainViewModel by viewModels()
+  val orgViewModel: OrgViewModel by viewModels()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -71,21 +58,16 @@ class MainActivity : ComponentActivity() {
     setContent {
       val uiState by viewModel.uiState.collectAsStateWithLifecycle()
       val context = LocalContext.current
-
-      if (uiState is MainUiState.OrgUpdated) {
-        Toast.makeText(
-            context,
-            (uiState as MainUiState.OrgUpdated).organization.name,
-            Toast.LENGTH_SHORT,
-          )
-          .show()
+      if (uiState is OrgDomainViewModel.OrgDomainUiState.DomainCreated) {
+        Toast.makeText(context, "Domain created", Toast.LENGTH_SHORT).show()
       }
+
       ClerkTheme {
         MainContent(
           onSave = { StorageHelper.saveValue(StorageKey.PUBLIC_KEY, it) },
           onClear = { StorageHelper.deleteValue(StorageKey.PUBLIC_KEY) },
-          onClickFirstItem = { viewModel.deleteOrg() },
-          onClickSecondItem = { filePickerLauncher.launch("image/*") },
+          onClickFirstItem = { viewModel.createOrgDomain() },
+          onClickSecondItem = { viewModel.setActive() },
         )
       }
     }

--- a/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
+++ b/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
@@ -58,8 +58,13 @@ class MainActivity : ComponentActivity() {
     setContent {
       val uiState by viewModel.uiState.collectAsStateWithLifecycle()
       val context = LocalContext.current
-      if (uiState is OrgDomainViewModel.OrgDomainUiState.DomainCreated) {
-        Toast.makeText(context, "Domain created", Toast.LENGTH_SHORT).show()
+      if (uiState is OrgDomainViewModel.OrgDomainUiState.DomainsFetched) {
+        Toast.makeText(
+            context,
+            "${(uiState as OrgDomainViewModel.OrgDomainUiState.DomainsFetched).domains.map { it.id }}",
+            Toast.LENGTH_SHORT,
+          )
+          .show()
       }
 
       ClerkTheme {
@@ -67,7 +72,7 @@ class MainActivity : ComponentActivity() {
           onSave = { StorageHelper.saveValue(StorageKey.PUBLIC_KEY, it) },
           onClear = { StorageHelper.deleteValue(StorageKey.PUBLIC_KEY) },
           onClickFirstItem = { viewModel.createOrgDomain() },
-          onClickSecondItem = { viewModel.setActive() },
+          onClickSecondItem = { viewModel.getAllDomains() },
         )
       }
     }

--- a/workbench/src/main/java/com/clerk/workbench/viewmodels/OrgDomainViewModel.kt
+++ b/workbench/src/main/java/com/clerk/workbench/viewmodels/OrgDomainViewModel.kt
@@ -1,0 +1,44 @@
+package com.clerk.workbench.viewmodels
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.clerk.api.Clerk
+import com.clerk.api.network.serialization.longErrorMessageOrNull
+import com.clerk.api.network.serialization.onFailure
+import com.clerk.api.network.serialization.onSuccess
+import com.clerk.api.organizations.createDomain
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class OrgDomainViewModel : ViewModel() {
+
+  private val _uiState = MutableStateFlow<OrgDomainUiState>(OrgDomainUiState.Idle)
+  val uiState = _uiState.asStateFlow()
+
+  fun createOrgDomain() {
+    viewModelScope.launch {
+      val org = Clerk.user?.organizationMemberships?.first()!!.organization
+      org
+        .createDomain(name = "4-domain.com")
+        .onSuccess { _uiState.value = OrgDomainUiState.DomainCreated }
+        .onFailure {
+          Log.e("OrgDomainViewModel", "Failed to create domain: ${it.longErrorMessageOrNull}")
+        }
+    }
+  }
+
+  fun setActive() {
+    viewModelScope.launch {
+      val session = Clerk.client.sessions.first()
+      Clerk.setActive(session.id, organizationId = "org_31qYzhGqspBIUkeg0FYWzC3P0dY")
+    }
+  }
+
+  sealed interface OrgDomainUiState {
+    data object Idle : OrgDomainUiState
+
+    data object DomainCreated : OrgDomainUiState
+  }
+}

--- a/workbench/src/main/java/com/clerk/workbench/viewmodels/OrgDomainViewModel.kt
+++ b/workbench/src/main/java/com/clerk/workbench/viewmodels/OrgDomainViewModel.kt
@@ -7,7 +7,9 @@ import com.clerk.api.Clerk
 import com.clerk.api.network.serialization.longErrorMessageOrNull
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
+import com.clerk.api.organizations.OrganizationDomain
 import com.clerk.api.organizations.createDomain
+import com.clerk.api.organizations.getDomains
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -29,6 +31,18 @@ class OrgDomainViewModel : ViewModel() {
     }
   }
 
+  fun getAllDomains() {
+    viewModelScope.launch {
+      val org = Clerk.user?.organizationMemberships?.first()!!.organization
+      org
+        .getDomains()
+        .onSuccess { _uiState.value = OrgDomainUiState.DomainsFetched(it.data) }
+        .onFailure {
+          Log.e("OrgDomainViewModel", "Failed to fetch domains: ${it.longErrorMessageOrNull}")
+        }
+    }
+  }
+
   fun setActive() {
     viewModelScope.launch {
       val session = Clerk.client.sessions.first()
@@ -37,6 +51,8 @@ class OrgDomainViewModel : ViewModel() {
   }
 
   sealed interface OrgDomainUiState {
+    data class DomainsFetched(val domains: List<OrganizationDomain>) : OrgDomainUiState
+
     data object Idle : OrgDomainUiState
 
     data object DomainCreated : OrgDomainUiState

--- a/workbench/src/main/java/com/clerk/workbench/viewmodels/OrgViewModel.kt
+++ b/workbench/src/main/java/com/clerk/workbench/viewmodels/OrgViewModel.kt
@@ -1,4 +1,4 @@
-package com.clerk.workbench
+package com.clerk.workbench.viewmodels
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
@@ -18,15 +18,16 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-class MainViewModel : ViewModel() {
+class OrgViewModel : ViewModel() {
 
-  private val _uiState = MutableStateFlow<MainUiState>(MainUiState.SignedOut)
+  private val _uiState = MutableStateFlow<OrgUiState>(OrgUiState.SignedOut)
   val uiState = _uiState.asStateFlow()
 
+  // region Top level org functions
   fun signIn(email: String, password: String) {
     viewModelScope.launch {
       SignIn.create(SignIn.CreateParams.Strategy.Password(identifier = email, password = password))
-        .onSuccess { _uiState.value = MainUiState.SignedIn }
+        .onSuccess { _uiState.value = OrgUiState.SignedIn }
         .onFailure { Log.e("SignInViewModel", "${it.longErrorMessageOrNull}", it.throwable) }
     }
   }
@@ -38,7 +39,7 @@ class MainViewModel : ViewModel() {
   fun getOrg() {
     viewModelScope.launch {
       Organization.get("org_31qVA5lAwmdNaa2DDMNANzLViDu")
-        .onSuccess { _uiState.value = MainUiState.OrgFetched(it) }
+        .onSuccess { _uiState.value = OrgUiState.OrgFetched(it) }
         .onFailure { Log.e("MainViewModel", "${it.longErrorMessageOrNull}", it.throwable) }
     }
   }
@@ -47,7 +48,7 @@ class MainViewModel : ViewModel() {
     viewModelScope.launch {
       Organization.get("org_31qVA5lAwmdNaa2DDMNANzLViDu")
         .flatMap { it.update("Crispy Sunglasses Org") }
-        .onSuccess { _uiState.value = MainUiState.OrgUpdated(it) }
+        .onSuccess { _uiState.value = OrgUiState.OrgUpdated(it) }
         .onFailure { Log.e("MainViewModel", "${it.longErrorMessageOrNull}", it.throwable) }
     }
   }
@@ -56,7 +57,7 @@ class MainViewModel : ViewModel() {
     viewModelScope.launch {
       Organization.get("org_31qVA5lAwmdNaa2DDMNANzLViDu")
         .flatMap { it.updateLogo(file) }
-        .onSuccess { _uiState.value = MainUiState.LogoUpdated(it) }
+        .onSuccess { _uiState.value = OrgUiState.LogoUpdated(it) }
     }
   }
 
@@ -71,16 +72,18 @@ class MainViewModel : ViewModel() {
       Organization.get("org_31qVA5lAwmdNaa2DDMNANzLViDu").flatMap { it.delete() }
     }
   }
-}
 
-sealed interface MainUiState {
-  data object SignedOut : MainUiState
+  // endregion
 
-  data object SignedIn : MainUiState
+  sealed interface OrgUiState {
+    data object SignedOut : OrgUiState
 
-  data class OrgFetched(val organization: Organization) : MainUiState
+    data object SignedIn : OrgUiState
 
-  data class OrgUpdated(val organization: Organization) : MainUiState
+    data class OrgFetched(val organization: Organization) : OrgUiState
 
-  data class LogoUpdated(val organization: Organization) : MainUiState
+    data class OrgUpdated(val organization: Organization) : OrgUiState
+
+    data class LogoUpdated(val organization: Organization) : OrgUiState
+  }
 }


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the organization and session management APIs, along with improved documentation and type updates. The most significant changes include the addition of organization domain management endpoints, a new method for setting the active session, and comprehensive documentation for organization-related API methods. These changes improve support for multi-session applications and provide robust organization domain handling.

### Organization Domain Management Enhancements
* Added multiple new endpoints to `OrganizationApi` for creating, retrieving, updating, and deleting organization domains, including domain verification flows and enrollment mode management. This enables fine-grained control over organization domains and their verification status.
* Introduced new extension functions in `Organization.kt` for domain management, such as `createDomain`, `getDomains`, `getDomain`, and `deleteDomain`, providing a convenient API for domain operations.
* Updated the `OrganizationDomain` data class to include new fields (`publicOrganizationData`, `totalPendingSuggestions`) and made `verification` nullable, reflecting the expanded domain model.

### Session Management Improvements
* Added a new `setActive` method to the `Clerk` object, allowing the active session and organization to be set for multi-session applications, with direct API integration.
* Implemented the `setActive` endpoint in `ClientApi` and defined its path in `Paths`, enabling session switching via API. [[1]](diffhunk://#diff-23ad87fde3f8f19790a6972eea5d963217eb8e4292e7875d9ebefe9d362c06bcR35-R53) [[2]](diffhunk://#diff-e63c50f7390358a0fe615f12529eff9678419c871d774262d555a5cec7c8699eR51-R52)

### API Documentation and Type Improvements
* Provided detailed KDoc documentation for all organization-related API methods in `OrganizationApi`, improving code readability and developer experience.
* Updated imports and minor code structure for consistency and clarity across API files. [[1]](diffhunk://#diff-19fa35ccb02c10b3c997c885afebe0df9916e4b05cc0c78cd267776f40b10124R6) [[2]](diffhunk://#diff-23ad87fde3f8f19790a6972eea5d963217eb8e4292e7875d9ebefe9d362c06bcR7-R12) [[3]](diffhunk://#diff-c6d2a45dc5f1cfacf52749c63564bd6b1eb2f600d5375c1fc3ac79f69f60166bR8-R9)

### Baseline and Lint Updates
* Added a new entry for `TooManyFunctions` for `OrganizationApi` in the Detekt baseline configuration, reflecting the expanded interface.

### Path and Routing Updates
* Defined new constants for organization domain paths and session activation in the `Paths` object, supporting the new API endpoints.

These changes collectively enhance the flexibility and capabilities of organization and session management within the API, making it easier to support advanced use cases such as multi-session applications and automated domain-based user enrollment.