### PR TITLE
Add user locale to android sign up request

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -2,6 +2,7 @@ package com.clerk.api
 
 import android.content.Context
 import com.clerk.api.configuration.ConfigurationManager
+import com.clerk.api.locale.LocaleProvider
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.client.Client
@@ -182,6 +183,27 @@ object Clerk {
   /** Indicates whether last name is enabled in user settings for this application. */
   val lastNameIsEnabled: Boolean
     get() = if (::environment.isInitialized) environment.lastNameIsEnabled else false
+
+  /**
+   * Reactive state for the current device locale in BCP-47 format.
+   *
+   * Observe this StateFlow to react to locale changes. The locale is used for sending localized
+   * emails during authentication flows (e.g., verification codes).
+   *
+   * Examples of BCP-47 format: "en-US", "pt-BR", "es-ES", "fr-FR"
+   */
+  val localeFlow: StateFlow<String?> = LocaleProvider.localeFlow
+
+  /**
+   * The current device locale in BCP-47 format.
+   *
+   * This locale is automatically sent with sign-up requests to enable localized verification
+   * emails. The locale is refreshed when the SDK is initialized and when the app starts.
+   *
+   * @return The device locale (e.g., "en-US", "pt-BR") or null if not yet initialized.
+   */
+  val locale: String?
+    get() = LocaleProvider.locale
 
   // endregion
 

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
@@ -12,6 +12,7 @@ import com.clerk.api.Constants.Config.REFRESH_TOKEN_INTERVAL
 import com.clerk.api.Constants.Config.TIMEOUT_MULTIPLIER
 import com.clerk.api.attestation.DeviceAttestationHelper
 import com.clerk.api.configuration.lifecycle.AppLifecycleListener
+import com.clerk.api.locale.LocaleProvider
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.client.Client
@@ -111,6 +112,7 @@ internal class ConfigurationManager {
     if (!storageInitialized) {
       context?.get()?.let { context ->
         StorageHelper.initialize(context)
+        LocaleProvider.initialize(context)
         storageInitialized = true
         ClerkLog.d("Storage initialized")
       }
@@ -176,6 +178,7 @@ internal class ConfigurationManager {
         AppLifecycleListener.configure {
           if (hasConfigured) {
             scope.launch {
+              LocaleProvider.refresh()
               refreshClientAndEnvironment(options)
               startTokenRefresh()
             }
@@ -527,6 +530,7 @@ internal class ConfigurationManager {
   fun cleanup() {
     refreshJob?.cancel()
     attestationJob?.cancel()
+    LocaleProvider.cleanup()
     context = null
     storageInitialized = false
     hasConfigured = false

--- a/source/api/src/main/kotlin/com/clerk/api/locale/LocaleProvider.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/locale/LocaleProvider.kt
@@ -1,0 +1,106 @@
+package com.clerk.api.locale
+
+import android.content.Context
+import com.clerk.api.log.ClerkLog
+import java.lang.ref.WeakReference
+import java.util.Locale
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Manages the user's locale for the Clerk SDK.
+ *
+ * This class provides access to the current device locale in BCP-47 format, which is used for
+ * sending localized emails (such as verification codes) during authentication flows.
+ *
+ * The locale is automatically initialized when the SDK is configured and refreshed when the app
+ * starts, ensuring that locale changes are picked up.
+ */
+internal object LocaleProvider {
+
+  /** Weak reference to application context to prevent memory leaks. */
+  private var context: WeakReference<Context>? = null
+
+  /** Internal mutable state flow for locale changes. */
+  private val _localeFlow = MutableStateFlow<String?>(null)
+
+  /**
+   * Reactive state for the current device locale in BCP-47 format.
+   *
+   * Observe this StateFlow to react to locale changes. The locale is automatically updated when
+   * the SDK is initialized and when the app starts.
+   *
+   * Examples of BCP-47 format: "en-US", "pt-BR", "es-ES", "fr-FR"
+   */
+  val localeFlow: StateFlow<String?> = _localeFlow.asStateFlow()
+
+  /**
+   * The current device locale in BCP-47 format.
+   *
+   * Returns the locale as a string in BCP-47 format (e.g., "en-US", "pt-BR"), or null if the
+   * locale has not been initialized yet.
+   */
+  val locale: String?
+    get() = _localeFlow.value
+
+  /**
+   * Initializes the LocaleProvider with the application context.
+   *
+   * This should be called once during SDK initialization. It captures the current device locale
+   * and makes it available for authentication requests.
+   *
+   * @param context The application context used to access system resources and locale information.
+   */
+  fun initialize(context: Context) {
+    this.context = WeakReference(context.applicationContext)
+    refresh()
+  }
+
+  /**
+   * Refreshes the current locale from the device.
+   *
+   * This method should be called when the app starts to pick up any locale changes that may have
+   * occurred while the app was not running. It's automatically called during SDK initialization and
+   * on app lifecycle events.
+   */
+  fun refresh() {
+    try {
+      val currentLocale = getDeviceLocale()
+      _localeFlow.value = currentLocale
+      ClerkLog.d("Locale refreshed: $currentLocale")
+    } catch (e: Exception) {
+      ClerkLog.e("Failed to refresh locale: ${e.message}")
+    }
+  }
+
+  /**
+   * Gets the current device locale in BCP-47 format.
+   *
+   * This method uses the device's default locale and converts it to BCP-47 format using
+   * [Locale.toLanguageTag]. The BCP-47 format is the standard format for locale identifiers and
+   * includes language and region information (e.g., "en-US" for English in the United States).
+   *
+   * @return The device locale in BCP-47 format, or null if unable to determine.
+   */
+  private fun getDeviceLocale(): String? {
+    return try {
+      val locale = Locale.getDefault()
+      locale.toLanguageTag()
+    } catch (e: Exception) {
+      ClerkLog.e("Failed to get device locale: ${e.message}")
+      null
+    }
+  }
+
+  /**
+   * Clears the locale state and releases the context reference.
+   *
+   * This should be called when the SDK is being cleaned up or re-initialized.
+   */
+  fun cleanup() {
+    _localeFlow.value = null
+    context = null
+    ClerkLog.d("LocaleProvider cleaned up")
+  }
+}


### PR DESCRIPTION
## Summary of changes

This PR implements automatic locale detection and inclusion in sign-up requests for the Android SDK, addressing Linear issue MOBILE-276.

Key changes:
-   **Added `locale` parameter** to `SignUp.CreateParams.Standard` and `SignUp.SignUpUpdateParams.Standard` to support localized emails.
-   **Introduced `LocaleProvider`** to reactively manage and provide the device's current locale in BCP-47 format.
-   **Integrated `LocaleProvider`** with the SDK:
    -   Locale is initialized on SDK configuration and refreshed on app start.
    -   `Clerk.localeFlow` and `Clerk.locale` are exposed for direct access.
    -   `SignUp.create()` now **automatically includes the device locale** if not explicitly provided in the request, ensuring localized emails are sent without requiring manual developer intervention.

---
Linear Issue: [MOBILE-276](https://linear.app/clerk/issue/MOBILE-276/android-send-user-locale-in-sign-up-request-for-localized-emails)

<a href="https://cursor.com/background-agent?bcId=bc-4296140c-ef2a-4bae-b4e0-ef1955d35d14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4296140c-ef2a-4bae-b4e0-ef1955d35d14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

