### PR TITLE
Add avatars

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -82,7 +82,7 @@ object Clerk {
    * This logo appears in sign-in screens, sign-up flows, and other authentication interfaces. The
    * URL is configured in your Clerk Dashboard under branding settings.
    */
-  val logoUrl: String?
+  val organizationLogoUrl: String?
     get() = if (::environment.isInitialized) environment.displayConfig.logoImageUrl else null
 
   // endregion

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -367,7 +367,7 @@ class ClerkTest {
     simulateUninitializedEnvironment()
 
     // When
-    val logoUrl = Clerk.logoUrl
+    val logoUrl = Clerk.organizationLogoUrl
 
     // Then
     assertEquals("", logoUrl)
@@ -381,7 +381,7 @@ class ClerkTest {
     initializeClerkWithEnvironment()
 
     // When
-    val logoUrl = Clerk.logoUrl
+    val logoUrl = Clerk.organizationLogoUrl
 
     // Then
     assertEquals(expectedLogoUrl, logoUrl)

--- a/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
@@ -1,0 +1,75 @@
+package com.clerk.ui.core.avatar
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import com.clerk.api.Clerk
+import com.clerk.ui.R
+import com.clerk.ui.theme.ClerkMaterialTheme
+
+@Composable
+internal fun AvatarView(
+  imageUrl: String?,
+  size: AvatarSize,
+  shape: Shape,
+  modifier: Modifier = Modifier,
+) {
+  Box(contentAlignment = Alignment.Center, modifier = modifier) {
+    SubcomposeAsyncImage(
+      model = imageUrl,
+      contentDescription = null,
+      modifier = Modifier.size(size.toDp()).clip(shape).then(modifier),
+      contentScale = ContentScale.Fit,
+      loading = { CircularProgressIndicator() },
+      error = {
+        Icon(
+          painter = painterResource(id = R.drawable.ic_profile),
+          contentDescription = null,
+          tint = ClerkMaterialTheme.colors.foreground,
+        )
+      },
+    )
+  }
+}
+
+@Composable
+fun OrganizationAvatar(
+  modifier: Modifier = Modifier,
+  shape: Shape? = null,
+  size: AvatarSize = AvatarSize.MEDIUM,
+) {
+  val url = Clerk.organizationLogoUrl
+  ClerkMaterialTheme {
+    AvatarView(
+      imageUrl = url,
+      size = size,
+      shape = shape ?: ClerkMaterialTheme.shape,
+      modifier = modifier,
+    )
+  }
+}
+
+enum class AvatarSize {
+  SMALL,
+  MEDIUM,
+  LARGE,
+}
+
+private fun AvatarSize.toDp(): Dp {
+  return when (this) {
+    AvatarSize.SMALL -> 24.dp
+    AvatarSize.MEDIUM -> 36.dp
+    AvatarSize.LARGE -> 48.dp
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
@@ -1,7 +1,11 @@
 package com.clerk.ui.core.avatar
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
@@ -11,11 +15,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
 import com.clerk.api.Clerk
 import com.clerk.ui.R
+import com.clerk.ui.core.dimens.dp10
 import com.clerk.ui.theme.ClerkMaterialTheme
 
 @Composable
@@ -23,24 +29,42 @@ internal fun AvatarView(
   imageUrl: String?,
   size: AvatarSize,
   shape: Shape,
+  avatarType: AvatarType,
   modifier: Modifier = Modifier,
 ) {
-  Box(contentAlignment = Alignment.Center, modifier = modifier) {
+  val placeholder =
+    when (avatarType) {
+      AvatarType.USER -> R.drawable.ic_user
+      AvatarType.ORGANIZATION -> R.drawable.ic_organization
+    }
+
+  Box(
+    modifier =
+      Modifier.wrapContentSize()
+        .background(color = ClerkMaterialTheme.colors.primaryForeground, shape = shape)
+        .padding(dp10),
+    contentAlignment = Alignment.Center,
+  ) {
     SubcomposeAsyncImage(
       model = imageUrl,
-      contentDescription = null,
+      contentDescription = stringResource(R.string.logo),
       modifier = Modifier.size(size.toDp()).clip(shape).then(modifier),
       contentScale = ContentScale.Fit,
       loading = { CircularProgressIndicator() },
       error = {
         Icon(
-          painter = painterResource(id = R.drawable.ic_profile),
+          painter = painterResource(placeholder),
           contentDescription = null,
           tint = ClerkMaterialTheme.colors.foreground,
         )
       },
     )
   }
+}
+
+internal enum class AvatarType {
+  USER,
+  ORGANIZATION,
 }
 
 @Composable
@@ -56,6 +80,20 @@ fun OrganizationAvatar(
       size = size,
       shape = shape ?: ClerkMaterialTheme.shape,
       modifier = modifier,
+      avatarType = AvatarType.ORGANIZATION,
+    )
+  }
+}
+
+@Composable
+fun UserAvatar(modifier: Modifier = Modifier) {
+  ClerkMaterialTheme {
+    AvatarView(
+      imageUrl = Clerk.user?.imageUrl,
+      size = AvatarSize.MEDIUM,
+      shape = CircleShape,
+      modifier = modifier,
+      avatarType = AvatarType.USER,
     )
   }
 }

--- a/source/ui/src/main/res/values/strings.xml
+++ b/source/ui/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="incorrect_verification_code">Incorrect verification code</string>
     <string name="success">Success</string>
     <string name="didn_t_receive_a_code_resend">Didn\'t receive a code? Resend (%1$d)</string>
+    <string name="logo">Logo</string>
 </resources>

--- a/workbench/src/main/AndroidManifest.xml
+++ b/workbench/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Clerk">
         <activity
-            android:name=".PhoneInputActivity"
+            android:name=".UiActivity"
             android:exported="false" />
         <activity
             android:name=".MainActivity"

--- a/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
+++ b/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
@@ -56,9 +56,7 @@ class MainActivity : ComponentActivity() {
         MainContent(
           onSave = { StorageHelper.saveValue(StorageKey.PUBLIC_KEY, it) },
           onClear = { StorageHelper.deleteValue(StorageKey.PUBLIC_KEY) },
-          onClickFirstItem = {
-            context.startActivity(Intent(context, PhoneInputActivity::class.java))
-          },
+          onClickFirstItem = { context.startActivity(Intent(context, UiActivity::class.java)) },
           onClickSecondItem = {},
         )
       }

--- a/workbench/src/main/java/com/clerk/workbench/UiActivity.kt
+++ b/workbench/src/main/java/com/clerk/workbench/UiActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import com.clerk.ui.core.avatar.AvatarSize
 import com.clerk.ui.core.avatar.OrganizationAvatar
 import com.clerk.workbench.ui.theme.WorkbenchTheme
 
@@ -33,7 +34,7 @@ fun MainContent(modifier: Modifier = Modifier) {
         .then(modifier),
     contentAlignment = Alignment.Center,
   ) {
-    OrganizationAvatar()
+    OrganizationAvatar(size = AvatarSize.LARGE)
   }
 }
 

--- a/workbench/src/main/java/com/clerk/workbench/UiActivity.kt
+++ b/workbench/src/main/java/com/clerk/workbench/UiActivity.kt
@@ -13,10 +13,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import com.clerk.ui.core.input.ClerkCodeInputField
+import com.clerk.ui.core.avatar.OrganizationAvatar
 import com.clerk.workbench.ui.theme.WorkbenchTheme
 
-class PhoneInputActivity : ComponentActivity() {
+class UiActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent { WorkbenchTheme { MainContent() } }
@@ -33,7 +33,7 @@ fun MainContent(modifier: Modifier = Modifier) {
         .then(modifier),
     contentAlignment = Alignment.Center,
   ) {
-    ClerkCodeInputField(onOtpTextChange = {}, secondsLeft = 60, otpLength = 6, onClickResend = {})
+    OrganizationAvatar()
   }
 }
 


### PR DESCRIPTION
This pull request introduces a new `AvatarView` component to the UI layer, refactors organization logo handling for clarity, and updates the workbench activity to showcase the new avatar functionality. The changes improve code organization, naming consistency, and UI composability.

**UI Components and Features:**

* Added a new `AvatarView` composable and supporting components (`OrganizationAvatar`, `UserAvatar`, `AvatarType`, `AvatarSize`) in `AvatarView.kt`, enabling reusable avatar rendering for users and organizations.
* Added a new string resource for the logo content description in `strings.xml`.

**API and Data Model Updates:**

* Renamed the `Clerk.logoUrl` property to `Clerk.organizationLogoUrl` for clearer intent and updated all usages and tests accordingly. [[1]](diffhunk://#diff-19fa35ccb02c10b3c997c885afebe0df9916e4b05cc0c78cd267776f40b10124L85-R85) [[2]](diffhunk://#diff-4b79e1947e0020e1a57ade0ae5d896671c075746881f9a62d3466b9258c9505eL370-R370) [[3]](diffhunk://#diff-4b79e1947e0020e1a57ade0ae5d896671c075746881f9a62d3466b9258c9505eL384-R384)

**Workbench Refactor and Demo:**

* Renamed `PhoneInputActivity` to `UiActivity` and updated the Android manifest and navigation to use the new activity. [[1]](diffhunk://#diff-1fd8268d5b066ba6f55d1f515a3b6898e13b6abbf7b3db9486b3cbdd6978c813L15-R15) [[2]](diffhunk://#diff-7a7e9ab030c8917a26943c52b6d01182bcccccc6c7a7614e49e85fff475af38eL59-R59) [[3]](diffhunk://#diff-421cb78d3ffbe3a057b339fb4e248260129a6e787c7784b03207fa8c2610e90dL16-R20)
* Updated the main content of `UiActivity` to display the organization avatar using the new `OrganizationAvatar` composable instead of the code input field.