### PR TITLE
Implement per-element ui theming

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
@@ -43,7 +43,9 @@ import com.clerk.ui.core.dimens.dp32
 import com.clerk.ui.core.dimens.dp36
 import com.clerk.ui.core.dimens.dp48
 import com.clerk.ui.core.dimens.dp96
+import com.clerk.ui.theme.ClerkElementTheme
 import com.clerk.ui.theme.ClerkMaterialTheme
+import com.clerk.ui.theme.mergeElementTheme
 
 @Composable
 internal fun AvatarView(
@@ -56,34 +58,39 @@ internal fun AvatarView(
   onEditTakePhoto: () -> Unit = {},
   onEditChoosePhoto: () -> Unit = {},
   onEditRemovePhoto: () -> Unit = {},
+  elementTheme: ClerkElementTheme? = null,
 ) {
-  val placeholder =
-    when (avatarType) {
-      AvatarType.USER -> R.drawable.ic_user
-      AvatarType.ORGANIZATION -> R.drawable.ic_organization
-    }
+  ClerkMaterialTheme {
+    val mergedTheme = mergeElementTheme(elementTheme)
+    val placeholder =
+      when (avatarType) {
+        AvatarType.USER -> R.drawable.ic_user
+        AvatarType.ORGANIZATION -> R.drawable.ic_organization
+      }
 
-  Box(modifier = Modifier.wrapContentSize().then(modifier), contentAlignment = Alignment.Center) {
-    SubcomposeAsyncImage(
-      model = imageUrl,
-      contentDescription = stringResource(R.string.logo),
-      modifier = Modifier.size(size.toDp()).clip(shape),
-      contentScale = ContentScale.FillBounds,
-      loading = { CircularProgressIndicator(modifier = Modifier.size(dp24)) },
-      error = {
-        Icon(
-          painter = painterResource(placeholder),
-          contentDescription = null,
-          tint = ClerkMaterialTheme.colors.foreground,
-        )
-      },
-    )
-    if (hasEditButton) {
-      EditButton(
-        onEditTakePhoto = onEditTakePhoto,
-        onEditChoosePhoto = onEditChoosePhoto,
-        onEditRemovePhoto = onEditRemovePhoto,
+    Box(modifier = Modifier.wrapContentSize().then(modifier), contentAlignment = Alignment.Center) {
+      SubcomposeAsyncImage(
+        model = imageUrl,
+        contentDescription = stringResource(R.string.logo),
+        modifier = Modifier.size(size.toDp()).clip(shape),
+        contentScale = ContentScale.FillBounds,
+        loading = { CircularProgressIndicator(modifier = Modifier.size(dp24)) },
+        error = {
+          Icon(
+            painter = painterResource(placeholder),
+            contentDescription = null,
+            tint = mergedTheme.colors.foreground,
+          )
+        },
       )
+      if (hasEditButton) {
+        EditButton(
+          onEditTakePhoto = onEditTakePhoto,
+          onEditChoosePhoto = onEditChoosePhoto,
+          onEditRemovePhoto = onEditRemovePhoto,
+          elementTheme = elementTheme,
+        )
+      }
     }
   }
 }
@@ -93,38 +100,43 @@ private fun BoxScope.EditButton(
   onEditTakePhoto: () -> Unit,
   onEditChoosePhoto: () -> Unit,
   onEditRemovePhoto: () -> Unit,
+  elementTheme: ClerkElementTheme? = null,
 ) {
-  var expanded by remember { mutableStateOf(false) }
-  Box(modifier = Modifier.align(Alignment.BottomEnd)) {
-    Surface(
-      modifier =
-        Modifier.size(dp32)
-          .shadow(
-            elevation = dp3,
-            spotColor = ClerkMaterialTheme.colors.shadow.copy(alpha = 0.08f),
-            ambientColor = ClerkMaterialTheme.colors.shadow.copy(alpha = 0.08f),
-            shape = ClerkMaterialTheme.shape,
-          ),
-      border = BorderStroke(dp1, color = ClerkMaterialTheme.colors.shadow.copy(alpha = 0.08f)),
-      shape = ClerkMaterialTheme.shape,
-      onClick = { expanded = true },
-    ) {
-      Box(contentAlignment = Alignment.Center) {
-        Icon(
-          painter = painterResource(R.drawable.ic_edit),
-          contentDescription = stringResource(R.string.edit_avatar),
-          tint = ClerkMaterialTheme.colors.mutedForeground,
-        )
+  ClerkMaterialTheme {
+    val mergedTheme = mergeElementTheme(elementTheme)
+    var expanded by remember { mutableStateOf(false) }
+    Box(modifier = Modifier.align(Alignment.BottomEnd)) {
+      Surface(
+        modifier =
+          Modifier.size(dp32)
+            .shadow(
+              elevation = dp3,
+              spotColor = mergedTheme.colors.shadow.copy(alpha = 0.08f),
+              ambientColor = mergedTheme.colors.shadow.copy(alpha = 0.08f),
+              shape = androidx.compose.foundation.shape.RoundedCornerShape(mergedTheme.design.borderRadius),
+            ),
+        border = BorderStroke(dp1, color = mergedTheme.colors.shadow.copy(alpha = 0.08f)),
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(mergedTheme.design.borderRadius),
+        onClick = { expanded = true },
+      ) {
+        Box(contentAlignment = Alignment.Center) {
+          Icon(
+            painter = painterResource(R.drawable.ic_edit),
+            contentDescription = stringResource(R.string.edit_avatar),
+            tint = mergedTheme.colors.mutedForeground,
+          )
+        }
       }
-    }
 
-    DropdownMenu(
-      expanded,
-      onEditTakePhoto,
-      onEditChoosePhoto,
-      onEditRemovePhoto,
-      onDismissRequest = { expanded = false },
-    )
+      DropdownMenu(
+        expanded,
+        onEditTakePhoto,
+        onEditChoosePhoto,
+        onEditRemovePhoto,
+        onDismissRequest = { expanded = false },
+        elementTheme = elementTheme,
+      )
+    }
   }
 }
 
@@ -135,52 +147,55 @@ private fun DropdownMenu(
   onEditChoosePhoto: () -> Unit,
   onEditRemovePhoto: () -> Unit,
   onDismissRequest: () -> Unit,
+  elementTheme: ClerkElementTheme? = null,
 ) {
-
-  DropdownMenu(
-    modifier =
-      Modifier.background(ClerkMaterialTheme.colors.background).defaultMinSize(minWidth = 144.dp),
-    expanded = expanded,
-    onDismissRequest = onDismissRequest,
-    offset = DpOffset(0.dp, dp12),
-  ) {
-    DropdownMenuItem(
-      text = {
-        Text(
-          text = stringResource(R.string.take_a_photo),
-          style = ClerkMaterialTheme.typography.bodyLarge,
-        )
-      },
-      onClick = {
-        onDismissRequest()
-        onEditTakePhoto()
-      },
-    )
-    DropdownMenuItem(
-      text = {
-        Text(
-          text = stringResource(R.string.choose_photo),
-          style = ClerkMaterialTheme.typography.bodyLarge,
-        )
-      },
-      onClick = {
-        onDismissRequest()
-        onEditChoosePhoto()
-      },
-    )
-    DropdownMenuItem(
-      text = {
-        Text(
-          text = stringResource(R.string.remove_photo),
-          color = ClerkMaterialTheme.colors.danger,
-          style = ClerkMaterialTheme.typography.bodyLarge,
-        )
-      },
-      onClick = {
-        onDismissRequest()
-        onEditRemovePhoto()
-      },
-    )
+  ClerkMaterialTheme {
+    val mergedTheme = mergeElementTheme(elementTheme)
+    DropdownMenu(
+      modifier =
+        Modifier.background(mergedTheme.colors.background).defaultMinSize(minWidth = 144.dp),
+      expanded = expanded,
+      onDismissRequest = onDismissRequest,
+      offset = DpOffset(0.dp, dp12),
+    ) {
+      DropdownMenuItem(
+        text = {
+          Text(
+            text = stringResource(R.string.take_a_photo),
+            style = mergedTheme.typography.bodyLarge,
+          )
+        },
+        onClick = {
+          onDismissRequest()
+          onEditTakePhoto()
+        },
+      )
+      DropdownMenuItem(
+        text = {
+          Text(
+            text = stringResource(R.string.choose_photo),
+            style = mergedTheme.typography.bodyLarge,
+          )
+        },
+        onClick = {
+          onDismissRequest()
+          onEditChoosePhoto()
+        },
+      )
+      DropdownMenuItem(
+        text = {
+          Text(
+            text = stringResource(R.string.remove_photo),
+            color = mergedTheme.colors.danger,
+            style = mergedTheme.typography.bodyLarge,
+          )
+        },
+        onClick = {
+          onDismissRequest()
+          onEditRemovePhoto()
+        },
+      )
+    }
   }
 }
 
@@ -194,15 +209,18 @@ fun OrganizationAvatar(
   modifier: Modifier = Modifier,
   shape: Shape? = null,
   size: AvatarSize = AvatarSize.MEDIUM,
+  elementTheme: ClerkElementTheme? = null,
 ) {
   val url = Clerk.organizationLogoUrl
   ClerkMaterialTheme {
+    val mergedTheme = mergeElementTheme(elementTheme)
     AvatarView(
       imageUrl = url,
       size = size,
-      shape = shape ?: ClerkMaterialTheme.shape,
+      shape = shape ?: androidx.compose.foundation.shape.RoundedCornerShape(mergedTheme.design.borderRadius),
       modifier = modifier,
       avatarType = AvatarType.ORGANIZATION,
+      elementTheme = elementTheme,
     )
   }
 }

--- a/source/ui/src/main/java/com/clerk/ui/core/badge/ClerkBadge.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/badge/ClerkBadge.kt
@@ -18,7 +18,9 @@ import androidx.compose.ui.unit.sp
 import com.clerk.ui.core.dimens.dp1
 import com.clerk.ui.core.dimens.dp12
 import com.clerk.ui.core.dimens.dp8
+import com.clerk.ui.theme.ClerkElementTheme
 import com.clerk.ui.theme.ClerkMaterialTheme
+import com.clerk.ui.theme.mergeElementTheme
 
 /**
  * A badge component that displays text with various styling options.
@@ -36,34 +38,36 @@ fun Badge(
   text: String,
   modifier: Modifier = Modifier,
   badgeType: ClerkBadgeType = ClerkBadgeType.Primary,
+  elementTheme: ClerkElementTheme? = null,
 ) {
-  val (backgroundColor, contentColor) =
-    when (badgeType) {
-      ClerkBadgeType.Primary ->
-        ClerkMaterialTheme.colors.primary to ClerkMaterialTheme.colors.primaryForeground
-      ClerkBadgeType.Secondary ->
-        ClerkMaterialTheme.colors.muted to ClerkMaterialTheme.colors.mutedForeground
-      ClerkBadgeType.Positive ->
-        ClerkMaterialTheme.computedColors.backgroundSuccess to ClerkMaterialTheme.colors.success
-      ClerkBadgeType.Negative ->
-        ClerkMaterialTheme.computedColors.backgroundDanger to ClerkMaterialTheme.colors.danger
-      ClerkBadgeType.Warning ->
-        ClerkMaterialTheme.computedColors.backgroundWarning to ClerkMaterialTheme.colors.warning
-    }
-
-  val borderColor =
-    when (badgeType) {
-      ClerkBadgeType.Primary -> Color.Transparent
-      ClerkBadgeType.Secondary -> ClerkMaterialTheme.computedColors.buttonBorder
-      ClerkBadgeType.Positive -> ClerkMaterialTheme.colors.success
-      ClerkBadgeType.Negative -> ClerkMaterialTheme.colors.danger
-      ClerkBadgeType.Warning -> ClerkMaterialTheme.colors.warning
-    }
-
   ClerkMaterialTheme {
+    val mergedTheme = mergeElementTheme(elementTheme)
+    val (backgroundColor, contentColor) =
+      when (badgeType) {
+        ClerkBadgeType.Primary ->
+          mergedTheme.colors.primary to mergedTheme.colors.primaryForeground
+        ClerkBadgeType.Secondary ->
+          mergedTheme.colors.muted to mergedTheme.colors.mutedForeground
+        ClerkBadgeType.Positive ->
+          mergedTheme.computedColors.backgroundSuccess to mergedTheme.colors.success
+        ClerkBadgeType.Negative ->
+          mergedTheme.computedColors.backgroundDanger to mergedTheme.colors.danger
+        ClerkBadgeType.Warning ->
+          mergedTheme.computedColors.backgroundWarning to mergedTheme.colors.warning
+      }
+
+    val borderColor =
+      when (badgeType) {
+        ClerkBadgeType.Primary -> Color.Transparent
+        ClerkBadgeType.Secondary -> mergedTheme.computedColors.buttonBorder
+        ClerkBadgeType.Positive -> mergedTheme.colors.success
+        ClerkBadgeType.Negative -> mergedTheme.colors.danger
+        ClerkBadgeType.Warning -> mergedTheme.colors.warning
+      }
+
     Surface(
       modifier = Modifier.then(modifier),
-      shape = ClerkMaterialTheme.shape,
+      shape = androidx.compose.foundation.shape.RoundedCornerShape(mergedTheme.design.borderRadius),
       color = backgroundColor,
       contentColor = contentColor,
       border = BorderStroke(dp1, borderColor),

--- a/source/ui/src/main/java/com/clerk/ui/core/button/standard/ButtonStyleTokens.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/button/standard/ButtonStyleTokens.kt
@@ -10,6 +10,7 @@ import com.clerk.ui.core.dimens.dp1
 import com.clerk.ui.core.dimens.dp32
 import com.clerk.ui.core.dimens.dp48
 import com.clerk.ui.theme.ClerkMaterialTheme
+import com.clerk.ui.theme.MergedElementTheme
 
 @Immutable
 internal data class ButtonStyleTokens(
@@ -26,11 +27,12 @@ internal data class ButtonStyleTokens(
 internal fun buildButtonTokens(
   config: ClerkButtonConfiguration,
   isPressed: Boolean,
+  theme: MergedElementTheme,
 ): ButtonStyleTokens {
   val text =
     when (config.size) {
-      ClerkButtonConfiguration.Size.Small -> ClerkMaterialTheme.typography.titleSmall
-      ClerkButtonConfiguration.Size.Large -> ClerkMaterialTheme.typography.titleMedium
+      ClerkButtonConfiguration.Size.Small -> theme.typography.titleSmall
+      ClerkButtonConfiguration.Size.Large -> theme.typography.titleMedium
     }
 
   val height =
@@ -57,11 +59,11 @@ internal fun buildButtonTokens(
     when (config.emphasis) {
       ClerkButtonConfiguration.Emphasis.None -> Color.Transparent
       ClerkButtonConfiguration.Emphasis.Low,
-      ClerkButtonConfiguration.Emphasis.High -> ClerkMaterialTheme.computedColors.buttonBorder
+      ClerkButtonConfiguration.Emphasis.High -> theme.computedColors.buttonBorder
     }
 
-  val foreground = generateForeground(config, isPressed)
-  val background = config.backgroundColorOverride ?: generateBackground(config, isPressed)
+  val foreground = generateForeground(config, isPressed, theme)
+  val background = config.backgroundColorOverride ?: generateBackground(config, isPressed, theme)
 
   return ButtonStyleTokens(
     textStyle = text,
@@ -75,43 +77,43 @@ internal fun buildButtonTokens(
 }
 
 @Composable
-private fun generateForeground(config: ClerkButtonConfiguration, isPressed: Boolean): Color =
+private fun generateForeground(config: ClerkButtonConfiguration, isPressed: Boolean, theme: MergedElementTheme): Color =
   when (config.style) {
     ClerkButtonConfiguration.ButtonStyle.Primary ->
       when (config.emphasis) {
-        ClerkButtonConfiguration.Emphasis.High -> ClerkMaterialTheme.colors.primaryForeground
+        ClerkButtonConfiguration.Emphasis.High -> theme.colors.primaryForeground
         ClerkButtonConfiguration.Emphasis.Low,
-        ClerkButtonConfiguration.Emphasis.None -> ClerkMaterialTheme.colors.primary
+        ClerkButtonConfiguration.Emphasis.None -> theme.colors.primary
       }
 
     ClerkButtonConfiguration.ButtonStyle.Secondary ->
       when (config.emphasis) {
         ClerkButtonConfiguration.Emphasis.None ->
-          if (isPressed) ClerkMaterialTheme.colors.foreground
-          else ClerkMaterialTheme.colors.mutedForeground
+          if (isPressed) theme.colors.foreground
+          else theme.colors.mutedForeground
         ClerkButtonConfiguration.Emphasis.Low,
-        ClerkButtonConfiguration.Emphasis.High -> ClerkMaterialTheme.colors.foreground
+        ClerkButtonConfiguration.Emphasis.High -> theme.colors.foreground
       }
 
     ClerkButtonConfiguration.ButtonStyle.Negative ->
       when (config.emphasis) {
-        ClerkButtonConfiguration.Emphasis.High -> ClerkMaterialTheme.colors.primaryForeground
+        ClerkButtonConfiguration.Emphasis.High -> theme.colors.primaryForeground
         ClerkButtonConfiguration.Emphasis.Low,
-        ClerkButtonConfiguration.Emphasis.None -> ClerkMaterialTheme.colors.danger
+        ClerkButtonConfiguration.Emphasis.None -> theme.colors.danger
       }
   }
 
 @Composable
-private fun generateBackground(config: ClerkButtonConfiguration, isPressed: Boolean): Color =
+private fun generateBackground(config: ClerkButtonConfiguration, isPressed: Boolean, theme: MergedElementTheme): Color =
   when (config.style) {
     ClerkButtonConfiguration.ButtonStyle.Primary ->
       when (config.emphasis) {
         ClerkButtonConfiguration.Emphasis.High ->
-          if (isPressed) ClerkMaterialTheme.computedColors.primaryPressed
-          else ClerkMaterialTheme.colors.primary
+          if (isPressed) theme.computedColors.primaryPressed
+          else theme.colors.primary
         ClerkButtonConfiguration.Emphasis.Low,
         ClerkButtonConfiguration.Emphasis.None ->
-          if (isPressed) ClerkMaterialTheme.colors.muted else ClerkMaterialTheme.colors.background
+          if (isPressed) theme.colors.muted else theme.colors.background
       }
 
     ClerkButtonConfiguration.ButtonStyle.Secondary ->
@@ -119,17 +121,17 @@ private fun generateBackground(config: ClerkButtonConfiguration, isPressed: Bool
         ClerkButtonConfiguration.Emphasis.None,
         ClerkButtonConfiguration.Emphasis.Low,
         ClerkButtonConfiguration.Emphasis.High ->
-          if (isPressed) ClerkMaterialTheme.colors.muted else ClerkMaterialTheme.colors.background
+          if (isPressed) theme.colors.muted else theme.colors.background
       }
 
     ClerkButtonConfiguration.ButtonStyle.Negative ->
       when (config.emphasis) {
         ClerkButtonConfiguration.Emphasis.High ->
-          if (isPressed) ClerkMaterialTheme.computedColors.backgroundDanger
-          else ClerkMaterialTheme.colors.danger
+          if (isPressed) theme.computedColors.backgroundDanger
+          else theme.colors.danger
         ClerkButtonConfiguration.Emphasis.Low,
         ClerkButtonConfiguration.Emphasis.None ->
-          if (isPressed) ClerkMaterialTheme.computedColors.backgroundDanger
-          else ClerkMaterialTheme.colors.background
+          if (isPressed) theme.computedColors.backgroundDanger
+          else theme.colors.background
       }
   }

--- a/source/ui/src/main/java/com/clerk/ui/core/button/standard/ClerkButton.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/button/standard/ClerkButton.kt
@@ -41,8 +41,10 @@ import com.clerk.ui.core.dimens.dp12
 import com.clerk.ui.core.dimens.dp2
 import com.clerk.ui.core.dimens.dp24
 import com.clerk.ui.core.dimens.dp6
+import com.clerk.ui.theme.ClerkElementTheme
 import com.clerk.ui.theme.ClerkMaterialTheme
 import com.clerk.ui.theme.DefaultColors
+import com.clerk.ui.theme.mergeElementTheme
 
 /**
  * A custom button component styled according to Clerk's design system.
@@ -80,6 +82,7 @@ fun ClerkButton(
   paddingValues: PaddingValues = PaddingValues(),
   configuration: ClerkButtonConfiguration = ClerkButtonDefaults.configuration(),
   icons: ClerkButtonIcons = ClerkButtonDefaults.icons(),
+  elementTheme: ClerkElementTheme? = null,
 ) {
   val interactionSource = remember { MutableInteractionSource() }
   val pressed by interactionSource.collectIsPressedAsState()
@@ -93,6 +96,7 @@ fun ClerkButton(
     interactionSource = interactionSource,
     paddingValues = paddingValues,
     icons = icons,
+    elementTheme = elementTheme,
   )
 }
 
@@ -115,6 +119,7 @@ internal fun ClerkButtonWithPressedState(
   paddingValues: PaddingValues = PaddingValues(),
   configuration: ClerkButtonConfiguration = ClerkButtonDefaults.configuration(),
   icons: ClerkButtonIcons = ClerkButtonDefaults.icons(),
+  elementTheme: ClerkElementTheme? = null,
 ) {
   val interactionSource = remember { MutableInteractionSource() }
   val pressed by interactionSource.collectIsPressedAsState()
@@ -132,6 +137,7 @@ internal fun ClerkButtonWithPressedState(
     configuration = configuration,
     icons = icons,
     paddingValues = paddingValues,
+    elementTheme = elementTheme,
   )
 }
 
@@ -162,10 +168,16 @@ private fun ClerkButtonImpl(
   interactionSource: MutableInteractionSource,
   modifier: Modifier = Modifier,
   icons: ClerkButtonIcons = ClerkButtonDefaults.icons(),
+  elementTheme: ClerkElementTheme? = null,
 ) {
   ClerkMaterialTheme {
+    val mergedTheme = mergeElementTheme(elementTheme)
     val tokens =
-      buildButtonTokens(config = configuration, isPressed = clerkButtonState.isPressedCombined)
+      buildButtonTokens(
+        config = configuration,
+        isPressed = clerkButtonState.isPressedCombined,
+        theme = mergedTheme,
+      )
 
     val surfaceModifier =
       Modifier.height(tokens.height)
@@ -176,19 +188,19 @@ private fun ClerkButtonImpl(
           ) {
             mod.shadow(
               elevation = dp1,
-              spotColor = ClerkMaterialTheme.colors.shadow,
-              ambientColor = ClerkMaterialTheme.colors.shadow,
-              shape = ClerkMaterialTheme.shape,
+              spotColor = mergedTheme.colors.shadow,
+              ambientColor = mergedTheme.colors.shadow,
+              shape = androidx.compose.foundation.shape.RoundedCornerShape(mergedTheme.design.borderRadius),
             )
           } else {
             mod
           }
         }
-        .clip(ClerkMaterialTheme.shape)
+        .clip(androidx.compose.foundation.shape.RoundedCornerShape(mergedTheme.design.borderRadius))
 
     Button(
       modifier = surfaceModifier,
-      shape = ClerkMaterialTheme.shape,
+      shape = androidx.compose.foundation.shape.RoundedCornerShape(mergedTheme.design.borderRadius),
       enabled = clerkButtonState.isEnabled,
       interactionSource = interactionSource,
       contentPadding = paddingValues,
@@ -208,6 +220,7 @@ private fun ClerkButtonImpl(
         tokens = tokens,
         size = configuration.size,
         paddingValues = paddingValues,
+        theme = mergedTheme,
       )
     }
   }
@@ -240,6 +253,7 @@ private fun ButtonContent(
   size: ClerkButtonConfiguration.Size,
   paddingValues: PaddingValues,
   tokens: ButtonStyleTokens,
+  theme: com.clerk.ui.theme.MergedElementTheme,
 ) {
   if (isLoading) {
     Box(
@@ -259,7 +273,7 @@ private fun ButtonContent(
     ) {
       val iconSize = if (size == ClerkButtonConfiguration.Size.Small) dp12 else dp24
       icons.leadingIcon?.let {
-        val iconColor = icons.leadingIconColor ?: ClerkMaterialTheme.colors.primaryForeground
+        val iconColor = icons.leadingIconColor ?: theme.colors.primaryForeground
         Icon(
           modifier = Modifier.size(iconSize),
           painter = painterResource(it),
@@ -277,7 +291,7 @@ private fun ButtonContent(
         )
       }
       icons.trailingIcon?.let {
-        val iconColor = icons.trailingIconColor ?: ClerkMaterialTheme.colors.primaryForeground
+        val iconColor = icons.trailingIconColor ?: theme.colors.primaryForeground
         Icon(
           painter = painterResource(it),
           contentDescription = null,

--- a/source/ui/src/main/java/com/clerk/ui/core/button/standard/ClerkTextButton.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/button/standard/ClerkTextButton.kt
@@ -18,8 +18,10 @@ import com.clerk.api.Clerk
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.core.dimens.dp6
 import com.clerk.ui.core.dimens.dp8
+import com.clerk.ui.theme.ClerkElementTheme
 import com.clerk.ui.theme.ClerkMaterialTheme
 import com.clerk.ui.theme.DefaultColors
+import com.clerk.ui.theme.mergeElementTheme
 
 /**
  * A simple composable that displays a clickable text.
@@ -32,26 +34,32 @@ import com.clerk.ui.theme.DefaultColors
  * @param textColor The color of the text. Defaults to the primary color from [ClerkMaterialTheme].
  * @param textStyle The style of the text. Defaults to `titleSmall` typography from
  *   [ClerkMaterialTheme].
+ * @param elementTheme Optional theme override for this element.
  * @param onClick Lambda to be invoked when the button is clicked.
  */
 @Composable
 fun ClerkTextButton(
   text: String,
   modifier: Modifier = Modifier,
-  textColor: Color = ClerkMaterialTheme.colors.primary,
-  textStyle: TextStyle = ClerkMaterialTheme.typography.titleSmall,
+  textColor: Color? = null,
+  textStyle: TextStyle? = null,
   boundedRipple: Boolean = true,
   rippleColor: Color = Color.Unspecified, // Unspecified -> uses LocalContentColor
+  elementTheme: ClerkElementTheme? = null,
   onClick: () -> Unit,
 ) {
   val interaction = remember { MutableInteractionSource() }
 
   ClerkMaterialTheme {
+    val mergedTheme = mergeElementTheme(elementTheme)
+    val finalTextColor = textColor ?: mergedTheme.colors.primary
+    val finalTextStyle = textStyle ?: mergedTheme.typography.titleSmall
+    
     Box(
       modifier =
         modifier
           .padding(horizontal = dp8)
-          .clip(ClerkMaterialTheme.shape) // masks ripple to this shape
+          .clip(androidx.compose.foundation.shape.RoundedCornerShape(mergedTheme.design.borderRadius)) // masks ripple to this shape
           .clickable(
             interactionSource = interaction,
             indication = ripple(bounded = boundedRipple, color = rippleColor),
@@ -60,7 +68,7 @@ fun ClerkTextButton(
           )
           .padding(horizontal = dp8, vertical = dp6)
     ) {
-      Text(text = text, color = textColor, style = textStyle)
+      Text(text = text, color = finalTextColor, style = finalTextStyle)
     }
   }
 }

--- a/source/ui/src/main/java/com/clerk/ui/core/divider/TextDivider.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/divider/TextDivider.kt
@@ -14,7 +14,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.clerk.ui.core.dimens.dp1
 import com.clerk.ui.core.dimens.dp16
+import com.clerk.ui.theme.ClerkElementTheme
 import com.clerk.ui.theme.ClerkMaterialTheme
+import com.clerk.ui.theme.mergeElementTheme
 
 /**
  * A composable that displays a horizontal divider with text in the middle.
@@ -24,10 +26,16 @@ import com.clerk.ui.theme.ClerkMaterialTheme
  *
  * @param text The text to display in the middle of the divider.
  * @param modifier The [Modifier] to be applied to the divider row.
+ * @param elementTheme Optional theme override for this element.
  */
 @Composable
-fun TextDivider(text: String, modifier: Modifier = Modifier) {
+fun TextDivider(
+  text: String,
+  modifier: Modifier = Modifier,
+  elementTheme: ClerkElementTheme? = null,
+) {
   ClerkMaterialTheme {
+    val mergedTheme = mergeElementTheme(elementTheme)
     Row(
       modifier = Modifier.fillMaxWidth().then(modifier),
       horizontalArrangement = Arrangement.spacedBy(dp16, alignment = Alignment.CenterHorizontally),
@@ -36,17 +44,17 @@ fun TextDivider(text: String, modifier: Modifier = Modifier) {
       HorizontalDivider(
         modifier = Modifier.weight(1f),
         thickness = dp1,
-        color = ClerkMaterialTheme.computedColors.border,
+        color = mergedTheme.computedColors.border,
       )
       Text(
         text = text,
-        style = ClerkMaterialTheme.typography.bodyMedium,
-        color = ClerkMaterialTheme.colors.mutedForeground,
+        style = mergedTheme.typography.bodyMedium,
+        color = mergedTheme.colors.mutedForeground,
       )
       HorizontalDivider(
         modifier = Modifier.weight(1f),
         thickness = dp1,
-        color = ClerkMaterialTheme.computedColors.border,
+        color = mergedTheme.computedColors.border,
       )
     }
   }

--- a/source/ui/src/main/java/com/clerk/ui/core/header/HeaderTextView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/header/HeaderTextView.kt
@@ -12,22 +12,30 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.sp
 import com.clerk.ui.core.dimens.dp8
 import com.clerk.ui.core.extensions.withMediumWeight
+import com.clerk.ui.theme.ClerkElementTheme
 import com.clerk.ui.theme.ClerkMaterialTheme
+import com.clerk.ui.theme.mergeElementTheme
 
 @Composable
-internal fun HeaderTextView(text: String, type: HeaderType, modifier: Modifier = Modifier) {
-  val (style, color) =
-    when (type) {
-      HeaderType.Title ->
-        ClerkMaterialTheme.typography.titleMedium
-          .withMediumWeight()
-          .copy(fontSize = 22.sp, lineHeight = 28.sp, letterSpacing = 0.sp) to
-          ClerkMaterialTheme.colors.foreground
-      HeaderType.Subtitle ->
-        ClerkMaterialTheme.typography.bodyLarge to ClerkMaterialTheme.colors.mutedForeground
-    }
-
+internal fun HeaderTextView(
+  text: String,
+  type: HeaderType,
+  modifier: Modifier = Modifier,
+  elementTheme: ClerkElementTheme? = null,
+) {
   ClerkMaterialTheme {
+    val mergedTheme = mergeElementTheme(elementTheme)
+    val (style, color) =
+      when (type) {
+        HeaderType.Title ->
+          mergedTheme.typography.titleMedium
+            .withMediumWeight()
+            .copy(fontSize = 22.sp, lineHeight = 28.sp, letterSpacing = 0.sp) to
+            mergedTheme.colors.foreground
+        HeaderType.Subtitle ->
+          mergedTheme.typography.bodyLarge to mergedTheme.colors.mutedForeground
+      }
+
     Text(
       text = text,
       style = style,

--- a/source/ui/src/main/java/com/clerk/ui/core/input/ClerkTextField.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/input/ClerkTextField.kt
@@ -38,7 +38,9 @@ import com.clerk.ui.core.dimens.dp12
 import com.clerk.ui.core.dimens.dp20
 import com.clerk.ui.core.dimens.dp24
 import com.clerk.ui.core.dimens.dp4
+import com.clerk.ui.theme.ClerkElementTheme
 import com.clerk.ui.theme.ClerkMaterialTheme
+import com.clerk.ui.theme.mergeElementTheme
 
 /**
  * A customizable text input field component following Clerk's design system.
@@ -76,6 +78,7 @@ fun ClerkTextField(
   inputContentType: ContentType = ContentType.Username,
   visualTransformation: VisualTransformation = VisualTransformation.None,
   keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+  elementTheme: ClerkElementTheme? = null,
 ) {
   var isVisible by remember {
     mutableStateOf(visualTransformation !is PasswordVisualTransformation)
@@ -85,19 +88,20 @@ fun ClerkTextField(
 
   LaunchedEffect(isFocused) { onFocusChange(isFocused) }
 
-  val textFieldColors = getTextFieldColors()
-
-  val labelStyle =
-    if (isFocused || value.isNotEmpty()) ClerkMaterialTheme.typography.bodySmall
-    else MaterialTheme.typography.bodyLarge
-  val labelColor =
-    when {
-      isError -> ClerkMaterialTheme.colors.danger
-      isFocused -> ClerkMaterialTheme.colors.primary
-      else -> ClerkMaterialTheme.colors.mutedForeground
-    }
-
   ClerkMaterialTheme {
+    val mergedTheme = mergeElementTheme(elementTheme)
+    val textFieldColors = getTextFieldColors(mergedTheme)
+
+    val labelStyle =
+      if (isFocused || value.isNotEmpty()) mergedTheme.typography.bodySmall
+      else MaterialTheme.typography.bodyLarge
+    val labelColor =
+      when {
+        isError -> mergedTheme.colors.danger
+        isFocused -> mergedTheme.colors.primary
+        else -> mergedTheme.colors.mutedForeground
+      }
+
     OutlinedTextField(
       interactionSource = interactionSource,
       modifier = modifier.fillMaxWidth().semantics { contentType = inputContentType },
@@ -106,7 +110,7 @@ fun ClerkTextField(
       keyboardOptions = keyboardOptions,
       maxLines = maxLines,
       enabled = enabled,
-      shape = ClerkMaterialTheme.shape,
+      shape = androidx.compose.foundation.shape.RoundedCornerShape(mergedTheme.design.borderRadius),
       isError = isError,
       colors = textFieldColors,
       visualTransformation =
@@ -117,7 +121,7 @@ fun ClerkTextField(
         },
       leadingIcon =
         leadingIcon?.let { resId ->
-          { ClickableIcon(resId = resId, onClick = {}, contentDescription = null) }
+          { ClickableIcon(resId = resId, onClick = {}, contentDescription = null, tint = mergedTheme.colors.mutedForeground) }
         },
       trailingIcon = {
         TrailingIcon(
@@ -129,21 +133,22 @@ fun ClerkTextField(
               isVisible = !isVisible
             }
           },
+          theme = mergedTheme,
         )
       },
       placeholder = placeholder?.let { ph -> { Text(ph) } },
       label = label?.let { text -> { Text(text = text, style = labelStyle, color = labelColor) } },
-      textStyle = ClerkMaterialTheme.typography.bodyLarge,
+      textStyle = mergedTheme.typography.bodyLarge,
       supportingText =
         supportingText?.let { support ->
           {
             Text(
               modifier = Modifier.padding(top = dp4),
               text = support,
-              style = ClerkMaterialTheme.typography.bodySmall,
+              style = mergedTheme.typography.bodySmall,
               color =
-                if (isError) ClerkMaterialTheme.colors.danger
-                else ClerkMaterialTheme.colors.mutedForeground,
+                if (isError) mergedTheme.colors.danger
+                else mergedTheme.colors.mutedForeground,
             )
           }
         },
@@ -157,6 +162,7 @@ private fun TrailingIcon(
   isError: Boolean,
   visualTransformation: VisualTransformation,
   onClick: () -> Unit,
+  theme: com.clerk.ui.theme.MergedElementTheme,
 ) {
 
   if (trailingIcon != null || isError || visualTransformation is PasswordVisualTransformation) {
@@ -167,22 +173,22 @@ private fun TrailingIcon(
         else -> trailingIcon!!
       }
     val tint =
-      if (isError) ClerkMaterialTheme.colors.danger else ClerkMaterialTheme.colors.mutedForeground
+      if (isError) theme.colors.danger else theme.colors.mutedForeground
     ClickableIcon(resId = resId, onClick = onClick, tint = tint, contentDescription = null)
   }
 }
 
 @Composable
-private fun getTextFieldColors(): TextFieldColors =
+private fun getTextFieldColors(theme: com.clerk.ui.theme.MergedElementTheme): TextFieldColors =
   OutlinedTextFieldDefaults.colors(
-    focusedBorderColor = ClerkMaterialTheme.colors.primary,
-    focusedLabelColor = ClerkMaterialTheme.colors.primary,
-    unfocusedBorderColor = ClerkMaterialTheme.computedColors.inputBorder,
-    unfocusedTextColor = ClerkMaterialTheme.colors.foreground,
-    unfocusedContainerColor = ClerkMaterialTheme.colors.background,
-    focusedContainerColor = ClerkMaterialTheme.colors.background,
-    errorBorderColor = ClerkMaterialTheme.colors.danger,
-    errorSupportingTextColor = ClerkMaterialTheme.colors.danger,
+    focusedBorderColor = theme.colors.primary,
+    focusedLabelColor = theme.colors.primary,
+    unfocusedBorderColor = theme.computedColors.inputBorder,
+    unfocusedTextColor = theme.colors.foreground,
+    unfocusedContainerColor = theme.colors.background,
+    focusedContainerColor = theme.colors.background,
+    errorBorderColor = theme.colors.danger,
+    errorSupportingTextColor = theme.colors.danger,
   )
 
 /**
@@ -197,7 +203,7 @@ private fun getTextFieldColors(): TextFieldColors =
 private fun ClickableIcon(
   @DrawableRes resId: Int,
   onClick: () -> Unit,
-  tint: androidx.compose.ui.graphics.Color = ClerkMaterialTheme.colors.mutedForeground,
+  tint: androidx.compose.ui.graphics.Color,
   contentDescription: String? = null,
 ) {
   Icon(

--- a/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedAuthScaffold.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedAuthScaffold.kt
@@ -31,7 +31,9 @@ import com.clerk.ui.core.header.HeaderTextView
 import com.clerk.ui.core.header.HeaderType
 import com.clerk.ui.core.input.ClerkTextField
 import com.clerk.ui.core.spacers.Spacers
+import com.clerk.ui.theme.ClerkElementTheme
 import com.clerk.ui.theme.ClerkMaterialTheme
+import com.clerk.ui.theme.mergeElementTheme
 
 @Composable
 internal fun ClerkThemedAuthScaffold(
@@ -45,15 +47,17 @@ internal fun ClerkThemedAuthScaffold(
   identifier: String? = null,
   onClickIdentifier: () -> Unit = {},
   spacingAfterIdentifier: Dp = dp32,
+  elementTheme: ClerkElementTheme? = null,
   content: @Composable () -> Unit,
 ) {
   ClerkMaterialTheme {
+    val mergedTheme = mergeElementTheme(elementTheme)
     Scaffold(
       modifier = Modifier.then(modifier),
       snackbarHost = { ClerkErrorSnackbar(snackbarHostState) },
       topBar = {
         ClerkTopAppBar(
-          backgroundColor = ClerkMaterialTheme.colors.background,
+          backgroundColor = mergedTheme.colors.background,
           onBackPressed = onBackPressed,
           hasLogo = hasLogo,
           hasBackButton = hasBackButton,
@@ -65,13 +69,13 @@ internal fun ClerkThemedAuthScaffold(
           Modifier.fillMaxWidth()
             .padding(innerPadding)
             .padding(horizontal = dp18)
-            .background(ClerkMaterialTheme.colors.background),
+            .background(mergedTheme.colors.background),
         horizontalAlignment = Alignment.CenterHorizontally,
       ) {
-        HeaderTextView(text = title, type = HeaderType.Title)
+        HeaderTextView(text = title, type = HeaderType.Title, elementTheme = elementTheme)
         subtitle?.let {
           Spacers.Vertical.Spacer8()
-          HeaderTextView(text = it, type = HeaderType.Subtitle)
+          HeaderTextView(text = it, type = HeaderType.Subtitle, elementTheme = elementTheme)
         }
         identifier?.let {
           Spacers.Vertical.Spacer8()
@@ -89,8 +93,9 @@ internal fun ClerkThemedAuthScaffold(
             icons =
               ClerkButtonDefaults.icons(
                 trailingIcon = R.drawable.ic_edit,
-                trailingIconColor = ClerkMaterialTheme.colors.mutedForeground,
+                trailingIconColor = mergedTheme.colors.mutedForeground,
               ),
+            elementTheme = elementTheme,
           )
         }
         Spacer(modifier = Modifier.height(spacingAfterIdentifier))

--- a/source/ui/src/main/java/com/clerk/ui/theme/ClerkElementTheme.kt
+++ b/source/ui/src/main/java/com/clerk/ui/theme/ClerkElementTheme.kt
@@ -1,0 +1,253 @@
+package com.clerk.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import com.clerk.api.ui.ClerkColors
+import com.clerk.api.ui.ClerkDesign
+import com.clerk.ui.theme.colors.ComputedColors
+
+/**
+ * A theme override that can be applied to individual UI elements.
+ *
+ * This allows you to customize the appearance of specific components without affecting the global
+ * theme. Any properties set to `null` will inherit from the current [ClerkMaterialTheme].
+ *
+ * Example usage:
+ * ```kotlin
+ * ClerkButton(
+ *   text = "Custom Button",
+ *   onClick = {},
+ *   elementTheme = ClerkElementTheme(
+ *     colors = ClerkElementColors(primary = Color.Red)
+ *   )
+ * )
+ * ```
+ */
+@Immutable
+data class ClerkElementTheme(
+  /**
+   * Optional color overrides for this element. Only non-null values will override the theme.
+   */
+  val colors: ClerkElementColors? = null,
+
+  /**
+   * Optional typography overrides for this element. Only non-null values will override the theme.
+   */
+  val typography: ClerkElementTypography? = null,
+
+  /**
+   * Optional design token overrides for this element. Only non-null values will override the theme.
+   */
+  val design: ClerkElementDesign? = null,
+
+  /**
+   * Optional computed color overrides for this element. Only non-null values will override the theme.
+   */
+  val computedColors: ClerkElementComputedColors? = null,
+)
+
+/**
+ * Partial color overrides for an element theme.
+ *
+ * All properties are optional. Only non-null values will override the current theme.
+ */
+@Immutable
+data class ClerkElementColors(
+  val primary: Color? = null,
+  val background: Color? = null,
+  val input: Color? = null,
+  val danger: Color? = null,
+  val success: Color? = null,
+  val warning: Color? = null,
+  val foreground: Color? = null,
+  val mutedForeground: Color? = null,
+  val primaryForeground: Color? = null,
+  val inputForeground: Color? = null,
+  val neutral: Color? = null,
+  val border: Color? = null,
+  val ring: Color? = null,
+  val muted: Color? = null,
+  val shadow: Color? = null,
+)
+
+/**
+ * Partial typography overrides for an element theme.
+ *
+ * All properties are optional. Only non-null values will override the current theme.
+ */
+@Immutable
+data class ClerkElementTypography(
+  val displayLarge: TextStyle? = null,
+  val displayMedium: TextStyle? = null,
+  val displaySmall: TextStyle? = null,
+  val headlineLarge: TextStyle? = null,
+  val headlineMedium: TextStyle? = null,
+  val headlineSmall: TextStyle? = null,
+  val titleLarge: TextStyle? = null,
+  val titleMedium: TextStyle? = null,
+  val titleSmall: TextStyle? = null,
+  val bodyLarge: TextStyle? = null,
+  val bodyMedium: TextStyle? = null,
+  val bodySmall: TextStyle? = null,
+  val labelLarge: TextStyle? = null,
+  val labelMedium: TextStyle? = null,
+  val labelSmall: TextStyle? = null,
+)
+
+/**
+ * Partial design token overrides for an element theme.
+ *
+ * All properties are optional. Only non-null values will override the current theme.
+ */
+@Immutable
+data class ClerkElementDesign(
+  val borderRadius: Dp? = null,
+)
+
+/**
+ * Partial computed color overrides for an element theme.
+ *
+ * All properties are optional. Only non-null values will override the current theme.
+ */
+@Immutable
+data class ClerkElementComputedColors(
+  val primaryPressed: Color? = null,
+  val border: Color? = null,
+  val buttonBorder: Color? = null,
+  val inputBorder: Color? = null,
+  val inputBorderFocused: Color? = null,
+  val dangerInputBorder: Color? = null,
+  val dangerInputBorderFocused: Color? = null,
+  val backgroundTransparent: Color? = null,
+  val backgroundSuccess: Color? = null,
+  val borderSuccess: Color? = null,
+  val backgroundDanger: Color? = null,
+  val borderDanger: Color? = null,
+  val backgroundWarning: Color? = null,
+  val borderWarning: Color? = null,
+)
+
+/**
+ * Merges an element theme with the current ClerkMaterialTheme, returning merged theme values.
+ *
+ * This function takes the current theme values and applies any non-null overrides from the element
+ * theme, creating a merged theme that can be used within a component.
+ *
+ * @param elementTheme The element theme containing optional overrides, or null to use the current theme.
+ * @return A [MergedElementTheme] containing the merged theme values.
+ */
+@Composable
+internal fun mergeElementTheme(elementTheme: ClerkElementTheme?): MergedElementTheme {
+  if (elementTheme == null) {
+    return MergedElementTheme(
+      colors = ClerkMaterialTheme.colors,
+      typography = ClerkMaterialTheme.typography,
+      design = ClerkMaterialTheme.design,
+      computedColors = ClerkMaterialTheme.computedColors,
+    )
+  }
+
+  val baseColors = ClerkMaterialTheme.colors
+  val elementColors = elementTheme.colors
+  val mergedColors =
+    ClerkThemeColors(
+      ClerkColors(
+        primary = elementColors?.primary ?: baseColors.primary,
+        background = elementColors?.background ?: baseColors.background,
+        input = elementColors?.input ?: baseColors.input,
+        danger = elementColors?.danger ?: baseColors.danger,
+        success = elementColors?.success ?: baseColors.success,
+        warning = elementColors?.warning ?: baseColors.warning,
+        foreground = elementColors?.foreground ?: baseColors.foreground,
+        mutedForeground = elementColors?.mutedForeground ?: baseColors.mutedForeground,
+        primaryForeground = elementColors?.primaryForeground ?: baseColors.primaryForeground,
+        inputForeground = elementColors?.inputForeground ?: baseColors.inputForeground,
+        neutral = elementColors?.neutral ?: baseColors.neutral,
+        border = elementColors?.border ?: baseColors.border,
+        ring = elementColors?.ring ?: baseColors.ring,
+        muted = elementColors?.muted ?: baseColors.muted,
+        shadow = elementColors?.shadow ?: baseColors.shadow,
+      ),
+    )
+
+  val baseTypography = ClerkMaterialTheme.typography
+  val elementTypography = elementTheme.typography
+  val mergedTypography =
+    Typography(
+      displayLarge = elementTypography?.displayLarge ?: baseTypography.displayLarge,
+      displayMedium = elementTypography?.displayMedium ?: baseTypography.displayMedium,
+      displaySmall = elementTypography?.displaySmall ?: baseTypography.displaySmall,
+      headlineLarge = elementTypography?.headlineLarge ?: baseTypography.headlineLarge,
+      headlineMedium = elementTypography?.headlineMedium ?: baseTypography.headlineMedium,
+      headlineSmall = elementTypography?.headlineSmall ?: baseTypography.headlineSmall,
+      titleLarge = elementTypography?.titleLarge ?: baseTypography.titleLarge,
+      titleMedium = elementTypography?.titleMedium ?: baseTypography.titleMedium,
+      titleSmall = elementTypography?.titleSmall ?: baseTypography.titleSmall,
+      bodyLarge = elementTypography?.bodyLarge ?: baseTypography.bodyLarge,
+      bodyMedium = elementTypography?.bodyMedium ?: baseTypography.bodyMedium,
+      bodySmall = elementTypography?.bodySmall ?: baseTypography.bodySmall,
+      labelLarge = elementTypography?.labelLarge ?: baseTypography.labelLarge,
+      labelMedium = elementTypography?.labelMedium ?: baseTypography.labelMedium,
+      labelSmall = elementTypography?.labelSmall ?: baseTypography.labelSmall,
+    )
+
+  val baseDesign = ClerkMaterialTheme.design
+  val elementDesign = elementTheme.design
+  val mergedDesign =
+    ClerkDesign(
+      borderRadius = elementDesign?.borderRadius ?: baseDesign.borderRadius,
+    )
+
+  val baseComputedColors = ClerkMaterialTheme.computedColors
+  val elementComputedColors = elementTheme.computedColors
+  val mergedComputedColors =
+    ComputedColors(
+      primaryPressed = elementComputedColors?.primaryPressed ?: baseComputedColors.primaryPressed,
+      border = elementComputedColors?.border ?: baseComputedColors.border,
+      buttonBorder = elementComputedColors?.buttonBorder ?: baseComputedColors.buttonBorder,
+      inputBorder = elementComputedColors?.inputBorder ?: baseComputedColors.inputBorder,
+      inputBorderFocused =
+        elementComputedColors?.inputBorderFocused ?: baseComputedColors.inputBorderFocused,
+      dangerInputBorder =
+        elementComputedColors?.dangerInputBorder ?: baseComputedColors.dangerInputBorder,
+      dangerInputBorderFocused =
+        elementComputedColors?.dangerInputBorderFocused
+          ?: baseComputedColors.dangerInputBorderFocused,
+      backgroundTransparent =
+        elementComputedColors?.backgroundTransparent ?: baseComputedColors.backgroundTransparent,
+      backgroundSuccess =
+        elementComputedColors?.backgroundSuccess ?: baseComputedColors.backgroundSuccess,
+      borderSuccess = elementComputedColors?.borderSuccess ?: baseComputedColors.borderSuccess,
+      backgroundDanger =
+        elementComputedColors?.backgroundDanger ?: baseComputedColors.backgroundDanger,
+      borderDanger = elementComputedColors?.borderDanger ?: baseComputedColors.borderDanger,
+      backgroundWarning =
+        elementComputedColors?.backgroundWarning ?: baseComputedColors.backgroundWarning,
+      borderWarning = elementComputedColors?.borderWarning ?: baseComputedColors.borderWarning,
+    )
+
+  return MergedElementTheme(
+    colors = mergedColors,
+    typography = mergedTypography,
+    design = mergedDesign,
+    computedColors = mergedComputedColors,
+  )
+}
+
+/**
+ * Internal data class holding merged theme values for an element.
+ *
+ * This is used internally by components to access theme values that have been merged with element
+ * theme overrides.
+ */
+@Immutable
+internal data class MergedElementTheme(
+  val colors: ClerkThemeColors,
+  val typography: Typography,
+  val design: ClerkDesign,
+  val computedColors: ComputedColors,
+)


### PR DESCRIPTION
## Summary of changes

Introduced a per-element theming system, allowing individual UI components to override specific theme properties (colors, typography, design tokens) without affecting the global `ClerkMaterialTheme`.

This enables more granular customization by:
*   Defining `ClerkElementTheme` and related data classes for partial theme overrides.
*   Implementing a `mergeElementTheme` function to combine element-specific themes with the global theme.
*   Updating core UI components (e.g., `ClerkButton`, `ClerkTextField`, `AvatarView`, `Badge`) to accept an optional `elementTheme` parameter and apply the merged styling.

The implementation is backward compatible; components will continue to use the global theme if no `elementTheme` is provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-66680609-4b27-45fb-a058-60f8f9488e12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-66680609-4b27-45fb-a058-60f8f9488e12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

