### PR TITLE
Ios pr to android

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
@@ -182,6 +182,9 @@ data class SignIn(
     /** The sign-in process needs a second factor verification. */
     @SerialName("needs_second_factor") NEEDS_SECOND_FACTOR,
 
+    /** Client trust verification is required. */
+    @SerialName("needs_client_trust") NEEDS_CLIENT_TRUST,
+
     /** The sign-in process needs an identifier. */
     @SerialName("needs_identifier") NEEDS_IDENTIFIER,
 
@@ -800,6 +803,25 @@ suspend fun SignIn.prepareFirstFactor(
 }
 
 /**
+ * Prepares the second factor verification for the sign-in process using the provided explicit
+ * strategy.
+ *
+ * This overload is useful when the factor/strategy is already known (e.g. user selected a method,
+ * or client trust requires a specific verification strategy) and you want to avoid implicit
+ * selection logic.
+ *
+ * @param strategy The second factor strategy to prepare.
+ * @return A [ClerkResult] containing the updated [SignIn] object on success, or a
+ *   [ClerkErrorResponse] on failure.
+ */
+suspend fun SignIn.prepareSecondFactor(
+  strategy: SignIn.PrepareSecondFactorStrategy
+): ClerkResult<SignIn, ClerkErrorResponse> {
+  val params = strategy.toParams()
+  return ClerkApi.signIn.prepareSecondFactor(id = id, params = params.toMap())
+}
+
+/**
  * Prepares the second factor verification for the sign-in process.
  *
  * This function is used to initiate the second factor verification process, which is required for
@@ -837,8 +859,7 @@ suspend fun SignIn.prepareSecondFactor(
       else -> error("No supported second factor found")
     }
 
-  val params = strategy.toParams()
-  return ClerkApi.signIn.prepareSecondFactor(id = id, params = params.toMap())
+  return prepareSecondFactor(strategy)
 }
 
 /**

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
@@ -96,6 +96,11 @@ internal class AuthState(
           backStack.add(AuthDestination.SignInFactorTwo(factor = it))
         } ?: backStack.add(AuthDestination.SignInGetHelp)
       }
+      SignIn.Status.NEEDS_CLIENT_TRUST -> {
+        signIn.startingSecondFactor?.let {
+          backStack.add(AuthDestination.SignInClientTrust(factor = it))
+        } ?: backStack.add(AuthDestination.SignInGetHelp)
+      }
       SignIn.Status.NEEDS_NEW_PASSWORD -> backStack.add(AuthDestination.SignInSetNewPassword)
       SignIn.Status.UNKNOWN -> return
     }

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -23,6 +23,7 @@ import com.clerk.ui.core.composition.LocalTelemetryCollector
 import com.clerk.ui.signin.SignInFactorOneView
 import com.clerk.ui.signin.SignInFactorTwoView
 import com.clerk.ui.signin.alternativemethods.SignInFactorAlternativeMethodsView
+import com.clerk.ui.signin.clienttrust.SignInClientTrustView
 import com.clerk.ui.signin.help.SignInGetHelpView
 import com.clerk.ui.signin.password.forgot.SignInFactorOneForgotPasswordView
 import com.clerk.ui.signin.password.reset.SignInSetNewPasswordView
@@ -87,6 +88,9 @@ fun AuthView(modifier: Modifier = Modifier, clerkTheme: ClerkTheme? = null) {
                 onAuthComplete = { backStack.clear() },
               )
             }
+            entry<AuthDestination.SignInClientTrust> { key ->
+              SignInClientTrustView(factor = key.factor, onAuthComplete = { backStack.clear() })
+            }
             entry<AuthDestination.SignInForgotPassword> {
               SignInFactorOneForgotPasswordView(
                 onClickFactor = { backStack.removeLastOrNull() },
@@ -142,6 +146,8 @@ internal object AuthDestination {
   @Serializable data class SignInFactorTwo(val factor: Factor) : NavKey
 
   @Serializable data class SignInFactorTwoUseAnotherMethod(val currentFactor: Factor) : NavKey
+
+  @Serializable data class SignInClientTrust(val factor: Factor) : NavKey
 
   @Serializable data object SignInForgotPassword : NavKey
 

--- a/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorTwoView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorTwoView.kt
@@ -8,6 +8,7 @@ import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.auth.PreviewAuthStateProvider
 import com.clerk.ui.core.common.StrategyKeys
 import com.clerk.ui.signin.backupcode.SignInFactorTwoBackupCodeView
+import com.clerk.ui.signin.code.FactorMode
 import com.clerk.ui.signin.code.SignInFactorCodeView
 import com.clerk.ui.signin.help.SignInGetHelpView
 import com.clerk.ui.theme.ClerkThemeOverrideProvider
@@ -33,10 +34,11 @@ fun SignInFactorTwoView(
   ClerkThemeOverrideProvider(clerkTheme) {
     when (factor.strategy) {
       StrategyKeys.TOTP,
+      StrategyKeys.EMAIL_CODE,
       StrategyKeys.PHONE_CODE ->
         SignInFactorCodeView(
           factor = factor,
-          isSecondFactor = true,
+          mode = FactorMode.SecondFactor,
           modifier = modifier,
           onAuthComplete = onAuthComplete,
         )

--- a/source/ui/src/main/java/com/clerk/ui/signin/clienttrust/SignInClientTrustView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/clienttrust/SignInClientTrustView.kt
@@ -1,0 +1,34 @@
+package com.clerk.ui.signin.clienttrust
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.ui.ClerkTheme
+import com.clerk.ui.core.common.StrategyKeys
+import com.clerk.ui.signin.code.FactorMode
+import com.clerk.ui.signin.code.SignInFactorCodeView
+import com.clerk.ui.signin.help.SignInGetHelpView
+import com.clerk.ui.theme.ClerkThemeOverrideProvider
+
+@Composable
+fun SignInClientTrustView(
+  factor: Factor,
+  modifier: Modifier = Modifier,
+  clerkTheme: ClerkTheme? = null,
+  onAuthComplete: () -> Unit,
+) {
+  ClerkThemeOverrideProvider(clerkTheme) {
+    when (factor.strategy) {
+      StrategyKeys.PHONE_CODE,
+      StrategyKeys.EMAIL_CODE ->
+        SignInFactorCodeView(
+          factor = factor,
+          mode = FactorMode.ClientTrust,
+          modifier = modifier,
+          onAuthComplete = onAuthComplete,
+        )
+      else -> SignInGetHelpView(modifier = modifier)
+    }
+  }
+}
+

--- a/source/ui/src/main/java/com/clerk/ui/signin/code/SignInPrepareHandler.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/code/SignInPrepareHandler.kt
@@ -56,7 +56,7 @@ internal class SignInPrepareHandler {
   internal suspend fun prepareForPhoneCode(
     inProgressSignIn: SignIn,
     factor: Factor,
-    isSecondFactor: Boolean,
+    useSecondFactorApi: Boolean,
     onError: (String) -> Unit,
   ) {
     val phoneNumberId = factor.phoneNumberId
@@ -65,9 +65,9 @@ internal class SignInPrepareHandler {
       return
     }
 
-    if (isSecondFactor) {
+    if (useSecondFactorApi) {
       inProgressSignIn
-        .prepareSecondFactor(phoneNumberId)
+        .prepareSecondFactor(SignIn.PrepareSecondFactorStrategy.PhoneCode(phoneNumberId))
         .onSuccess { ClerkLog.v("Successfully prepared second factor for phone code") }
         .onFailure { ClerkLog.e("Error preparing second factor for phone code: $it") }
     } else {
@@ -85,6 +85,7 @@ internal class SignInPrepareHandler {
   internal suspend fun prepareForEmailCode(
     inProgressSignIn: SignIn,
     factor: Factor,
+    useSecondFactorApi: Boolean,
     onError: (String) -> Unit,
   ) {
     val emailAddressId = factor.emailAddressId
@@ -93,14 +94,21 @@ internal class SignInPrepareHandler {
       return
     }
 
-    inProgressSignIn
-      .prepareFirstFactor(
-        SignIn.PrepareFirstFactorParams.EmailCode(emailAddressId = emailAddressId)
-      )
-      .onSuccess { ClerkLog.v("Successfully prepared for email code: $it") }
-      .onFailure {
-        onError(it.errorMessage)
-        ClerkLog.e("Error preparing for email code: ${it.errorMessage}")
-      }
+    if (useSecondFactorApi) {
+      inProgressSignIn
+        .prepareSecondFactor(SignIn.PrepareSecondFactorStrategy.EmailCode(emailAddressId))
+        .onSuccess { ClerkLog.v("Successfully prepared second factor for email code: $it") }
+        .onFailure { ClerkLog.e("Error preparing second factor for email code: $it") }
+    } else {
+      inProgressSignIn
+        .prepareFirstFactor(
+          SignIn.PrepareFirstFactorParams.EmailCode(emailAddressId = emailAddressId)
+        )
+        .onSuccess { ClerkLog.v("Successfully prepared for email code: $it") }
+        .onFailure {
+          onError(it.errorMessage)
+          ClerkLog.e("Error preparing for email code: ${it.errorMessage}")
+        }
+    }
   }
 }

--- a/source/ui/src/main/res/values-ar/strings.xml
+++ b/source/ui/src/main/res/values-ar/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">أعد الإرسال</string>
     <string name="didn_t_receive_a_code">"لم تستلم رمزاً؟ "</string>
     <string name="verifying">جارٍ التحقق…</string>
+    <string name="client_trust_new_device_notice">أنت تسجل الدخول من جهاز جديد. نطلب التحقق للحفاظ على أمان حسابك.</string>
     <string name="passkey_icon">أيقونة مفتاح المرور</string>
     <string name="using_your_passkey">استخدام مفتاح المرور الخاص بك يؤكد أنك أنت. قد يطلب جهازك بصمة الإصبع أو الوجه أو قفل الشاشة.</string>
     <string name="use_your_passkey">استخدم مفتاح المرور الخاص بك</string>

--- a/source/ui/src/main/res/values-de/strings.xml
+++ b/source/ui/src/main/res/values-de/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">Erneut senden</string>
     <string name="didn_t_receive_a_code">"Keinen Code erhalten? "</string>
     <string name="verifying">Wird überprüft…</string>
+    <string name="client_trust_new_device_notice">Sie melden sich von einem neuen Gerät an. Wir bitten um Verifizierung, um Ihr Konto sicher zu halten.</string>
     <string name="passkey_icon">Passkey-Symbol</string>
     <string name="using_your_passkey">Die Verwendung Ihres Passkeys bestätigt, dass Sie es sind. Ihr Gerät kann nach Ihrem Fingerabdruck, Gesicht oder Bildschirmsperre fragen.</string>
     <string name="use_your_passkey">Verwenden Sie Ihren Passkey</string>

--- a/source/ui/src/main/res/values-el/strings.xml
+++ b/source/ui/src/main/res/values-el/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">Επανάληψη</string>
     <string name="didn_t_receive_a_code">"Δεν λάβατε κωδικό; "</string>
     <string name="verifying">Επαλήθευση…</string>
+    <string name="client_trust_new_device_notice">Συνδέεστε από μια νέα συσκευή. Ζητάμε επαλήθευση για να διατηρήσουμε τον λογαριασμό σας ασφαλή.</string>
     <string name="passkey_icon">Εικονίδιο κλειδιού πρόσβασης</string>
     <string name="using_your_passkey">Η χρήση του κλειδιού πρόσβασης σας επιβεβαιώνει ότι είστε εσείς. Η συσκευή σας μπορεί να ζητήσει το δακτυλικό σας αποτύπωμα, το πρόσωπό σας ή τον κωδικό κλειδώματος οθόνης.</string>
     <string name="use_your_passkey">Χρησιμοποιήστε το κλειδί πρόσβασης σας</string>

--- a/source/ui/src/main/res/values-es/strings.xml
+++ b/source/ui/src/main/res/values-es/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">Reenviar</string>
     <string name="didn_t_receive_a_code">"¿No recibiste un código? "</string>
     <string name="verifying">Verificando…</string>
+    <string name="client_trust_new_device_notice">Estás iniciando sesión desde un dispositivo nuevo. Estamos solicitando verificación para mantener tu cuenta segura.</string>
     <string name="passkey_icon">Icono de clave de acceso</string>
     <string name="using_your_passkey">Usar tu clave de acceso confirma que eres tú. Tu dispositivo puede solicitar tu huella dactilar, rostro o bloqueo de pantalla.</string>
     <string name="use_your_passkey">Usa tu clave de acceso</string>

--- a/source/ui/src/main/res/values-fr/strings.xml
+++ b/source/ui/src/main/res/values-fr/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">Renvoyer</string>
     <string name="didn_t_receive_a_code">"Vous n\'avez pas reçu de code ? "</string>
     <string name="verifying">Vérification en cours…</string>
+    <string name="client_trust_new_device_notice">Vous vous connectez depuis un nouvel appareil. Nous demandons une vérification pour sécuriser votre compte.</string>
     <string name="passkey_icon">Icône de clé d\'accès</string>
     <string name="using_your_passkey">L\'utilisation de votre clé d\'accès confirme que c\'est vous. Votre appareil peut demander votre empreinte digitale, votre visage ou le verrouillage de l\'écran.</string>
     <string name="use_your_passkey">Utiliser votre clé d\'accès</string>

--- a/source/ui/src/main/res/values-hi/strings.xml
+++ b/source/ui/src/main/res/values-hi/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">पुनः भेजें</string>
     <string name="didn_t_receive_a_code">"कोड नहीं मिला? "</string>
     <string name="verifying">सत्यापन हो रहा है…</string>
+    <string name="client_trust_new_device_notice">आप एक नए डिवाइस से साइन इन कर रहे हैं। हम आपके खाते को सुरक्षित रखने के लिए सत्यापन मांग रहे हैं।</string>
     <string name="passkey_icon">पासकी आइकन</string>
     <string name="using_your_passkey">अपनी पासकी का उपयोग करना पुष्टि करता है कि यह आप ही हैं। आपका डिवाइस आपकी फिंगरप्रिंट, चेहरे या स्क्रीन लॉक के लिए पूछ सकता है।</string>
     <string name="use_your_passkey">अपनी पासकी का उपयोग करें</string>

--- a/source/ui/src/main/res/values-it/strings.xml
+++ b/source/ui/src/main/res/values-it/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">Reinvia</string>
     <string name="didn_t_receive_a_code">"Non hai ricevuto un codice? "</string>
     <string name="verifying">Verifica in corso…</string>
+    <string name="client_trust_new_device_notice">Stai effettuando l\'accesso da un nuovo dispositivo. Richiediamo la verifica per mantenere il tuo account sicuro.</string>
     <string name="passkey_icon">Icona passkey</string>
     <string name="using_your_passkey">L\'uso della tua passkey conferma che sei tu. Il tuo dispositivo potrebbe richiedere l\'impronta digitale, il volto o il blocco schermo.</string>
     <string name="use_your_passkey">Usa la tua passkey</string>

--- a/source/ui/src/main/res/values-ja/strings.xml
+++ b/source/ui/src/main/res/values-ja/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">再送信</string>
     <string name="didn_t_receive_a_code">"コードを受信しませんでしたか？ "</string>
     <string name="verifying">確認中…</string>
+    <string name="client_trust_new_device_notice">新しいデバイスからサインインしています。アカウントを安全に保つため、確認を求めています。</string>
     <string name="passkey_icon">パスキーアイコン</string>
     <string name="using_your_passkey">パスキーを使用することで、本人であることが確認されます。デバイスが指紋、顔認証、または画面ロックを要求する場合があります。</string>
     <string name="use_your_passkey">パスキーを使用</string>

--- a/source/ui/src/main/res/values-ko/strings.xml
+++ b/source/ui/src/main/res/values-ko/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">다시 보내기</string>
     <string name="didn_t_receive_a_code">"코드를 받지 못하셨나요? "</string>
     <string name="verifying">확인 중…</string>
+    <string name="client_trust_new_device_notice">새로운 기기에서 로그인하고 있습니다. 계정을 안전하게 유지하기 위해 확인을 요청하고 있습니다.</string>
     <string name="passkey_icon">패스키 아이콘</string>
     <string name="using_your_passkey">패스키를 사용하면 본인임이 확인됩니다. 기기가 지문, 얼굴 인식 또는 화면 잠금을 요청할 수 있습니다.</string>
     <string name="use_your_passkey">패스키 사용</string>

--- a/source/ui/src/main/res/values-pt/strings.xml
+++ b/source/ui/src/main/res/values-pt/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">Reenviar</string>
     <string name="didn_t_receive_a_code">"Não recebeu um código? "</string>
     <string name="verifying">Verificando…</string>
+    <string name="client_trust_new_device_notice">Você está entrando em um novo dispositivo. Estamos solicitando verificação para manter sua conta segura.</string>
     <string name="passkey_icon">Ícone de chave de acesso</string>
     <string name="using_your_passkey">Usar sua chave de acesso confirma que é você. Seu dispositivo pode solicitar sua impressão digital, rosto ou bloqueio de tela.</string>
     <string name="use_your_passkey">Use sua chave de acesso</string>

--- a/source/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/source/ui/src/main/res/values-zh-rCN/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">重新发送</string>
     <string name="didn_t_receive_a_code">"没收到验证码？ "</string>
     <string name="verifying">正在验证…</string>
+    <string name="client_trust_new_device_notice">您正在从新设备登录。我们需要进行验证以保护您的账户安全。</string>
     <string name="passkey_icon">通行密钥图标</string>
     <string name="using_your_passkey">使用您的通行密钥可确认是您本人。您的设备可能会要求您提供指纹、面容或屏幕锁定。</string>
     <string name="use_your_passkey">使用您的通行密钥</string>

--- a/source/ui/src/main/res/values/strings.xml
+++ b/source/ui/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="resend">Resend</string>
     <string name="didn_t_receive_a_code">"Didn't receive a code? "</string>
     <string name="verifying">Verifying…</string>
+    <string name="client_trust_new_device_notice">You\'re signing in from a new device. We\'re asking for verification to keep your account secure.</string>
     <string name="passkey_icon">Passkey icon</string>
     <string name="using_your_passkey">Using your passkey confirms it\'s you. Your device may ask for your fingerprint, face or screen lock.</string>
     <string name="use_your_passkey">Use your passkey</string>

--- a/source/ui/src/test/java/com/clerk/ui/signin/code/SignInAttemptHandlerTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/code/SignInAttemptHandlerTest.kt
@@ -69,10 +69,34 @@ class SignInAttemptHandlerTest {
   }
 
   @Test
+  fun attemptEmailCodeAsSecondFactorShouldCallAttemptSecondFactorAndTriggerSuccessCallback() =
+    runTest {
+      val code = "123456"
+      val successResult = ClerkResult.success(mockSignIn)
+      var successCallbackCalled = false
+      var errorCallbackCalled = false
+
+      coEvery {
+        mockSignIn.attemptSecondFactor(SignIn.AttemptSecondFactorParams.EmailCode(code = code))
+      } returns successResult
+
+      handler.attemptEmailCode(
+        inProgressSignIn = mockSignIn,
+        code = code,
+        useSecondFactorApi = true,
+        onSuccessCallback = { successCallbackCalled = true },
+        onErrorCallback = { errorCallbackCalled = true },
+      )
+
+      coVerify { mockSignIn.attemptSecondFactor(any()) }
+      assert(successCallbackCalled)
+      assert(!errorCallbackCalled)
+    }
+
+  @Test
   fun attemptFirstFactorEmailCodeShouldTriggerErrorCallbackOnFailure() = runTest {
     val code = "123456"
-    val errorResponse = mockk<ClerkErrorResponse>()
-    every { errorResponse.errors } returns emptyList()
+    val errorResponse = ClerkErrorResponse(errors = emptyList())
     val failureResult = ClerkResult.apiFailure(errorResponse)
     var successCallbackCalled = false
     var errorCallbackCalled = false
@@ -113,7 +137,7 @@ class SignInAttemptHandlerTest {
       handler.attemptFirstFactorPhoneCode(
         inProgressSignIn = mockSignIn,
         code = code,
-        isSecondFactor = false,
+        useSecondFactorApi = false,
         onSuccessCallback = { successCallbackCalled = true },
         onErrorCallback = { errorCallbackCalled = true },
       )
@@ -126,8 +150,7 @@ class SignInAttemptHandlerTest {
   @Test
   fun attemptFirstFactorPhoneCodeAsFirstFactorShouldTriggerErrorCallbackOnFailure() = runTest {
     val code = "654321"
-    val errorResponse = mockk<ClerkErrorResponse>()
-    every { errorResponse.errors } returns emptyList()
+    val errorResponse = ClerkErrorResponse(errors = emptyList())
     val failureResult = ClerkResult.apiFailure(errorResponse)
     var successCallbackCalled = false
     var errorCallbackCalled = false
@@ -139,7 +162,7 @@ class SignInAttemptHandlerTest {
     handler.attemptFirstFactorPhoneCode(
       inProgressSignIn = mockSignIn,
       code = code,
-      isSecondFactor = false,
+      useSecondFactorApi = false,
       onSuccessCallback = { successCallbackCalled = true },
       onErrorCallback = { errorCallbackCalled = true },
     )
@@ -164,7 +187,7 @@ class SignInAttemptHandlerTest {
       handler.attemptFirstFactorPhoneCode(
         inProgressSignIn = mockSignIn,
         code = code,
-        isSecondFactor = true,
+        useSecondFactorApi = true,
         onSuccessCallback = { successCallbackCalled = true },
         onErrorCallback = { errorCallbackCalled = true },
       )
@@ -177,8 +200,7 @@ class SignInAttemptHandlerTest {
   @Test
   fun attemptFirstFactorPhoneCodeAsSecondFactorShouldTriggerErrorCallbackOnFailure() = runTest {
     val code = "789012"
-    val errorResponse = mockk<ClerkErrorResponse>()
-    every { errorResponse.errors } returns emptyList()
+    val errorResponse = ClerkErrorResponse(errors = emptyList())
     val failureResult = ClerkResult.apiFailure(errorResponse)
     var successCallbackCalled = false
     var errorCallbackCalled = false
@@ -190,7 +212,7 @@ class SignInAttemptHandlerTest {
     handler.attemptFirstFactorPhoneCode(
       inProgressSignIn = mockSignIn,
       code = code,
-      isSecondFactor = true,
+      useSecondFactorApi = true,
       onSuccessCallback = { successCallbackCalled = true },
       onErrorCallback = { errorCallbackCalled = true },
     )
@@ -226,8 +248,7 @@ class SignInAttemptHandlerTest {
   @Test
   fun attemptForTotpShouldTriggerErrorCallbackOnFailure() = runTest {
     val code = "345678"
-    val errorResponse = mockk<ClerkErrorResponse>()
-    every { errorResponse.errors } returns emptyList()
+    val errorResponse = ClerkErrorResponse(errors = emptyList())
     val failureResult = ClerkResult.apiFailure(errorResponse)
     var successCallbackCalled = false
     var errorCallbackCalled = false
@@ -276,8 +297,7 @@ class SignInAttemptHandlerTest {
   @Test
   fun attemptResetForEmailCodeShouldTriggerErrorCallbackOnFailure() = runTest {
     val code = "901234"
-    val errorResponse = mockk<ClerkErrorResponse>()
-    every { errorResponse.errors } returns emptyList()
+    val errorResponse = ClerkErrorResponse(errors = emptyList())
     val failureResult = ClerkResult.apiFailure(errorResponse)
     var successCallbackCalled = false
     var errorCallbackCalled = false
@@ -328,8 +348,7 @@ class SignInAttemptHandlerTest {
   @Test
   fun attemptResetForPhoneCodeShouldTriggerErrorCallbackOnFailure() = runTest {
     val code = "567890"
-    val errorResponse = mockk<ClerkErrorResponse>()
-    every { errorResponse.errors } returns emptyList()
+    val errorResponse = ClerkErrorResponse(errors = emptyList())
     val failureResult = ClerkResult.apiFailure(errorResponse)
     var successCallbackCalled = false
     var errorCallbackCalled = false


### PR DESCRIPTION
## Summary of changes

This PR implements the **client trust verification** flow on Android, mirroring the functionality introduced in `clerk-ios#304`.

Key changes include:

-   **New Sign-in Status**: Added `SignIn.Status.NEEDS_CLIENT_TRUST` to the API model.
-   **Auth Routing**: Introduced a new `AuthDestination.SignInClientTrust` to handle this status, routing to a dedicated client trust screen.
-   **Code Factor Mode**: Refactored the code verification screen (`SignInFactorCodeView`) to use a `FactorMode` enum (`FirstFactor`, `SecondFactor`, `ClientTrust`). The `ClientTrust` mode ensures:
    -   It utilizes **second-factor API endpoints** for email and phone code verification.
    -   It displays a **"new device" warning message** to the user.
-   **API Enhancements**: Added an explicit `prepareSecondFactor(strategy)` overload to allow specific second-factor strategies (e.g., email_code) to be prepared.
-   **Localization**: Added the `client_trust_new_device_notice` string across all supported locales.

This ensures consistent client trust handling and user experience between the iOS and Android SDKs.

---
<a href="https://cursor.com/background-agent?bcId=bc-a78f5a87-2451-43ff-a0b0-4ceb6e30a45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a78f5a87-2451-43ff-a0b0-4ceb6e30a45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

