### PR TITLE
May layout stack vertically when needed

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/signin/password/set/SignInFactorOnePasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/set/SignInFactorOnePasswordView.kt
@@ -173,7 +173,7 @@ private fun Footer(authState: AuthState, factor: Factor) {
   }
 }
 
-@Preview
+@Preview(device = "spec:width=300dp,height=891dp")
 @Composable
 private fun PreviewSignInFactorOnePasswordView() {
   PreviewAuthStateProvider {

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/set/SignInFactorOnePasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/set/SignInFactorOnePasswordView.kt
@@ -1,5 +1,7 @@
 package com.clerk.ui.signin.password.set
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -9,10 +11,14 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.clerk.api.Clerk
@@ -112,25 +118,58 @@ private fun SignInFactorOnePasswordViewImpl(
 
 @Composable
 private fun Footer(authState: AuthState, factor: Factor) {
-  Row(modifier = Modifier.fillMaxWidth().padding(horizontal = dp8)) {
-    ClerkTextButton(
-      text = stringResource(R.string.use_another_method),
-      onClick = {
-        authState.navigateTo(Destination.SignInFactorOneUseAnotherMethod(currentFactor = factor))
-      },
-    )
-    Spacer(modifier = Modifier.weight(1f))
-    ClerkTextButton(
-      text = stringResource(R.string.forgot_password),
-      onClick = {
-        Clerk.signIn?.resetPasswordFactor?.let {
-          authState.navigateTo(Destination.SignInForgotPassword)
-        }
-          ?: authState.navigateTo(
-            Destination.SignInFactorOneUseAnotherMethod(currentFactor = factor)
-          )
-      },
-    )
+  val windowInfo = LocalWindowInfo.current
+  val density = LocalDensity.current
+  val widthDp = with(density) { windowInfo.containerSize.width.toDp() }
+  val isCompact = widthDp < 360.dp
+  if (isCompact) {
+    Column(
+      modifier = Modifier.fillMaxWidth().padding(horizontal = dp8),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.spacedBy(dp24),
+    ) {
+      ClerkTextButton(
+        text = stringResource(R.string.use_another_method),
+        onClick = {
+          authState.navigateTo(Destination.SignInFactorOneUseAnotherMethod(currentFactor = factor))
+        },
+      )
+      ClerkTextButton(
+        text = stringResource(R.string.forgot_password),
+        onClick = {
+          Clerk.signIn?.resetPasswordFactor?.let {
+            authState.navigateTo(Destination.SignInForgotPassword)
+          }
+            ?: authState.navigateTo(
+              Destination.SignInFactorOneUseAnotherMethod(currentFactor = factor)
+            )
+        },
+      )
+    }
+  } else {
+    Row(
+      modifier = Modifier.fillMaxWidth().padding(horizontal = dp8),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      ClerkTextButton(
+        text = stringResource(R.string.use_another_method),
+        onClick = {
+          authState.navigateTo(Destination.SignInFactorOneUseAnotherMethod(currentFactor = factor))
+        },
+      )
+      ClerkTextButton(
+        text = stringResource(R.string.forgot_password),
+        onClick = {
+          Clerk.signIn?.resetPasswordFactor?.let {
+            authState.navigateTo(Destination.SignInForgotPassword)
+          }
+            ?: authState.navigateTo(
+              Destination.SignInFactorOneUseAnotherMethod(currentFactor = factor)
+            )
+        },
+      )
+    }
   }
 }
 


### PR DESCRIPTION
This pull request updates the layout of the `Footer` in the `SignInFactorOnePasswordView` to improve responsiveness based on screen width. The layout now adapts between a vertical column and a horizontal row depending on the device's width, ensuring better usability on compact devices.

**Responsive layout improvements:**

* Refactored the `Footer` composable to use a `Column` layout with centered alignment and spacing when the screen width is less than 360dp, and to use a `Row` layout with spaced buttons for wider screens. This ensures the UI adapts gracefully to different device sizes. [[1]](diffhunk://#diff-50ce43bc00d02f571fd3e0c9a08828f4de33acd5a71a2cc98657128b2e2f4398L115-L122) [[2]](diffhunk://#diff-50ce43bc00d02f571fd3e0c9a08828f4de33acd5a71a2cc98657128b2e2f4398R149-R176)

**Imports and preview updates:**

* Added necessary imports for `Column`, `Arrangement`, `Alignment`, `LocalDensity`, `LocalWindowInfo`, and `dp` units to support the new responsive logic. [[1]](diffhunk://#diff-50ce43bc00d02f571fd3e0c9a08828f4de33acd5a71a2cc98657128b2e2f4398R3-R4) [[2]](diffhunk://#diff-50ce43bc00d02f571fd3e0c9a08828f4de33acd5a71a2cc98657128b2e2f4398R14-R21)
* Updated the `@Preview` annotation to specify a device width of 300dp, allowing for testing of the compact layout in previews.

<img width="305" height="891" alt="image" src="https://github.com/user-attachments/assets/256fc657-b78a-4b53-bd6c-029ac08317ab" />
