### PR TITLE
Fix clerk sdk secure storage initialization

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/storage/StorageHelper.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/storage/StorageHelper.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.clerk.api.Constants.Storage.CLERK_PREFERENCES_FILE_NAME
-import com.clerk.api.storage.StorageHelper.secureStorage
+import com.clerk.api.log.ClerkLog
 
 /**
  * Helper class to manage secure storage of data. SharedPreferences are used to store data, all keys
@@ -12,33 +12,68 @@ import com.clerk.api.storage.StorageHelper.secureStorage
  */
 internal object StorageHelper {
 
-  private lateinit var secureStorage: SharedPreferences
+  private val storageLock = Any()
+  @Volatile private var secureStorage: SharedPreferences? = null
 
   /**
    * Synchronously initializes the secure storage. We do this synchronously because we need to
    * ensure that the storage is initialized before we generate a device ID.
    */
   fun initialize(context: Context) {
-    secureStorage = context.getSharedPreferences(CLERK_PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
+    if (secureStorage != null) {
+      return
+    }
+
+    synchronized(storageLock) {
+      if (secureStorage == null) {
+        secureStorage =
+          context.applicationContext.getSharedPreferences(
+            CLERK_PREFERENCES_FILE_NAME,
+            Context.MODE_PRIVATE,
+          )
+        ClerkLog.d("StorageHelper initialized")
+      }
+    }
   }
 
   /** Save value of string type to [secureStorage] */
   internal fun saveValue(key: StorageKey, value: String) {
-    if (value.isNotEmpty()) {
-      secureStorage.edit(commit = true) { putString(key.name, value) }
+    if (value.isEmpty()) {
       return
     }
+
+    val storage = secureStorage
+    if (storage == null) {
+      ClerkLog.w("Attempted to save ${key.name} before storage initialization")
+      return
+    }
+
+    storage.edit(commit = true) { putString(key.name, value) }
   }
 
   /** Load value of string type from [secureStorage] */
   internal fun loadValue(key: StorageKey): String? {
-    return secureStorage.getString(key.name, null)
+    val storage = secureStorage
+    if (storage == null) {
+      ClerkLog.w("Attempted to load ${key.name} before storage initialization")
+      return null
+    }
+
+    return storage.getString(key.name, null)
   }
 
   /** Delete value of string type from [secureStorage] */
   internal fun deleteValue(name: String) {
-    secureStorage.edit { remove(name) }
+    val storage = secureStorage
+    if (storage == null) {
+      ClerkLog.w("Attempted to delete $name before storage initialization")
+      return
+    }
+
+    storage.edit { remove(name) }
   }
+
+  internal fun isInitialized(): Boolean = secureStorage != null
 }
 
 internal enum class StorageKey(val key: String) {


### PR DESCRIPTION
## Summary of changes

Addresses the `lateinit property secureStorage has not been initialized` crash by:
*   Changing `secureStorage` to a nullable, `@Volatile` property with thread-safe, double-checked initialization.
*   Adding checks in `saveValue`, `loadValue`, and `deleteValue` to prevent access if storage is not yet initialized, logging warnings and returning early instead of crashing.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2f09a76-9845-4ef2-8535-11e71429edcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b2f09a76-9845-4ef2-8535-11e71429edcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage initialization reliability with enhanced thread-safety mechanisms
  * Added validation checks to prevent data persistence failures
  * Enhanced error logging and diagnostics for storage operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->