### PR TITLE
Fix maven central publish task not found

### DIFF
--- a/source/api/build.gradle.kts
+++ b/source/api/build.gradle.kts
@@ -46,6 +46,8 @@ mavenPublishing {
   signAllPublications()
   coordinates("com.clerk", "clerk-android", libs.versions.clerk.sdk.get())
 
+  publishToMavenCentral()
+
   pom {
     name.set("Clerk Android UI")
     description.set("UI components for Clerk Android SDK")


### PR DESCRIPTION
## What
Added `publishToMavenCentral()` to the `mavenPublishing` block in `source/api/build.gradle.kts`.

## Why
The `publishMavenPublicationToMavenCentralRepository` task was not found, causing the Maven Central publishing action to fail. This change configures the Vanniktech Maven publish plugin to correctly create and expose this task.

## Ticket
N/A (Reported as a broken action)

---
[Slack Thread](https://clerkinc.slack.com/archives/C08SE0321GR/p1757372462482989?thread_ts=1757372462.482989&cid=C08SE0321GR)

<a href="https://cursor.com/background-agent?bcId=bc-84c7c0d7-4df7-4ec2-9346-aa0ae3e71ff7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84c7c0d7-4df7-4ec2-9346-aa0ae3e71ff7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

