### PR TITLE
Name field functionality

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
@@ -518,7 +518,7 @@ data class SignUp(
     }
 
     val fieldPriority: List<String> =
-      listOf("email_address", "phone_number", "username", "username")
+      listOf("email_address", "phone_number", "username", "password", "first_name", "last_name")
   }
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
@@ -83,8 +83,12 @@ private fun SignUpCompleteProfileImpl(
   val hasLegalUrls = termsUrl != null || privacyPolicyUrl != null
   val showLegalConsent = legalConsentRequired && hasLegalUrls
 
-  authState.signUpFirstName = firstName
-  authState.signUpLastName = lastName
+  // Initialize authState values only once when provided (for previews/tests)
+  // This uses LaunchedEffect to prevent resetting user input on recomposition
+  androidx.compose.runtime.LaunchedEffect(Unit) {
+    if (firstName.isNotEmpty()) authState.signUpFirstName = firstName
+    if (lastName.isNotEmpty()) authState.signUpLastName = lastName
+  }
 
   val state by viewModel.state.collectAsStateWithLifecycle()
   val snackbarHostState = remember { SnackbarHostState() }


### PR DESCRIPTION
## Summary of changes

This PR addresses two issues related to user sign-up:

1.  **Prevents first and last name fields from being reset on recomposition:** The `authState.signUpFirstName` and `authState.signUpLastName` were being overwritten on every recomposition, clearing user input. This is now fixed by initializing these values only once using `LaunchedEffect`.
2.  **Corrects `fieldPriority` list:** The `fieldPriority` list in `SignUp.kt` was updated to include `first_name` and `last_name`, and to correctly list `password` instead of a duplicate `username`. This ensures proper field collection order during sign-up.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0e88f2a-97c3-495b-8430-b12b7a51c984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f0e88f2a-97c3-495b-8430-b12b7a51c984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

