### PR TITLE
refactor: split sendMfaCode and use builder for signInWithIdToken

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -7,6 +7,7 @@ import com.clerk.api.Constants.Strategy.PASSWORD
 import com.clerk.api.Constants.Strategy.PHONE_CODE
 import com.clerk.api.auth.builders.EnterpriseSsoBuilder
 import com.clerk.api.auth.builders.SignInIdentifierBuilder
+import com.clerk.api.auth.builders.SignInWithIdTokenBuilder
 import com.clerk.api.auth.builders.SignInWithOtpBuilder
 import com.clerk.api.auth.builders.SignInWithPasswordBuilder
 import com.clerk.api.auth.builders.SignUpBuilder
@@ -257,23 +258,27 @@ class Auth internal constructor() {
   /**
    * Signs in with an ID token from an identity provider.
    *
-   * @param token The ID token from the identity provider.
-   * @param provider The ID token provider.
-   * @return A [ClerkResult] containing the [SignIn] object on success, or a [ClerkErrorResponse] on
+   * @param block Builder block to configure the token and provider.
+   * @return A [ClerkResult] containing the [OAuthResult] on success, or a [ClerkErrorResponse] on
    *   failure.
    *
    * ### Example usage:
    * ```kotlin
-   * val result = clerk.auth.signInWithIdToken(idToken, IdTokenProvider.GOOGLE)
+   * val result = clerk.auth.signInWithIdToken {
+   *     token = idToken
+   *     provider = IdTokenProvider.GOOGLE
+   * }
    * ```
    */
   suspend fun signInWithIdToken(
-    token: String,
-    provider: IdTokenProvider,
+    block: SignInWithIdTokenBuilder.() -> Unit
   ): ClerkResult<OAuthResult, ClerkErrorResponse> {
-    return when (provider) {
+    val builder = SignInWithIdTokenBuilder().apply(block)
+    builder.validate()
+
+    return when (builder.provider!!) {
       IdTokenProvider.GOOGLE -> {
-        when (val result = ClerkApi.signIn.authenticateWithGoogle(token = token)) {
+        when (val result = ClerkApi.signIn.authenticateWithGoogle(token = builder.token!!)) {
           is ClerkResult.Success -> ClerkResult.success(OAuthResult(signIn = result.value))
           is ClerkResult.Failure -> ClerkResult.apiFailure(result.error)
         }

--- a/source/api/src/main/kotlin/com/clerk/api/auth/builders/SignInBuilders.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/builders/SignInBuilders.kt
@@ -1,5 +1,7 @@
 package com.clerk.api.auth.builders
 
+import com.clerk.api.auth.types.IdTokenProvider
+
 /**
  * Builder for sign-in with identifier.
  *
@@ -88,5 +90,32 @@ class SignInWithOtpBuilder {
     require(email == null || phone == null) {
       "Only one of email or phone should be provided, not both"
     }
+  }
+}
+
+/**
+ * Builder for sign-in with ID token.
+ *
+ * Use this builder to sign in with an ID token from an identity provider such as Google.
+ *
+ * ### Example usage:
+ * ```kotlin
+ * clerk.auth.signInWithIdToken {
+ *     token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+ *     provider = IdTokenProvider.GOOGLE
+ * }
+ * ```
+ */
+@ClerkDsl
+class SignInWithIdTokenBuilder {
+  /** The ID token from the identity provider. */
+  var token: String? = null
+
+  /** The identity provider that issued the token. */
+  var provider: IdTokenProvider? = null
+
+  internal fun validate() {
+    require(token != null) { "Token must be provided" }
+    require(provider != null) { "Provider must be provided" }
   }
 }

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
@@ -247,50 +247,6 @@ suspend fun SignIn.verifyWithPasskey(credential: String): ClerkResult<SignIn, Cl
 }
 
 /**
- * Sends an MFA verification code.
- *
- * @param block Builder block to configure where to send the MFA code.
- * @return A [ClerkResult] containing the updated [SignIn] object on success, or a
- *   [ClerkErrorResponse] on failure.
- *
- * ### Example usage:
- * ```kotlin
- * signIn.sendMfaCode { phone = "+1234567890" }
- * // or
- * signIn.sendMfaCode { email = "user@email.com" }
- * ```
- */
-suspend fun SignIn.sendMfaCode(
-  block: SendCodeBuilder.() -> Unit
-): ClerkResult<SignIn, ClerkErrorResponse> {
-  val builder = SendCodeBuilder().apply(block)
-  builder.validate()
-
-  val params =
-    if (builder.phone != null) {
-      val phoneNumberId =
-        supportedSecondFactors
-          ?.find { it.strategy == SignIn.PrepareSecondFactorParams.PHONE_CODE }
-          ?.phoneNumberId
-      SignIn.PrepareSecondFactorParams(
-        strategy = SignIn.PrepareSecondFactorParams.PHONE_CODE,
-        phoneNumberId = phoneNumberId,
-      )
-    } else {
-      val emailAddressId =
-        supportedSecondFactors
-          ?.find { it.strategy == SignIn.PrepareSecondFactorParams.EMAIL_CODE }
-          ?.emailAddressId
-      SignIn.PrepareSecondFactorParams(
-        strategy = SignIn.PrepareSecondFactorParams.EMAIL_CODE,
-        emailAddressId = emailAddressId,
-      )
-    }
-
-  return ClerkApi.signIn.prepareSecondFactor(id = id, params = params.toMap())
-}
-
-/**
  * Verifies MFA with the provided code and type.
  *
  * @param code The MFA verification code.


### PR DESCRIPTION
- Remove sendMfaCode builder function, align with iOS SDK using separate sendMfaPhoneCode() and sendMfaEmailCode() functions
- Convert signInWithIdToken to use builder pattern instead of params

## Summary of changes
