### PR TITLE
Add SignInFactorTwoView

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorTwoView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorTwoView.kt
@@ -1,0 +1,33 @@
+package com.clerk.ui.signin
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.clerk.api.network.model.factor.Factor
+import com.clerk.ui.core.common.StrategyKeys
+import com.clerk.ui.signin.backupcode.SignInFactorTwoBackupCodeView
+import com.clerk.ui.signin.code.SignInFactorCodeView
+import com.clerk.ui.signin.help.SignInGetHelpView
+
+@Composable
+fun SignInFactorTwoView(factor: Factor, modifier: Modifier = Modifier) {
+  when (factor.strategy) {
+    StrategyKeys.TOTP,
+    StrategyKeys.PHONE_CODE ->
+      SignInFactorCodeView(factor = factor, isSecondFactor = true, modifier = modifier)
+    StrategyKeys.BACKUP_CODE ->
+      SignInFactorTwoBackupCodeView(
+        onBackPressed = {},
+        modifier = modifier,
+        onSubmitSuccess = {},
+        onUseAnotherMethod = {},
+      )
+    else -> SignInGetHelpView()
+  }
+}
+
+@PreviewLightDark
+@Composable
+private fun Preview() {
+  SignInFactorTwoView(factor = Factor(StrategyKeys.TOTP))
+}

--- a/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorTwoView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorTwoView.kt
@@ -9,6 +9,17 @@ import com.clerk.ui.signin.backupcode.SignInFactorTwoBackupCodeView
 import com.clerk.ui.signin.code.SignInFactorCodeView
 import com.clerk.ui.signin.help.SignInGetHelpView
 
+/**
+ * A composable that acts as a router for displaying the appropriate second-factor authentication
+ * view.
+ *
+ * Based on the `strategy` of the provided [factor], this composable will delegate rendering to the
+ * corresponding view, such as [SignInFactorCodeView] for TOTP or phone code, or
+ * [SignInFactorTwoBackupCodeView] for backup codes.
+ *
+ * @param factor The second factor to be verified.
+ * @param modifier The [Modifier] to be applied to the view.
+ */
 @Composable
 fun SignInFactorTwoView(factor: Factor, modifier: Modifier = Modifier) {
   when (factor.strategy) {

--- a/source/ui/src/main/java/com/clerk/ui/signin/alternativemethods/SignInFactorAlternativeMethodsView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/alternativemethods/SignInFactorAlternativeMethodsView.kt
@@ -23,6 +23,22 @@ import com.clerk.ui.util.TextIconHelper
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
+/**
+ * A view that displays alternative sign-in methods.
+ *
+ * This component can be used for both first-factor and second-factor authentication steps, showing
+ * a list of available methods like social providers (for first factor), or other verification
+ * strategies (e.g., password, phone code).
+ *
+ * @param currentFactor The factor that the user is currently trying to authenticate with. This is
+ *   used to determine which alternative factors to show.
+ * @param onBackPressed A callback invoked when the user presses the back button.
+ * @param modifier The [Modifier] to be applied to the view.
+ * @param isSecondFactor A flag indicating whether the view is being used for a second-factor
+ *   authentication step. This affects which alternative factors are fetched.
+ * @param onClickFactor A callback invoked when the user selects an alternative factor from the
+ *   list.
+ */
 @Composable
 fun SignInFactorAlternativeMethodsView(
   currentFactor: Factor,
@@ -46,6 +62,18 @@ fun SignInFactorAlternativeMethodsView(
   )
 }
 
+/**
+ * The internal implementation of the [SignInFactorAlternativeMethodsView].
+ *
+ * @param onBackPressed A callback invoked when the user presses the back button.
+ * @param providers A list of social providers to display.
+ * @param alternativeFactors A list of alternative factors (e.g., password, passkey) to display.
+ * @param modifier The [Modifier] to be applied to the view.
+ * @param textIconHelper A helper class to get the appropriate text and icon for each factor.
+ * @param viewModel The [AlternativeMethodsViewModel] for handling the view's logic, such as social
+ *   sign-in.
+ * @param onClickFactor A callback invoked when the user selects an alternative factor.
+ */
 @Composable
 private fun SignInFactorAlternativeMethodsViewImpl(
   onBackPressed: () -> Unit,
@@ -65,10 +93,10 @@ private fun SignInFactorAlternativeMethodsViewImpl(
   ) {
     if (providers.isNotEmpty()) {
       ClerkSocialRow(providers = providers, onClick = { viewModel.signInWithProvider(it) })
+      Spacers.Vertical.Spacer24()
+      TextDivider(text = stringResource(R.string.or))
+      Spacers.Vertical.Spacer24()
     }
-    Spacers.Vertical.Spacer24()
-    TextDivider(text = stringResource(R.string.or))
-    Spacers.Vertical.Spacer24()
     AlternativeFactorList(
       alternativeFactors = alternativeFactors,
       textIconHelper = textIconHelper,

--- a/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeView.kt
@@ -62,12 +62,14 @@ fun SignInFactorCodeView(
   modifier: Modifier = Modifier,
   onBackPressed: () -> Unit = {},
   onClickResend: () -> Unit = {},
+  isSecondFactor: Boolean = false,
 ) {
   SignInFactorCodeViewImpl(
     factor = factor,
     modifier = modifier,
     onBackPressed = onBackPressed,
     onClickResend = onClickResend,
+    isSecondFactor = isSecondFactor,
   )
 }
 
@@ -96,6 +98,7 @@ private fun SignInFactorCodeViewImpl(
   modifier: Modifier = Modifier,
   viewModel: SignInFactorCodeViewModel = viewModel(),
   onUseAnotherMethod: () -> Unit = {},
+  isSecondFactor: Boolean = false,
 ) {
   val state by viewModel.state.collectAsStateWithLifecycle()
   val verificationState = state.verificationState()
@@ -122,7 +125,7 @@ private fun SignInFactorCodeViewImpl(
       verificationState = verificationState,
       onOtpTextChange = {
         if (it.length == 6) {
-          viewModel.attempt(factor, isSecondFactor = false, code = it)
+          viewModel.attempt(factor, isSecondFactor = isSecondFactor, code = it)
         }
       },
       showResend = SignInFactorCodeHelper.showResend(factor, verificationState),


### PR DESCRIPTION
This pull request introduces a new composable router for second-factor authentication and improves code clarity and flexibility in the sign-in UI components. The main focus is on cleanly routing to the correct second-factor view and making the codebase more maintainable with better documentation and parameterization.

**Second-factor authentication routing:**

* Added `SignInFactorTwoView`, a new composable that routes to the appropriate second-factor authentication view (`SignInFactorCodeView`, `SignInFactorTwoBackupCodeView`, or `SignInGetHelpView`) based on the `Factor`'s strategy. This centralizes and simplifies the logic for rendering the correct second-factor UI.

**Code flexibility and correctness:**

* Updated `SignInFactorCodeView` and its implementation to accept an `isSecondFactor` parameter, allowing it to distinguish between first and second-factor authentication attempts and pass this information to the view model. [[1]](diffhunk://#diff-89caaa67470e52d7b369847a4c65640c3e2ae9bb2180475280fa175a138609d4R65-R72) [[2]](diffhunk://#diff-89caaa67470e52d7b369847a4c65640c3e2ae9bb2180475280fa175a138609d4R101) [[3]](diffhunk://#diff-89caaa67470e52d7b369847a4c65640c3e2ae9bb2180475280fa175a138609d4L125-R128)

**Documentation improvements:**

* Added detailed KDoc comments to `SignInFactorAlternativeMethodsView` and its internal implementation, clarifying their purpose, parameters, and usage for future maintainers. [[1]](diffhunk://#diff-add92586cdbc67634c63c1b99aa5bf475f35ea6aae069cc726bcc3715e6fadceR26-R41) [[2]](diffhunk://#diff-add92586cdbc67634c63c1b99aa5bf475f35ea6aae069cc726bcc3715e6fadceR65-R76)

**UI logic fixes:**

* Fixed the logic in `SignInFactorAlternativeMethodsViewImpl` to ensure that the divider and spacing are only shown when social providers are present, improving the layout's correctness.