### PR TITLE
Add error state for External Account connection

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountRow.kt
@@ -3,12 +3,15 @@ package com.clerk.ui.userprofile.connectedaccount
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -25,9 +28,13 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.clerk.api.externalaccount.ExternalAccount
 import com.clerk.api.externalaccount.oauthProviderType
+import com.clerk.api.network.model.error.Error
+import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.logoUrl
 import com.clerk.ui.R
+import com.clerk.ui.core.dimens.dp16
+import com.clerk.ui.core.dimens.dp2
 import com.clerk.ui.core.dimens.dp20
 import com.clerk.ui.core.dimens.dp24
 import com.clerk.ui.core.dimens.dp8
@@ -117,18 +124,75 @@ private fun EmailWithAccountBadge(externalAccount: ExternalAccount) {
         style = ClerkMaterialTheme.typography.bodyMedium,
       )
     }
-    Spacers.Vertical.Spacer4()
-    Text(
-      text = externalAccount.emailAddress,
-      color = ClerkMaterialTheme.colors.foreground,
-      style = ClerkMaterialTheme.typography.bodyLarge,
-    )
+    Spacers.Vertical.Spacer8()
+    if (externalAccount.verification?.error != null) {
+      Row(horizontalArrangement = Arrangement.spacedBy(dp8)) {
+        Box(
+          modifier =
+            Modifier.size(dp20)
+              .background(
+                color = ClerkMaterialTheme.computedColors.backgroundDanger,
+                shape = RoundedCornerShape(dp2),
+              ),
+          contentAlignment = Alignment.Center,
+        ) {
+          Icon(
+            modifier = Modifier.size(dp16),
+            painter = painterResource(R.drawable.ic_warning),
+            contentDescription = null,
+            tint = ClerkMaterialTheme.colors.warning,
+          )
+        }
+        externalAccount.verification?.error?.message?.let {
+          Text(
+            text = it,
+            color = ClerkMaterialTheme.colors.danger,
+            style = ClerkMaterialTheme.typography.bodyMedium,
+          )
+        }
+      }
+    } else {
+      Text(
+        text = externalAccount.emailAddress,
+        color = ClerkMaterialTheme.colors.foreground,
+        style = ClerkMaterialTheme.typography.bodyLarge,
+      )
+    }
   }
 }
 
 enum class ExternalAccountAction {
   Reconnect,
   Remove,
+}
+
+@PreviewLightDark
+@Composable
+private fun PreviewWithError() {
+  ClerkMaterialTheme {
+    UserProfileExternalAccountRow(
+      onError = {},
+      externalAccount =
+        ExternalAccount(
+          id = "eac_34o5pCBEhohJtr1Ni14YiX8aQ0K",
+          identificationId = "idn_34o5pAvdtMtjAAdeFBfTkRfs77e",
+          provider = "oauth_google",
+          providerUserId = "102662613248529322762",
+          emailAddress = "sam@clerk.dev",
+          approvedScopes =
+            "email https://www.googleapis.com/auth/userinfo.email" +
+              " https://www.googleapis.com/auth/userinfo.profile openid profile",
+          createdAt = 1L,
+          verification =
+            Verification(
+              error =
+                Error(
+                  "This email address associated with this OAuth account is already claimed by another user."
+                )
+            ),
+        ),
+    )
+  }
 }
 
 @PreviewLightDark


### PR DESCRIPTION
This pull request enhances the user experience for displaying external account information in the user profile, specifically by showing error messages when an account verification fails. The changes also improve UI consistency and add preview functionality for error states.

**UI improvements for error handling:**

* Added a new UI row in `EmailWithAccountBadge` to display a warning icon and error message when `externalAccount.verification.error` is present, using a visually distinct background and colors for better visibility.
* Increased vertical spacing between elements for improved readability when an error is shown.

**Preview and testing enhancements:**

* Added a `PreviewWithError` composable to allow easy visual testing of the error state in the UI, using a sample `ExternalAccount` with a verification error.

**Dependency and import updates:**

* Imported additional Compose UI components (`Box`, `Icon`, `RoundedCornerShape`) and project-specific dimension values (`dp16`, `dp2`) to support the new UI elements. [[1]](diffhunk://#diff-910cf5284520fc2d864233bce3acdca4258b0950c8ccaa2d09c7edd35b3842faR6-R14) [[2]](diffhunk://#diff-910cf5284520fc2d864233bce3acdca4258b0950c8ccaa2d09c7edd35b3842faR31-R37)
* Added imports for error and verification models to support error handling logic.