### PR TITLE
Add unit tests for user profile viewmodels

### DIFF
--- a/source/ui/src/test/java/com/clerk/ui/userprofile/MainDispatcherRule.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.clerk.ui.userprofile
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+  private val dispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher() {
+  override fun starting(description: Description) {
+    Dispatchers.setMain(dispatcher)
+  }
+
+  override fun finished(description: Description) {
+    Dispatchers.resetMain()
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/account/UserProfileAccountViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/account/UserProfileAccountViewModelTest.kt
@@ -1,0 +1,38 @@
+package com.clerk.ui.userprofile.account
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.serialization.ClerkResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserProfileAccountViewModelTest {
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun signOut_invokesClerkSignOut() = runTest {
+    coEvery { Clerk.signOut() } returns ClerkResult.success(Unit)
+
+    val viewModel = UserProfileAccountViewModel()
+
+    viewModel.signOut()
+
+    coVerify { Clerk.signOut() }
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/connectedaccount/AddConnectedAccountViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/connectedaccount/AddConnectedAccountViewModelTest.kt
@@ -1,0 +1,141 @@
+package com.clerk.ui.userprofile.connectedaccount
+
+import com.clerk.api.Clerk
+import com.clerk.api.externalaccount.ExternalAccount
+import com.clerk.api.externalaccount.reauthorize
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.api.sso.OAuthProvider
+import com.clerk.api.sso.OAuthResult
+import com.clerk.api.sso.ResultType
+import com.clerk.api.user.User
+import com.clerk.api.user.createExternalAccount
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.any
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddConnectedAccountViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    every { Clerk.isGoogleOneTapEnabled } returns false
+    mockkStatic("com.clerk.api.user.UserKt")
+    mockkStatic("com.clerk.api.externalaccount.ExternalAccountKt")
+    mockkObject(SignIn.Companion)
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkObject(SignIn.Companion)
+    unmockkStatic("com.clerk.api.externalaccount.ExternalAccountKt")
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun connectExternalAccount_success_setsSuccessState() = runTest {
+    val user = mockk<User>()
+    val account = mockk<ExternalAccount>()
+    every { Clerk.user } returns user
+    coEvery { user.createExternalAccount(any()) } returns ClerkResult.success(account)
+    coEvery { account.reauthorize() } returns ClerkResult.success(account)
+
+    val viewModel = AddConnectedAccountViewModel()
+
+    viewModel.connectExternalAccount(OAuthProvider.GITHUB)
+    advanceUntilIdle()
+
+    assertEquals(AddConnectedAccountViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun connectExternalAccount_failure_setsErrorState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "fail")))
+    coEvery { user.createExternalAccount(any()) } returns ClerkResult.Failure(error)
+
+    val viewModel = AddConnectedAccountViewModel()
+
+    viewModel.connectExternalAccount(OAuthProvider.GITHUB)
+    advanceUntilIdle()
+
+    assertEquals(AddConnectedAccountViewModel.State.Error("fail"), viewModel.state.value)
+  }
+
+  @Test
+  fun connectExternalAccount_withoutUser_setsGuardError() = runTest {
+    every { Clerk.user } returns null
+
+    val viewModel = AddConnectedAccountViewModel()
+
+    viewModel.connectExternalAccount(OAuthProvider.GITHUB)
+    advanceUntilIdle()
+
+    assertEquals(AddConnectedAccountViewModel.State.Error("User does not exist"), viewModel.state.value)
+  }
+
+  @Test
+  fun googleOneTap_success_setsSuccessState() = runTest {
+    val result = mockk<OAuthResult> { every { resultType } returns ResultType.SIGN_IN }
+    every { Clerk.user } returns mockk()
+    every { Clerk.isGoogleOneTapEnabled } returns true
+    coEvery { SignIn.authenticateWithGoogleOneTap() } returns ClerkResult.success(result)
+
+    val viewModel = AddConnectedAccountViewModel()
+
+    viewModel.connectExternalAccount(OAuthProvider.GOOGLE)
+    advanceUntilIdle()
+
+    assertEquals(AddConnectedAccountViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun googleOneTap_unknownResult_setsErrorState() = runTest {
+    val result = mockk<OAuthResult> { every { resultType } returns ResultType.UNKNOWN }
+    every { Clerk.user } returns mockk()
+    every { Clerk.isGoogleOneTapEnabled } returns true
+    coEvery { SignIn.authenticateWithGoogleOneTap() } returns ClerkResult.success(result)
+
+    val viewModel = AddConnectedAccountViewModel()
+
+    viewModel.connectExternalAccount(OAuthProvider.GOOGLE)
+    advanceUntilIdle()
+
+    assertEquals(AddConnectedAccountViewModel.State.Error("Unknown result type"), viewModel.state.value)
+  }
+
+  @Test
+  fun googleOneTap_failure_setsErrorState() = runTest {
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "nope")))
+    every { Clerk.user } returns mockk()
+    every { Clerk.isGoogleOneTapEnabled } returns true
+    coEvery { SignIn.authenticateWithGoogleOneTap() } returns ClerkResult.Failure(error)
+
+    val viewModel = AddConnectedAccountViewModel()
+
+    viewModel.connectExternalAccount(OAuthProvider.GOOGLE)
+    advanceUntilIdle()
+
+    assertEquals(AddConnectedAccountViewModel.State.Error("nope"), viewModel.state.value)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/email/AddEmailViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/email/AddEmailViewModelTest.kt
@@ -1,0 +1,82 @@
+package com.clerk.ui.userprofile.email
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.user.User
+import com.clerk.api.user.createEmailAddress
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.any
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddEmailViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    mockkStatic("com.clerk.api.user.UserKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun addEmail_success_emitsSuccessState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    coEvery { user.createEmailAddress(any()) } returns ClerkResult.success(mockk())
+
+    val viewModel = AddEmailViewModel()
+
+    viewModel.addEmail("user@example.com")
+    advanceUntilIdle()
+
+    assertEquals(AddEmailViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun addEmail_failure_emitsErrorState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "bad")))
+    coEvery { user.createEmailAddress(any()) } returns ClerkResult.Failure(error)
+
+    val viewModel = AddEmailViewModel()
+
+    viewModel.addEmail("user@example.com")
+    advanceUntilIdle()
+
+    assertEquals(AddEmailViewModel.State.Error("bad"), viewModel.state.value)
+  }
+
+  @Test
+  fun addEmail_withoutUser_emitsGuardError() = runTest {
+    every { Clerk.user } returns null
+
+    val viewModel = AddEmailViewModel()
+
+    viewModel.addEmail("user@example.com")
+    advanceUntilIdle()
+
+    assertEquals(AddEmailViewModel.State.Error("No current user found"), viewModel.state.value)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/email/EmailViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/email/EmailViewModelTest.kt
@@ -1,0 +1,104 @@
+package com.clerk.ui.userprofile.email
+
+import com.clerk.api.Clerk
+import com.clerk.api.emailaddress.EmailAddress
+import com.clerk.api.emailaddress.delete
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.user.User
+import com.clerk.api.user.User.UpdateParams
+import com.clerk.api.user.update
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.any
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EmailViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    mockkStatic("com.clerk.api.user.UserKt")
+    mockkStatic("com.clerk.api.emailaddress.EmailAddressKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.emailaddress.EmailAddressKt")
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun setAsPrimary_success_emitsSuccessState() = runTest {
+    val user = mockk<User>()
+    val email = mockk<EmailAddress>(relaxed = true)
+    every { Clerk.user } returns user
+    coEvery { user.update(any<UpdateParams>()) } returns ClerkResult.success(user)
+
+    val viewModel = EmailViewModel()
+
+    viewModel.setAsPrimary(email)
+    advanceUntilIdle()
+
+    assertEquals(EmailViewModel.State.SetAsPrimary.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun setAsPrimary_failure_emitsFailureState() = runTest {
+    val user = mockk<User>()
+    val email = mockk<EmailAddress>(relaxed = true)
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "oops")))
+    coEvery { user.update(any<UpdateParams>()) } returns ClerkResult.Failure(error)
+
+    val viewModel = EmailViewModel()
+
+    viewModel.setAsPrimary(email)
+    advanceUntilIdle()
+
+    assertEquals(EmailViewModel.State.Failure("oops"), viewModel.state.value)
+  }
+
+  @Test
+  fun remove_success_emitsRemoveSuccessState() = runTest {
+    val email = mockk<EmailAddress>()
+    coEvery { email.delete() } returns ClerkResult.success(mockk())
+
+    val viewModel = EmailViewModel()
+
+    viewModel.remove(email)
+    advanceUntilIdle()
+
+    assertEquals(EmailViewModel.State.Remove.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun remove_failure_emitsFailureState() = runTest {
+    val email = mockk<EmailAddress>()
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "remove")))
+    coEvery { email.delete() } returns ClerkResult.Failure(error)
+
+    val viewModel = EmailViewModel()
+
+    viewModel.remove(email)
+    advanceUntilIdle()
+
+    assertEquals(EmailViewModel.State.Failure("remove"), viewModel.state.value)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/mfa/MfaAddSmsViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/mfa/MfaAddSmsViewModelTest.kt
@@ -1,0 +1,61 @@
+package com.clerk.ui.userprofile.mfa
+
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.phonenumber.PhoneNumber
+import com.clerk.api.phonenumber.setReservedForSecondFactor
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MfaAddSmsViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkStatic("com.clerk.api.phonenumber.PhoneNumberKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.phonenumber.PhoneNumberKt")
+  }
+
+  @Test
+  fun reserveForSecondFactor_success_setsSuccessState() = runTest {
+    val phoneNumber = mockk<PhoneNumber>()
+    coEvery { phoneNumber.setReservedForSecondFactor(true) } returns ClerkResult.success(mockk())
+
+    val viewModel = MfaAddSmsViewModel()
+
+    viewModel.reserveForSecondFactor(phoneNumber)
+    advanceUntilIdle()
+
+    assertEquals(MfaAddSmsViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun reserveForSecondFactor_failure_setsErrorState() = runTest {
+    val phoneNumber = mockk<PhoneNumber>()
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "fail")))
+    coEvery { phoneNumber.setReservedForSecondFactor(true) } returns ClerkResult.Failure(error)
+
+    val viewModel = MfaAddSmsViewModel()
+
+    viewModel.reserveForSecondFactor(phoneNumber)
+    advanceUntilIdle()
+
+    assertEquals(MfaAddSmsViewModel.State.Error("fail"), viewModel.state.value)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/UserProfileSecurityViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/UserProfileSecurityViewModelTest.kt
@@ -1,0 +1,71 @@
+package com.clerk.ui.userprofile.security
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
+import com.clerk.api.user.User
+import com.clerk.api.user.allSessions
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserProfileSecurityViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    mockkStatic("com.clerk.api.user.UserKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun loadSessions_success_setsSuccessState() = runTest {
+    val user = mockk<User>()
+    val sessions = listOf(mockk<Session>(), mockk())
+    every { Clerk.user } returns user
+    coEvery { user.allSessions() } returns ClerkResult.success(sessions)
+
+    val viewModel = UserProfileSecurityViewModel()
+
+    viewModel.loadSessions()
+    advanceUntilIdle()
+
+    assertEquals(UserProfileSecurityViewModel.State.Success(sessions), viewModel.state.value)
+  }
+
+  @Test
+  fun loadSessions_failure_setsErrorState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "fail")))
+    coEvery { user.allSessions() } returns ClerkResult.Failure(error)
+
+    val viewModel = UserProfileSecurityViewModel()
+
+    viewModel.loadSessions()
+    advanceUntilIdle()
+
+    assertEquals(UserProfileSecurityViewModel.State.Error("fail"), viewModel.state.value)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/delete/DeleteAccountViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/delete/DeleteAccountViewModelTest.kt
@@ -1,0 +1,69 @@
+package com.clerk.ui.userprofile.security.delete
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.user.User
+import com.clerk.api.user.delete
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeleteAccountViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    mockkStatic("com.clerk.api.user.UserKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun deleteAccount_success_setsSuccessState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    coEvery { user.delete() } returns ClerkResult.success(mockk())
+
+    val viewModel = DeleteAccountViewModel()
+
+    viewModel.deleteAccount()
+    advanceUntilIdle()
+
+    assertEquals(DeleteAccountViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun deleteAccount_failure_setsErrorState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "boom")))
+    coEvery { user.delete() } returns ClerkResult.Failure(error)
+
+    val viewModel = DeleteAccountViewModel()
+
+    viewModel.deleteAccount()
+    advanceUntilIdle()
+
+    assertEquals(DeleteAccountViewModel.State.Error("boom"), viewModel.state.value)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/device/AllDevicesViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/device/AllDevicesViewModelTest.kt
@@ -1,0 +1,98 @@
+package com.clerk.ui.userprofile.security.device
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
+import com.clerk.api.session.Session.SessionStatus
+import com.clerk.api.session.SessionActivity
+import com.clerk.api.user.User
+import com.clerk.api.user.allSessions
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AllDevicesViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    every { Clerk.session } returns null
+    mockkStatic("com.clerk.api.user.UserKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun allSessions_success_sortsDevices() = runTest {
+    val user = mockk<User>()
+    val currentSession = session(id = "current", lastActiveAt = 100L)
+    val otherRecent = session(id = "other", lastActiveAt = 200L)
+    val older = session(id = "older", lastActiveAt = 50L)
+
+    every { Clerk.user } returns user
+    every { Clerk.session } returns currentSession
+    coEvery { user.allSessions() } returns ClerkResult.success(listOf(older, otherRecent, currentSession))
+
+    val viewModel = AllDevicesViewModel()
+
+    viewModel.allSessions()
+    advanceUntilIdle()
+
+    val successState = viewModel.state.value as AllDevicesViewModel.State.Success
+    assertEquals(listOf(currentSession, otherRecent, older), successState.devices)
+  }
+
+  @Test
+  fun allSessions_failure_setsErrorState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "bad")))
+    coEvery { user.allSessions() } returns ClerkResult.Failure(error)
+
+    val viewModel = AllDevicesViewModel()
+
+    viewModel.allSessions()
+    advanceUntilIdle()
+
+    assertEquals(AllDevicesViewModel.State.Error("bad"), viewModel.state.value)
+  }
+
+  private fun session(id: String, lastActiveAt: Long): Session =
+    Session(
+      id = id,
+      status = SessionStatus.ACTIVE,
+      expireAt = 0L,
+      abandonAt = null,
+      lastActiveAt = lastActiveAt,
+      latestActivity = SessionActivity(id = "activity-$id"),
+      lastActiveOrganizationId = null,
+      actor = null,
+      user = null,
+      publicUserData = null,
+      factorVerificationAge = null,
+      createdAt = 0L,
+      updatedAt = 0L,
+      tasks = emptyList(),
+      lastActiveToken = null,
+    )
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/device/DeviceViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/device/DeviceViewModelTest.kt
@@ -1,0 +1,74 @@
+package com.clerk.ui.userprofile.security.device
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
+import com.clerk.api.session.revoke
+import com.clerk.api.user.User
+import com.clerk.api.user.allSessions
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeviceViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    mockkStatic("com.clerk.api.session.SessionKt")
+    mockkStatic("com.clerk.api.user.UserKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkStatic("com.clerk.api.session.SessionKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun signOut_success_setsSuccessState() = runTest {
+    val session = mockk<Session>()
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    coEvery { session.revoke() } returns ClerkResult.success(session)
+    coEvery { user.allSessions() } returns ClerkResult.success(emptyList())
+
+    val viewModel = DeviceViewModel()
+
+    viewModel.signOut(session)
+    advanceUntilIdle()
+
+    assertEquals(DeviceViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun signOut_failure_setsErrorState() = runTest {
+    val session = mockk<Session>()
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "no")))
+    coEvery { session.revoke() } returns ClerkResult.Failure(error)
+
+    val viewModel = DeviceViewModel()
+
+    viewModel.signOut(session)
+    advanceUntilIdle()
+
+    assertEquals(DeviceViewModel.State.Error("no"), viewModel.state.value)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/mfa/UserProfileMfaViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/mfa/UserProfileMfaViewModelTest.kt
@@ -1,0 +1,87 @@
+package com.clerk.ui.userprofile.security.mfa
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.phonenumber.PhoneNumber
+import com.clerk.api.phonenumber.setReservedForSecondFactor
+import com.clerk.api.user.User
+import com.clerk.api.user.createBackupCodes
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserProfileMfaViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    mockkStatic("com.clerk.api.phonenumber.PhoneNumberKt")
+    mockkStatic("com.clerk.api.user.UserKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkStatic("com.clerk.api.phonenumber.PhoneNumberKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun makeDefaultSecondFactor_failure_setsErrorState() = runTest {
+    val user = mockk<User>()
+    val phone = mockk<PhoneNumber>()
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "fail")))
+    coEvery { phone.setReservedForSecondFactor(true) } returns ClerkResult.Failure(error)
+
+    val viewModel = UserProfileMfaViewModel()
+
+    viewModel.makeDefaultSecondFactor(phone)
+    advanceUntilIdle()
+
+    assertEquals(UserProfileMfaViewModel.State.Error("fail"), viewModel.state.value)
+  }
+
+  @Test
+  fun makeDefaultSecondFactor_noUser_setsErrorState() = runTest {
+    every { Clerk.user } returns null
+
+    val viewModel = UserProfileMfaViewModel()
+
+    viewModel.makeDefaultSecondFactor(mockk())
+    advanceUntilIdle()
+
+    assertEquals(UserProfileMfaViewModel.State.Error("User does not exist"), viewModel.state.value)
+  }
+
+  @Test
+  fun regenerateBackupCodes_failure_setsErrorState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "boom")))
+    coEvery { user.createBackupCodes() } returns ClerkResult.Failure(error)
+
+    val viewModel = UserProfileMfaViewModel()
+
+    viewModel.regenerateBackupCodes()
+    advanceUntilIdle()
+
+    assertEquals(UserProfileMfaViewModel.State.Error("boom"), viewModel.state.value)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/passkey/UserProfilePasskeyViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/passkey/UserProfilePasskeyViewModelTest.kt
@@ -1,0 +1,100 @@
+package com.clerk.ui.userprofile.security.passkey
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.passkeys.Passkey
+import com.clerk.api.passkeys.delete
+import com.clerk.api.user.User
+import com.clerk.api.user.createPasskey
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserProfilePasskeyViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    mockkStatic("com.clerk.api.passkeys.PasskeyKt")
+    mockkStatic("com.clerk.api.user.UserKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkStatic("com.clerk.api.passkeys.PasskeyKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun deletePasskey_success_setsSuccessState() = runTest {
+    val passkey = mockk<Passkey>()
+    coEvery { passkey.delete() } returns ClerkResult.success(passkey)
+
+    val viewModel = UserProfilePasskeyViewModel()
+
+    viewModel.deletePasskey(passkey)
+    advanceUntilIdle()
+
+    assertEquals(UserProfilePasskeyViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun deletePasskey_failure_setsErrorState() = runTest {
+    val passkey = mockk<Passkey>()
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "bad")))
+    coEvery { passkey.delete() } returns ClerkResult.Failure(error)
+
+    val viewModel = UserProfilePasskeyViewModel()
+
+    viewModel.deletePasskey(passkey)
+    advanceUntilIdle()
+
+    assertEquals(UserProfilePasskeyViewModel.State.Error("bad"), viewModel.state.value)
+  }
+
+  @Test
+  fun createPasskey_success_setsSuccessState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    coEvery { user.createPasskey() } returns ClerkResult.success(mockk())
+
+    val viewModel = UserProfilePasskeyViewModel()
+
+    viewModel.createPasskey()
+    advanceUntilIdle()
+
+    assertEquals(UserProfilePasskeyViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun createPasskey_failure_setsErrorState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "boom")))
+    coEvery { user.createPasskey() } returns ClerkResult.Failure(error)
+
+    val viewModel = UserProfilePasskeyViewModel()
+
+    viewModel.createPasskey()
+    advanceUntilIdle()
+
+    assertEquals(UserProfilePasskeyViewModel.State.Error("boom"), viewModel.state.value)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/password/UserProfileChangePasswordViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/password/UserProfileChangePasswordViewModelTest.kt
@@ -1,0 +1,91 @@
+package com.clerk.ui.userprofile.security.password
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.user.User
+import com.clerk.api.user.updatePassword
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.any
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserProfileChangePasswordViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    mockkStatic("com.clerk.api.user.UserKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun resetPassword_success_setsSuccessState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    coEvery { user.updatePassword(any()) } returns ClerkResult.success(user)
+
+    val viewModel = UserProfileChangePasswordViewModel()
+
+    viewModel.resetPassword("old", "new", true)
+    advanceUntilIdle()
+
+    assertEquals(UserProfileChangePasswordViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun resetPassword_failure_setsErrorState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "fail")))
+    coEvery { user.updatePassword(any()) } returns ClerkResult.Failure(error)
+
+    val viewModel = UserProfileChangePasswordViewModel()
+
+    viewModel.resetPassword("old", "new", false)
+    advanceUntilIdle()
+
+    assertEquals(UserProfileChangePasswordViewModel.State.Error("fail"), viewModel.state.value)
+  }
+
+  @Test
+  fun resetPassword_withoutUser_setsGuardError() = runTest {
+    every { Clerk.user } returns null
+
+    val viewModel = UserProfileChangePasswordViewModel()
+
+    viewModel.resetPassword("old", "new", false)
+    advanceUntilIdle()
+
+    assertEquals(UserProfileChangePasswordViewModel.State.Error("User does not exist"), viewModel.state.value)
+  }
+
+  @Test
+  fun resetState_setsIdle() {
+    val viewModel = UserProfileChangePasswordViewModel()
+
+    viewModel.resetState()
+
+    assertEquals(UserProfileChangePasswordViewModel.State.Idle, viewModel.state.value)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/update/UpdateProfileViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/update/UpdateProfileViewModelTest.kt
@@ -1,0 +1,123 @@
+package com.clerk.ui.userprofile.update
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.user.User
+import com.clerk.api.user.User.UpdateParams
+import com.clerk.api.user.deleteProfileImage
+import com.clerk.api.user.get
+import com.clerk.api.user.setProfileImage
+import com.clerk.api.user.update
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.any
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateProfileViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    mockkStatic("com.clerk.api.user.UserKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun removeProfileImage_success_updatesState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    coEvery { user.deleteProfileImage() } returns ClerkResult.success(Unit)
+    coEvery { user.get() } returns ClerkResult.success(user)
+
+    val viewModel = UpdateProfileViewModel()
+
+    viewModel.removeProfileImage()
+    advanceUntilIdle()
+
+    assertEquals(UpdateProfileViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun removeProfileImage_failure_emitsError() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "boom")))
+    coEvery { user.deleteProfileImage() } returns ClerkResult.Failure(error)
+
+    val viewModel = UpdateProfileViewModel()
+
+    viewModel.removeProfileImage()
+    advanceUntilIdle()
+
+    assertEquals(
+      UpdateProfileViewModel.State.Error("Failed to delete profile image: boom"),
+      viewModel.state.value,
+    )
+  }
+
+  @Test
+  fun uploadProfileImage_success_emitsSuccess() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    coEvery { user.setProfileImage(any()) } returns ClerkResult.success(mockk())
+    coEvery { user.get() } returns ClerkResult.success(user)
+
+    val viewModel = UpdateProfileViewModel()
+
+    viewModel.uploadProfileImage(mockk())
+    advanceUntilIdle()
+
+    assertEquals(UpdateProfileViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun save_success_setsSuccessState() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    coEvery { user.update(any<UpdateParams>()) } returns ClerkResult.success(user)
+    coEvery { user.get() } returns ClerkResult.success(user)
+
+    val viewModel = UpdateProfileViewModel()
+
+    viewModel.save("Jane", "Doe", "jane")
+    advanceUntilIdle()
+
+    assertEquals(UpdateProfileViewModel.State.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun removeProfileImage_withoutUser_emitsAuthenticationError() = runTest {
+    every { Clerk.user } returns null
+
+    val viewModel = UpdateProfileViewModel()
+
+    viewModel.removeProfileImage()
+    advanceUntilIdle()
+
+    assertEquals(
+      UpdateProfileViewModel.State.Error("User not authenticated"),
+      viewModel.state.value,
+    )
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/verify/UserProfileVerifyViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/verify/UserProfileVerifyViewModelTest.kt
@@ -1,0 +1,155 @@
+package com.clerk.ui.userprofile.verify
+
+import com.clerk.api.Clerk
+import com.clerk.api.emailaddress.EmailAddress
+import com.clerk.api.emailaddress.attemptVerification
+import com.clerk.api.emailaddress.prepareVerification
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.phonenumber.PhoneNumber
+import com.clerk.api.phonenumber.attemptVerification
+import com.clerk.api.phonenumber.prepareVerification
+import com.clerk.api.user.User
+import com.clerk.api.user.attemptTotpVerification
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.any
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserProfileVerifyViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.user } returns null
+    mockkStatic("com.clerk.api.emailaddress.EmailAddressKt")
+    mockkStatic("com.clerk.api.phonenumber.PhoneNumberKt")
+    mockkStatic("com.clerk.api.user.UserKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.user.UserKt")
+    unmockkStatic("com.clerk.api.phonenumber.PhoneNumberKt")
+    unmockkStatic("com.clerk.api.emailaddress.EmailAddressKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun prepareEmailAddress_success_setsAuthSuccess() = runTest {
+    val email = mockk<EmailAddress>()
+    coEvery { email.prepareVerification(any()) } returns ClerkResult.success(mockk())
+
+    val viewModel = UserProfileVerifyViewModel()
+
+    viewModel.prepareEmailAddress(email)
+    advanceUntilIdle()
+
+    assertEquals(UserProfileVerifyViewModel.AuthState.Success, viewModel.state.value)
+  }
+
+  @Test
+  fun prepareEmailAddress_failure_setsError() = runTest {
+    val email = mockk<EmailAddress>()
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "fail")))
+    coEvery { email.prepareVerification(any()) } returns ClerkResult.Failure(error)
+
+    val viewModel = UserProfileVerifyViewModel()
+
+    viewModel.prepareEmailAddress(email)
+    advanceUntilIdle()
+
+    assertEquals(UserProfileVerifyViewModel.AuthState.Error("fail"), viewModel.state.value)
+  }
+
+  @Test
+  fun attemptEmailAddress_success_updatesVerificationState() = runTest {
+    val email = mockk<EmailAddress>()
+    coEvery { email.attemptVerification(any()) } returns ClerkResult.success(mockk())
+
+    val viewModel = UserProfileVerifyViewModel()
+
+    viewModel.attemptEmailAddress(email, "123456")
+    advanceUntilIdle()
+
+    assertEquals(UserProfileVerifyViewModel.VerificationTextState.Verified, viewModel.verificationTextState.value)
+  }
+
+  @Test
+  fun attemptEmailAddress_failure_updatesVerificationError() = runTest {
+    val email = mockk<EmailAddress>()
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "bad")))
+    coEvery { email.attemptVerification(any()) } returns ClerkResult.Failure(error)
+
+    val viewModel = UserProfileVerifyViewModel()
+
+    viewModel.attemptEmailAddress(email, "123456")
+    advanceUntilIdle()
+
+    assertEquals(
+      UserProfileVerifyViewModel.VerificationTextState.Error("bad"),
+      viewModel.verificationTextState.value,
+    )
+  }
+
+  @Test
+  fun attemptTotp_success_setsVerified() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    coEvery { user.attemptTotpVerification(any()) } returns ClerkResult.success(mockk())
+
+    val viewModel = UserProfileVerifyViewModel()
+
+    viewModel.attemptTotp("654321")
+    advanceUntilIdle()
+
+    assertEquals(UserProfileVerifyViewModel.VerificationTextState.Verified, viewModel.verificationTextState.value)
+  }
+
+  @Test
+  fun attemptTotp_failure_setsError() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    val error = ClerkErrorResponse(errors = listOf(ClerkErrorResponse.Error(longMessage = "oops")))
+    coEvery { user.attemptTotpVerification(any()) } returns ClerkResult.Failure(error)
+
+    val viewModel = UserProfileVerifyViewModel()
+
+    viewModel.attemptTotp("654321")
+    advanceUntilIdle()
+
+    assertEquals(
+      UserProfileVerifyViewModel.VerificationTextState.Error("oops"),
+      viewModel.verificationTextState.value,
+    )
+  }
+
+  @Test
+  fun attemptTotp_withoutUser_setsGuardError() = runTest {
+    every { Clerk.user } returns null
+
+    val viewModel = UserProfileVerifyViewModel()
+
+    viewModel.attemptTotp("654321")
+    advanceUntilIdle()
+
+    assertEquals(
+      UserProfileVerifyViewModel.VerificationTextState.Error("User does not exist"),
+      viewModel.verificationTextState.value,
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add coroutine test rule for user profile unit tests
- cover user profile viewmodels with success and failure scenarios across account, security, and verification flows
- ensure user profile device and MFA viewmodels handle error cases as expected

## Testing
- `./gradlew :source:ui:testDebugUnitTest` (fails: toolchain for Java 17 not available in CI environment)

------
https://chatgpt.com/codex/tasks/task_e_69014ac6d2608322b20094542b18522a