### PR TITLE
Update all libraries and bump clerk version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,41 +3,50 @@ activityKtx = "1.11.0"
 agp = "8.13.0"
 appcompat = "1.7.1"
 automap = "0.1.1"
-chucker = "4.1.0"
-clerk-sdk = "0.1.9"
+chucker = "4.2.0"
 composeBom = "2025.09.00"
+core = "1.7.0"
 coreKtxVersion = "1.7.0"
 detekt = "1.23.8"
 dokka = "1.9.20"
-foundationLayoutAndroid = "1.9.1"
-hiltAndroid = "2.57"
-hiltCompiler = "2.57"
-hiltNavigationCompose = "1.3.0"
-jdk = "17"
-jvmTarget = "17"
 kotlin = "2.2.10"
 ksp = "2.2.10-2.0.2"
-lifecycleProcess = "2.9.2"
+lifecycleProcess = "2.9.3"
 material3 = "1.3.2"
+materialKolor = "3.0.1"
 mavenPublish = "0.34.0"
-minSdk = "24"
-compileSdk = "36"
 navigationCompose = "2.9.4"
-okhttp = "4.12.0"
+okhttp = "5.1.0"
 retrofit = "3.0.0"
+robolectric = "4.16"
 sortDependencies = "0.15"
 spotless = "7.2.1"
 coreKtx = "1.17.0"
 junit = "1.3.0"
 espressoCore = "3.7.0"
+material = "1.13.0"
+uiToolingPreviewAndroid = "1.9.1"
+paparazziPlugin = "2.0.0-alpha02"
+turbineVersion = "1.2.1"
+
+# Build Versions -- Do not delete
+clerk-sdk = "0.1.10"
+clerk-ui = "0.1.0-SNAPSHOT"
+jdk = "17"
+jvmTarget = "17"
+minSdk = "24"
+compileSdk = "36"
 
 [libraries]
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityKtx" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-arch-test = "androidx.arch.core:core-testing:2.2.0"
 androidx-browser = "androidx.browser:browser:1.9.0"
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
+androidx-compose-icons = "org.jetbrains.compose.material:material-icons-core:1.7.3"
+androidx-core = { module = "androidx.test:core", version.ref = "core" }
 androidx-credentials = "androidx.credentials:credentials:1.5.0"
-androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
 androidx-lifecycle = "androidx.lifecycle:lifecycle-runtime-compose:2.9.3"
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
 androidx-lifecycle-runtime = "androidx.lifecycle:lifecycle-runtime-ktx:2.9.3"
@@ -58,17 +67,17 @@ compose-lints = "com.slack.lint.compose:compose-lint-checks:1.4.2"
 core-ktx = { module = "androidx.test:core-ktx", version.ref = "coreKtxVersion" }
 google-identity = "com.google.android.libraries.identity.googleid:googleid:1.1.1"
 google-playIntegrity = "com.google.android.play:integrity:1.5.0"
-hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hiltCompiler" }
-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+google-libphonenumber = "com.googlecode.libphonenumber:libphonenumber:9.0.13"
 junit = "junit:junit:4.13.2"
 jwt-decode = "com.auth0.android:jwtdecode:2.0.2"
 kotlinx-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2"
 kotlinx-coroutines-test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
 kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.7.1-0.6.x-compat"
-kotlinx-serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3"
+kotlinx-immutable = "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0"
+kotlinx-serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
 ksp-api = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "ksp" }
 material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
+materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
 mockito = "org.mockito:mockito-core:5.19.0"
 mockk = "io.mockk:mockk:1.14.5"
 navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
@@ -76,20 +85,23 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhtt
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-kotlinx = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
-robolectric = "org.robolectric:robolectric:4.16"
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbineVersion" }
 versioning-plugin = { module = "org.jetbrains.dokka:versioning-plugin", version.ref = "dokka" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junit" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "ui-tooling-preview-android", version.ref = "uiToolingPreviewAndroid" }
+paparazzi = "app.cash.paparazzi:paparazzi:2.0.0-alpha02"
+
 
 [plugins]
+paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazziPlugin" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hiltAndroid" }
 jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
This pull request updates and expands the project's dependency versions and library references in `gradle/libs.versions.toml`. The main focus is on upgrading several core libraries (such as OkHttp, Chucker, and lifecycle-process), introducing new dependencies (like Paparazzi and Turbine), and cleaning up or reorganizing some version and plugin definitions.

Dependency upgrades and additions:

* Upgraded key libraries: `chucker` to 4.2.0, `okhttp` to 5.1.0, and `lifecycleProcess` to 2.9.3, improving stability and feature support.
* Added new dependencies: `materialKolor`, `paparazzi`, `turbine`, and `google-libphonenumber` for enhanced UI, testing, and utility capabilities. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL6-L40) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL61-L92)
* Updated `kotlinx-serialization` to 1.9.0 and introduced `kotlinx-immutable` for better collection handling.

Testing and tooling enhancements:

* Added and updated test-related libraries: `robolectric` now references a version variable, and new entries for `paparazzi` and `androidx-ui-tooling-preview-android` have been included. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL6-L40) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL61-L92)
* Introduced the Paparazzi Gradle plugin for improved UI snapshot testing.

Cleanup and reorganization:

* Removed unused or redundant dependencies and plugin references, such as Hilt-related entries, and reorganized version and plugin blocks for clarity. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL6-L40) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL61-L92)