### PR TITLE
Fix NavDisplay backstack crash during auth transitions

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -67,48 +67,48 @@ fun AuthView(modifier: Modifier = Modifier, clerkTheme: ClerkTheme? = null) {
         entryProvider =
           entryProvider {
             entry<AuthDestination.AuthStart> {
-              AuthStartView(onAuthComplete = { backStack.clear() })
+              AuthStartView(onAuthComplete = { /* AuthView will unmount naturally */ })
             }
             entry<AuthDestination.SignInFactorOne> { key ->
-              SignInFactorOneView(factor = key.factor, onAuthComplete = { backStack.clear() })
+              SignInFactorOneView(factor = key.factor, onAuthComplete = { /* AuthView will unmount naturally */ })
             }
             entry<AuthDestination.SignInFactorOneUseAnotherMethod> { key ->
               SignInFactorAlternativeMethodsView(
                 currentFactor = key.currentFactor,
-                onAuthComplete = { backStack.clear() },
+                onAuthComplete = { /* AuthView will unmount naturally */ },
               )
             }
             entry<AuthDestination.SignInFactorTwo> { key ->
-              SignInFactorTwoView(factor = key.factor, onAuthComplete = { backStack.clear() })
+              SignInFactorTwoView(factor = key.factor, onAuthComplete = { /* AuthView will unmount naturally */ })
             }
             entry<AuthDestination.SignInFactorTwoUseAnotherMethod> { key ->
               SignInFactorAlternativeMethodsView(
                 currentFactor = key.currentFactor,
                 isSecondFactor = true,
-                onAuthComplete = { backStack.clear() },
+                onAuthComplete = { /* AuthView will unmount naturally */ },
               )
             }
             entry<AuthDestination.SignInForgotPassword> {
               SignInFactorOneForgotPasswordView(
                 onClickFactor = { backStack.removeLastOrNull() },
-                onAuthComplete = { backStack.clear() },
+                onAuthComplete = { /* AuthView will unmount naturally */ },
               )
             }
             entry<AuthDestination.SignInSetNewPassword> {
-              SignInSetNewPasswordView(onAuthComplete = { backStack.clear() })
+              SignInSetNewPasswordView(onAuthComplete = { /* AuthView will unmount naturally */ })
             }
             entry<AuthDestination.SignInGetHelp> { SignInGetHelpView() }
             entry<AuthDestination.SignInClientTrust> { key ->
-              SignInClientTrustView(factor = key.factor, onAuthComplete = { backStack.clear() })
+              SignInClientTrustView(factor = key.factor, onAuthComplete = { /* AuthView will unmount naturally */ })
             }
             entry<AuthDestination.SignUpCollectField> { key ->
-              SignUpCollectFieldView(field = key.field, onAuthComplete = { backStack.clear() })
+              SignUpCollectFieldView(field = key.field, onAuthComplete = { /* AuthView will unmount naturally */ })
             }
             entry<AuthDestination.SignUpCode> { key ->
-              SignUpCodeView(field = key.field, onAuthComplete = { backStack.clear() })
+              SignUpCodeView(field = key.field, onAuthComplete = { /* AuthView will unmount naturally */ })
             }
             entry<AuthDestination.SignUpCompleteProfile> {
-              SignUpCompleteProfileView(onAuthComplete = { backStack.clear() })
+              SignUpCompleteProfileView(onAuthComplete = { /* AuthView will unmount naturally */ })
             }
           },
       )


### PR DESCRIPTION
Fixes #461

## Problem

The app crashes with `java.lang.IllegalArgumentException: NavDisplay backstack cannot be empty` during sign in → sign out → sign in flows. This crash occurs consistently when users transition between authentication states.

The crash happens at `NavDisplay.kt:199` where the androidx.navigation3 library enforces an invariant that the backstack must not be empty.

## Root Cause

When authentication completes, `onAuthComplete = { backStack.clear() }` callbacks completely empty the backstack, including the root entry (`AuthDestination.AuthStart`). During the recomposition triggered by auth state changes, NavDisplay attempts to access the empty backstack and crashes.

## Changes Made

### AuthState.kt

1. Added `resetToRoot()` helper function that safely resets the backstack to the root entry instead of clearing it completely:
   ```kotlin
   private fun resetToRoot() {
     if (backStack.size > 1) {
       backStack.pop(backStack.size - 1)
     }
   }
   ```

2. Updated `clearBackStack()` to use `resetToRoot()`

3. Replaced all `backStack.clear()` calls with `resetToRoot()` in:
   - `SignIn.Status.NEEDS_IDENTIFIER`
   - `SignUp.Status.ABANDONED`
   - EMAIL_ADDRESS verification fallback
   - PHONE_NUMBER verification fallback
   - Default verification fallback

### AuthView.kt

Replaced all `onAuthComplete = { backStack.clear() }` callbacks with empty implementations `onAuthComplete = { /* AuthView will unmount naturally */ }`

**Rationale:** When auth completes, the `AuthViewModel` transitions to `SignedIn` state, `AuthGate` unmounts `AuthView`, and the entire backstack is garbage collected naturally. Manual clearing is unnecessary and causes crashes.

## Why This Fix Works

1. **Maintains Invariant**: The backstack always has at least the root entry (`AuthDestination.AuthStart`) while NavDisplay is active
2. **Safe for NavDisplay**: Never encounters an empty backstack during rendering, recomposition, or animations
3. **Handles All Transitions**: Works correctly for rapid sign in/out cycles and all auth flows
4. **Minimal Changes**: Only touches navigation logic, no breaking changes
5. **Natural Cleanup**: AuthView unmounts naturally when auth completes, backstack is garbage collected safely

## Testing

All scenarios tested successfully with no crashes:

- Normal sign in flow
- Sign in → sign out → sign in (repeated 10+ cycles)
- Multi-factor authentication flows
- Sign up flows with verification
- Password reset flows

## Impact

- **Breaking Changes**: None
- **Behavioral Changes**: Backstack now maintains root entry until AuthView unmounts (internal implementation detail)
- **Performance**: No impact
- **Compatibility**: Fully backward compatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved navigation crashes occurring during rapid authentication state transitions through improved back stack management
  * Enhanced authentication completion flow stability by preserving navigation hierarchy and relying on natural unmount behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->