### PR TITLE
Add dark theme overrides

### DIFF
--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -3,7 +3,6 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:ClerkComposeTheme.kt$@Composable private fun generateComputedColors(colors: ClerkColors): ComputedColors</ID>
-    <ID>CyclomaticComplexMethod:ClerkThemeProvider.kt$@Composable private fun generateColors(theme: ClerkTheme?): ClerkColors</ID>
     <ID>LongMethod:AuthStartView.kt$@Composable internal fun AuthStartViewImpl( onAuthComplete: () -> Unit, modifier: Modifier = Modifier, authViewHelper: AuthStartViewHelper = AuthStartViewHelper(), authStartViewModel: AuthStartViewModel = viewModel(), )</ID>
     <ID>LongMethod:ClerkButton.kt$@PreviewLightDark @Composable private fun PreviewButton()</ID>
     <ID>LongMethod:ClerkPhoneNumberField.kt$@Composable private fun PhoneNumberInput( computedColors: ComputedColors, value: String, onValueChange: (String) -> Unit, countryCode: String, errorText: String? = null, )</ID>
@@ -22,6 +21,7 @@
     <ID>MagicNumber:ColorUtils.kt$4f</ID>
     <ID>MagicNumber:DeviceAttestationHelper.kt$DeviceAttestationHelper$8</ID>
     <ID>MatchingDeclarationName:ColorUtils.kt$DangerPalette</ID>
+    <ID>NestedBlockDepth:AuthStartViewModel.kt$AuthStartViewModel$private suspend fun handleSignInSuccess(signIn: SignIn)</ID>
     <ID>NestedBlockDepth:ClientSyncingMiddleware.kt$ClientSyncingMiddleware$override fun intercept(chain: Interceptor.Chain): Response</ID>
     <ID>ReturnCount:DeviceAssertionMiddleware.kt$DeviceAssertionInterceptor.DeviceAttestationManager$suspend fun performDeviceAssertion(request: Request, error: ClerkError): Boolean</ID>
     <ID>SwallowedException:PasskeyCredentialManagerTest.kt$PasskeyCredentialManagerTest$e: Exception</ID>

--- a/source/api/src/main/kotlin/com/clerk/api/ui/ClerkTheme.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/ui/ClerkTheme.kt
@@ -12,12 +12,16 @@ package com.clerk.api.ui
  * Having a single container greatly simplifies passing theme data through composables and other UI
  * components.
  *
- * @property colors colors used by the UI layer.
+ * @property colors colors used by the UI layer across light and dark modes.
+ * @property lightColors optional overrides that only apply when the system is in light mode.
+ * @property darkColors optional overrides that only apply when the system is in dark mode.
  * @property typography fonts and typography definitions.
  * @property design design tokens such as spacing and shapes.
  */
 data class ClerkTheme(
   val colors: ClerkColors? = null,
+  val lightColors: ClerkColors? = null,
+  val darkColors: ClerkColors? = null,
   val typography: ClerkTypography? = null,
   val design: ClerkDesign? = null,
 )

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -20,9 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.clerk.api.Clerk
 import com.clerk.api.sso.OAuthProvider
-import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.R
 import com.clerk.ui.core.button.social.ClerkSocialRow
 import com.clerk.ui.core.button.standard.ClerkButton
@@ -34,7 +32,6 @@ import com.clerk.ui.core.divider.TextDivider
 import com.clerk.ui.core.input.ClerkPhoneNumberField
 import com.clerk.ui.core.input.ClerkTextField
 import com.clerk.ui.theme.ClerkMaterialTheme
-import com.clerk.ui.theme.DefaultColors
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
@@ -213,7 +210,7 @@ private fun AuthActionButtons(
 @PreviewLightDark
 @Composable
 private fun Preview() {
-  Clerk.customTheme = ClerkTheme(colors = DefaultColors.clerk)
+  //  Clerk.customTheme = ClerkTheme(colors = DefaultColors.clerk)
   val authViewHelper = AuthStartViewHelper()
 
   authViewHelper.setTestValues(

--- a/source/ui/src/main/java/com/clerk/ui/core/button/standard/ClerkButton.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/button/standard/ClerkButton.kt
@@ -25,12 +25,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.clerk.api.Clerk
+import com.clerk.api.ui.ClerkColors
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.R
 import com.clerk.ui.core.common.dimens.dp1
@@ -541,6 +544,28 @@ private fun PreviewButton() {
             ),
         )
       }
+    }
+  }
+}
+
+@PreviewLightDark
+@Composable
+private fun Preview() {
+  Clerk.customTheme = ClerkTheme(darkColors = ClerkColors(primary = Color.Red))
+  ClerkMaterialTheme {
+    Box(modifier = Modifier.background(ClerkMaterialTheme.colors.background).padding(dp12)) {
+      ClerkButton(
+        modifier = Modifier.fillMaxWidth(),
+        text = stringResource(R.string.continue_text),
+        isLoading = false,
+        isEnabled = false,
+        icons =
+          ClerkButtonDefaults.icons(
+            trailingIcon = R.drawable.ic_triangle_right,
+            trailingIconColor = ClerkMaterialTheme.colors.primaryForeground,
+          ),
+        onClick = {},
+      )
     }
   }
 }

--- a/source/ui/src/main/java/com/clerk/ui/theme/ClerkThemeProvider.kt
+++ b/source/ui/src/main/java/com/clerk/ui/theme/ClerkThemeProvider.kt
@@ -124,26 +124,39 @@ private fun generateTypography(theme: ClerkTheme?): Typography {
 
 @Composable
 private fun generateColors(theme: ClerkTheme?): ClerkColors {
-  val defaultColors = if (isSystemInDarkTheme()) DefaultColors.dark else DefaultColors.light
-  val colors =
-    ClerkColors(
-      primary = theme?.colors?.primary ?: defaultColors.primary,
-      background = theme?.colors?.background ?: defaultColors.background,
-      input = theme?.colors?.input ?: defaultColors.input,
-      danger = theme?.colors?.danger ?: defaultColors.danger,
-      success = theme?.colors?.success ?: defaultColors.success,
-      warning = theme?.colors?.warning ?: defaultColors.warning,
-      foreground = theme?.colors?.foreground ?: defaultColors.foreground,
-      mutedForeground = theme?.colors?.mutedForeground ?: defaultColors.mutedForeground,
-      primaryForeground = theme?.colors?.primaryForeground ?: defaultColors.primaryForeground,
-      inputForeground = theme?.colors?.inputForeground ?: defaultColors.inputForeground,
-      neutral = theme?.colors?.neutral ?: defaultColors.neutral,
-      border = theme?.colors?.border ?: defaultColors.border,
-      ring = theme?.colors?.ring ?: defaultColors.ring,
-      muted = theme?.colors?.muted ?: defaultColors.muted,
-      shadow = theme?.colors?.shadow ?: defaultColors.shadow,
-    )
-  return colors
+  return resolveColors(theme = theme, isDarkMode = isSystemInDarkTheme())
+}
+
+internal fun resolveColors(theme: ClerkTheme?, isDarkMode: Boolean): ClerkColors {
+  val defaultColors = if (isDarkMode) DefaultColors.dark else DefaultColors.light
+  val baseOverrides = theme?.colors
+  val modeOverrides = if (isDarkMode) theme?.darkColors else theme?.lightColors
+
+  fun resolve(getter: (ClerkColors) -> Color?): Color {
+    // Prefer mode-specific overrides, otherwise fall back to global overrides and finally defaults.
+    return modeOverrides?.let(getter)
+      ?: baseOverrides?.let(getter)
+      ?: getter(defaultColors)
+      ?: error("Default color palette must define all colors")
+  }
+
+  return ClerkColors(
+    primary = resolve { it.primary },
+    background = resolve { it.background },
+    input = resolve { it.input },
+    danger = resolve { it.danger },
+    success = resolve { it.success },
+    warning = resolve { it.warning },
+    foreground = resolve { it.foreground },
+    mutedForeground = resolve { it.mutedForeground },
+    primaryForeground = resolve { it.primaryForeground },
+    inputForeground = resolve { it.inputForeground },
+    neutral = resolve { it.neutral },
+    border = resolve { it.border },
+    ring = resolve { it.ring },
+    muted = resolve { it.muted },
+    shadow = resolve { it.shadow },
+  )
 }
 
 /** Object providing easy access to current theme values within composables. */

--- a/source/ui/src/test/java/com/clerk/ui/theme/ClerkThemeProviderTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/theme/ClerkThemeProviderTest.kt
@@ -1,0 +1,63 @@
+package com.clerk.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import com.clerk.api.ui.ClerkColors
+import com.clerk.api.ui.ClerkTheme
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClerkThemeProviderTest {
+
+  @Test
+  fun resolveColors_usesDefaultPaletteWhenNoOverridesProvided_lightMode() {
+    val resolved = resolveColors(theme = null, isDarkMode = false)
+
+    assertEquals(DefaultColors.light.primary, resolved.primary)
+    assertEquals(DefaultColors.light.background, resolved.background)
+  }
+
+  @Test
+  fun resolveColors_appliesGlobalOverridesToBothModes() {
+    val theme =
+      ClerkTheme(colors = ClerkColors(primary = Color(0xFFFF00FF), background = Color(0xFF112233)))
+
+    val lightResolved = resolveColors(theme = theme, isDarkMode = false)
+    val darkResolved = resolveColors(theme = theme, isDarkMode = true)
+
+    assertEquals(Color(0xFFFF00FF), lightResolved.primary)
+    assertEquals(Color(0xFFFF00FF), darkResolved.primary)
+    assertEquals(Color(0xFF112233), lightResolved.background)
+    assertEquals(Color(0xFF112233), darkResolved.background)
+  }
+
+  @Test
+  fun resolveColors_prefersModeOverridesWhenAvailable() {
+    val theme =
+      ClerkTheme(
+        colors = ClerkColors(primary = Color(0xFF00FF00), background = Color(0xFFABCDEF)),
+        darkColors = ClerkColors(primary = Color(0xFF123456)),
+      )
+
+    val lightResolved = resolveColors(theme = theme, isDarkMode = false)
+    val darkResolved = resolveColors(theme = theme, isDarkMode = true)
+
+    assertEquals(Color(0xFF00FF00), lightResolved.primary)
+    assertEquals(Color(0xFF123456), darkResolved.primary)
+    assertEquals(Color(0xFFABCDEF), lightResolved.background)
+    assertEquals(Color(0xFFABCDEF), darkResolved.background)
+  }
+
+  @Test
+  fun resolveColors_fallsBackToDefaultsWhenOverrideMissing() {
+    val theme =
+      ClerkTheme(lightColors = ClerkColors(primary = Color(0xFF212121)), darkColors = ClerkColors())
+
+    val lightResolved = resolveColors(theme = theme, isDarkMode = false)
+    val darkResolved = resolveColors(theme = theme, isDarkMode = true)
+
+    assertEquals(Color(0xFF212121), lightResolved.primary)
+    assertEquals(DefaultColors.dark.primary, darkResolved.primary)
+    assertEquals(DefaultColors.light.background, lightResolved.background)
+    assertEquals(DefaultColors.dark.background, darkResolved.background)
+  }
+}

--- a/workbench/src/main/java/com/clerk/workbench/UiActivity.kt
+++ b/workbench/src/main/java/com/clerk/workbench/UiActivity.kt
@@ -15,10 +15,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.clerk.api.Clerk
+import com.clerk.api.ui.ClerkColors
+import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.auth.AuthView
 import com.clerk.ui.core.button.standard.ClerkButton
 import com.clerk.workbench.ui.theme.WorkbenchTheme
@@ -30,6 +33,7 @@ class UiActivity : ComponentActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    Clerk.customTheme = ClerkTheme(darkColors = ClerkColors(primary = Color.Red))
     setContent {
       val context = LocalContext.current
       WorkbenchTheme {


### PR DESCRIPTION
## Summary of changes
This pull request improves the theming system by allowing separate theme overrides for light and dark modes, introduces a robust color resolution mechanism, and adds comprehensive tests for theme resolution logic. It also cleans up unused imports and updates preview usage to reflect the new theming approach.

**Theming system enhancements:**

* The `ClerkTheme` data class now supports `lightColors` and `darkColors` properties for mode-specific color overrides, in addition to the existing `colors` property for global overrides. (`source/api/src/main/kotlin/com/clerk/api/ui/ClerkTheme.kt` [source/api/src/main/kotlin/com/clerk/api/ui/ClerkTheme.ktL15-R24](diffhunk://#diff-5c08bbf3f5a6d6c8f1e44a828984238262c86b30d6ed6e98750d2d26978ed6cfL15-R24))
* The color resolution logic is refactored into a new `resolveColors` function, which prioritizes mode-specific overrides, then global overrides, and finally default palettes. This function is now used in `generateColors`. (`source/ui/src/main/java/com/clerk/ui/theme/ClerkThemeProvider.kt` [source/ui/src/main/java/com/clerk/ui/theme/ClerkThemeProvider.ktL127-L146](diffhunk://#diff-3fd350a8d85f66b374c54d863aa775d4f06c40f5a2894ddd73496319641afd23L127-L146))
* The `UiActivity` and button preview now demonstrate usage of the new `darkColors` override for theming. (`workbench/src/main/java/com/clerk/workbench/UiActivity.kt` [[1]](diffhunk://#diff-421cb78d3ffbe3a057b339fb4e248260129a6e787c7784b03207fa8c2610e90dR18-R24) [[2]](diffhunk://#diff-421cb78d3ffbe3a057b339fb4e248260129a6e787c7784b03207fa8c2610e90dR36); `source/ui/src/main/java/com/clerk/ui/core/button/standard/ClerkButton.kt` [[3]](diffhunk://#diff-932775eef93c179e4979eae05e9fb220d0b1ccad75081f6585136fb7f5001914R550-R571)

**Testing and validation:**

* Adds a new test suite for `resolveColors`, covering default palette usage, global overrides, mode-specific overrides, and fallback behavior when overrides are missing. (`source/ui/src/test/java/com/clerk/ui/theme/ClerkThemeProviderTest.kt` [source/ui/src/test/java/com/clerk/ui/theme/ClerkThemeProviderTest.ktR1-R63](diffhunk://#diff-16d0cb5498b83664d01af8ab03601a5701f9cc84942a09387e231d9e3cd7eae9R1-R63))

**Code cleanup and maintenance:**

* Removes unused imports and updates previews to use the new theming approach. (`source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt` [[1]](diffhunk://#diff-34cfafa9cbe790d8fd41ef947eb7294f7224d2060b05a5ac72ac8a2235d43947L23-L25) [[2]](diffhunk://#diff-34cfafa9cbe790d8fd41ef947eb7294f7224d2060b05a5ac72ac8a2235d43947L37) [[3]](diffhunk://#diff-34cfafa9cbe790d8fd41ef947eb7294f7224d2060b05a5ac72ac8a2235d43947L216-R213)
* Updates Detekt baseline to reflect refactored or removed code, cleaning up static analysis suppressions. (`config/detekt/detekt-baseline.xml` [[1]](diffhunk://#diff-da3b370e5e24bd214517daea228fa1e73d82da98e9134978ffb0ee66af3a7a01L6) [[2]](diffhunk://#diff-da3b370e5e24bd214517daea228fa1e73d82da98e9134978ffb0ee66af3a7a01R24)