### PR TITLE
Unify session source of truth in clerk.kt

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -155,7 +155,7 @@ object Clerk {
 
   /** The current user for the active session. */
   val user: User?
-    get() = session?.user
+    get() = userFlow.value
 
   // endregion
 

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -472,4 +472,98 @@ class ClerkTest {
     // Then
     assertFalse(debugMode)
   }
+
+  @Test
+  fun `clearSessionAndUserState nulls both sessionFlow and userFlow`() = runTest {
+    // Given - setup initial state with active session and user
+    val activeSessionId = "active_session_id"
+
+    every { mockClient.lastActiveSessionId } returns activeSessionId
+    every { mockClient.sessions } returns listOf(mockSession)
+    every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockSession.id } returns activeSessionId
+    every { mockSession.user } returns mockUser
+    initializeClerkWithClient(mockClient)
+
+    // Verify initial state has session and user
+    assertEquals(mockSession, Clerk.sessionFlow.value)
+    assertEquals(mockUser, Clerk.userFlow.value)
+    assertEquals(mockSession, Clerk.session)
+    assertEquals(mockUser, Clerk.user)
+    assertTrue(Clerk.isSignedIn)
+
+    // When - clear session and user state (simulating sign out)
+    Clerk.clearSessionAndUserState()
+
+    // Then - verify both flows are null
+    assertNull(Clerk.sessionFlow.value)
+    assertNull(Clerk.userFlow.value)
+    assertNull(Clerk.session)
+    assertNull(Clerk.user)
+    assertFalse(Clerk.isSignedIn)
+  }
+
+  @Test
+  fun `session property returns sessionFlow value`() = runTest {
+    // Given - setup initial state
+    val activeSessionId = "active_session_id"
+
+    every { mockClient.lastActiveSessionId } returns activeSessionId
+    every { mockClient.sessions } returns listOf(mockSession)
+    every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockSession.id } returns activeSessionId
+    initializeClerkWithClient(mockClient)
+
+    // When
+    val sessionFromProperty = Clerk.session
+    val sessionFromFlow = Clerk.sessionFlow.value
+
+    // Then - both should return the same value
+    assertEquals(sessionFromFlow, sessionFromProperty)
+    assertEquals(mockSession, sessionFromProperty)
+  }
+
+  @Test
+  fun `user property returns userFlow value`() = runTest {
+    // Given - setup initial state
+    val activeSessionId = "active_session_id"
+
+    every { mockClient.lastActiveSessionId } returns activeSessionId
+    every { mockClient.sessions } returns listOf(mockSession)
+    every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockSession.id } returns activeSessionId
+    every { mockSession.user } returns mockUser
+    initializeClerkWithClient(mockClient)
+
+    // When
+    val userFromProperty = Clerk.user
+    val userFromFlow = Clerk.userFlow.value
+
+    // Then - both should return the same value
+    assertEquals(userFromFlow, userFromProperty)
+    assertEquals(mockUser, userFromProperty)
+  }
+
+  @Test
+  fun `updateSessionAndUserState updates both flows correctly`() = runTest {
+    // Given - setup initial state with no session
+    simulateUninitializedClient()
+    assertNull(Clerk.sessionFlow.value)
+    assertNull(Clerk.userFlow.value)
+
+    // When - update client to have an active session
+    val activeSessionId = "active_session_id"
+    every { mockClient.lastActiveSessionId } returns activeSessionId
+    every { mockClient.sessions } returns listOf(mockSession)
+    every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockSession.id } returns activeSessionId
+    every { mockSession.user } returns mockUser
+    Clerk.updateClient(mockClient)
+
+    // Then - both flows should be updated
+    assertEquals(mockSession, Clerk.sessionFlow.value)
+    assertEquals(mockUser, Clerk.userFlow.value)
+    assertEquals(mockSession, Clerk.session)
+    assertEquals(mockUser, Clerk.user)
+  }
 }


### PR DESCRIPTION
## Summary of changes

Unifies session state management in `Clerk.kt` by making `sessionFlow` the single source of truth for all session-related fields. This resolves issues where the `session` property could return stale data after logout due to relying on `client.activeSessions()` which wasn't immediately cleared.

The `session` and `isSignedIn` properties now directly read from `sessionFlow.value`, and `updateSessionAndUserState()` is adjusted to update `_session` directly, ensuring consistency across the application.

---
[Slack Thread](https://clerkinc.slack.com/archives/C08SE0321GR/p1761140246369749?thread_ts=1761140246.369749&cid=C08SE0321GR)

<a href="https://cursor.com/background-agent?bcId=bc-d5053b8a-20d2-4bd4-8356-88c0b50e8210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5053b8a-20d2-4bd4-8356-88c0b50e8210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced reactive user state flow for real-time user data updates via reactive bindings.

* **Refactor**
  * Improved session and user state management consistency by unifying state retrieval through reactive flows.

* **Tests**
  * Expanded test coverage to validate session and user state management, property parity, and state operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->