### PR TITLE
Add vercel as OAuth provider

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/sso/OAuthProvider.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/OAuthProvider.kt
@@ -14,7 +14,7 @@ import com.clerk.api.Clerk
  * The enum includes support for major OAuth providers such as:
  * - **Social platforms**: Facebook, Google, Twitter, Instagram, TikTok, Discord
  * - **Professional platforms**: LinkedIn, Microsoft, Slack
- * - **Developer platforms**: GitHub, GitLab, Bitbucket, Atlassian
+ * - **Developer platforms**: GitHub, GitLab, Bitbucket, Atlassian, Vercel
  * - **Business platforms**: HubSpot, Notion, Dropbox, Box, Xero
  * - **Entertainment platforms**: Spotify, Twitch
  * - **AI platforms**: Hugging Face
@@ -116,6 +116,9 @@ enum class OAuthProvider {
 
   /** Hugging Face OAuth authentication provider. */
   HUGGING_FACE,
+
+  /** Vercel OAuth authentication provider. */
+  VERCEL,
 
   /** Custom OAuth authentication provider for enterprise or specialized implementations. */
   CUSTOM,
@@ -235,6 +238,7 @@ enum class OAuthProvider {
             strategy = "oauth_huggingface",
             name = "Hugging Face",
           )
+        VERCEL -> OAuthProviderData(provider = "vercel", strategy = "oauth_vercel", name = "Vercel")
         CUSTOM -> OAuthProviderData(provider = "custom", strategy = "oauth_custom", name = "Custom")
         UNKNOWN ->
           OAuthProviderData(provider = "unknown", strategy = "oauth_unknown", name = "Unknown")


### PR DESCRIPTION
## Summary of changes
This pull request adds support for the Vercel OAuth provider to the `OAuthProvider` enum and its related documentation and logic. The main changes include updating the documentation, adding the new enum value, and handling Vercel in the provider data mapping.

**OAuth provider support:**

* Updated the documentation in `OAuthProvider.kt` to list Vercel as a supported developer platform.
* Added `VERCEL` as a new value in the `OAuthProvider` enum.
* Updated the `toProviderData()` method to handle the new `VERCEL` provider, returning the appropriate `OAuthProviderData`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vercel is now available as an OAuth authentication provider. Users can sign in using their Vercel accounts alongside other supported authentication methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->