### PR TITLE
update runners to use blacksmith

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest-xlarge
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest-xlarge
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -4,7 +4,7 @@ on: [ pull_request ]
 jobs:
   detekt:
     name: Check Code Quality
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Clone repo

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull') }}
 jobs:
   docs:
-    runs-on: macos-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - uses: actions/checkout@v6
       with:
@@ -58,7 +58,7 @@ jobs:
         path: Docs.zip
   publish:
     needs: [docs]
-    runs-on: macos-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-release:
-    runs-on: macos-latest-xlarge
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.event_name == 'workflow_dispatch'
     outputs:
       version: ${{ steps.get_version.outputs.version }}
@@ -109,7 +109,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
-    runs-on: macos-latest-xlarge
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: create-release
     if: always() && (github.event_name == 'release' || needs.create-release.result == 'success')
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   create-release:
-    runs-on: macos-latest-xlarge
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.event_name == 'workflow_dispatch'
     outputs:
       version: ${{ steps.set_version.outputs.version }}
@@ -141,7 +141,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
-    runs-on: macos-latest-xlarge
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: create-release
     if: always() && (github.event_name == 'release' || needs.create-release.result == 'success')
     


### PR DESCRIPTION
## Summary of changes
This pull request updates the GitHub Actions workflows to use the `blacksmith-4vcpu-ubuntu-2404` runner instead of the previous `macos-latest` or `ubuntu-latest` runners. This change standardizes the runner environment across all workflows, which can help improve consistency, resource allocation, and potentially reduce costs.

**Workflow runner updates:**

* Switched the runner in `.github/workflows/android-test.yml`, `.github/workflows/android.yml`, `.github/workflows/manual-release.yml`, and `.github/workflows/publish.yml` from `macos-latest-xlarge` to `blacksmith-4vcpu-ubuntu-2404` for both build and release jobs. [[1]](diffhunk://#diff-5c54e9f5f5c460ea41561e581fadedaa4a0ce51332fea1a072428d20f926a304L10-R10) [[2]](diffhunk://#diff-b46b6cdc887427355980140454172d7b5ff3dd1f68523667bdd4947358d927d8L9-R9) [[3]](diffhunk://#diff-15fb1f5c1e9076ac354d7b3c7a9e3d508e100c550bfbabd66ec943ea883bf0d9L10-R10) [[4]](diffhunk://#diff-15fb1f5c1e9076ac354d7b3c7a9e3d508e100c550bfbabd66ec943ea883bf0d9L112-R112) [[5]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L15-R15) [[6]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L144-R144)
* Changed the runner for code quality checks in `.github/workflows/detekt.yml` from `ubuntu-latest` to `blacksmith-4vcpu-ubuntu-2404`.
* Updated both the documentation build and publish jobs in `.github/workflows/docs.yml` to use `blacksmith-4vcpu-ubuntu-2404` instead of `macos-latest`. [[1]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL15-R15) [[2]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL61-R61)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions runner infrastructure across CI/CD pipelines to use optimized compute environments for improved build performance and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->