### PR TITLE
User verification methods

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/emailaddress/EmailAddress.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/emailaddress/EmailAddress.kt
@@ -125,3 +125,31 @@ suspend fun EmailAddress.get(): ClerkResult<EmailAddress, ClerkErrorResponse> {
 suspend fun EmailAddress.delete(): ClerkResult<DeletedObject, ClerkErrorResponse> {
   return ClerkApi.user.deleteEmailAddress(emailAddressId = this.id)
 }
+
+/**
+ * Sends a verification code to this email address.
+ *
+ * This is a convenience method that calls [prepareVerification] with the [EmailCode] strategy. A
+ * one-time verification code will be sent to this email address. Use [verifyCode] to complete the
+ * verification process.
+ *
+ * @return A [ClerkResult] containing the updated [EmailAddress] on success, or a
+ *   [ClerkErrorResponse] on failure
+ */
+suspend fun EmailAddress.sendCode(): ClerkResult<EmailAddress, ClerkErrorResponse> {
+  return prepareVerification(EmailAddress.PrepareVerificationParams.EmailCode())
+}
+
+/**
+ * Verifies this email address using the provided verification code.
+ *
+ * This is a convenience method that calls [attemptVerification] with the provided code. The
+ * verification code is typically received via email after calling [sendCode].
+ *
+ * @param code The one-time verification code received via email
+ * @return A [ClerkResult] containing the updated [EmailAddress] on success, or a
+ *   [ClerkErrorResponse] on failure
+ */
+suspend fun EmailAddress.verifyCode(code: String): ClerkResult<EmailAddress, ClerkErrorResponse> {
+  return attemptVerification(code)
+}

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
@@ -126,6 +126,39 @@ suspend fun OrganizationDomain.updateEnrollmentMode(
 }
 
 /**
+ * Sends a verification code to the specified email address for domain affiliation verification.
+ *
+ * This is a convenience method that calls [prepareAffiliationVerification]. A one-time verification
+ * code will be sent to the specified email address. Use [verifyCode] to complete the verification
+ * process.
+ *
+ * @param affiliationEmailAddress The email address to send the verification code to
+ * @return A [ClerkResult] containing the updated [OrganizationDomain] on success or a
+ *   [ClerkErrorResponse] on failure
+ */
+suspend fun OrganizationDomain.sendEmailCode(
+  affiliationEmailAddress: String
+): ClerkResult<OrganizationDomain, ClerkErrorResponse> {
+  return prepareAffiliationVerification(affiliationEmailAddress)
+}
+
+/**
+ * Verifies the domain affiliation using the provided verification code.
+ *
+ * This is a convenience method that calls [attemptAffiliationVerification] with the provided code.
+ * The verification code is typically received via email after calling [sendEmailCode].
+ *
+ * @param code The verification code received via email
+ * @return A [ClerkResult] containing the updated [OrganizationDomain] on success or a
+ *   [ClerkErrorResponse] on failure
+ */
+suspend fun OrganizationDomain.verifyCode(
+  code: String
+): ClerkResult<OrganizationDomain, ClerkErrorResponse> {
+  return attemptAffiliationVerification(code)
+}
+
+/**
  * When the Clerk API returns a collection of objects it uses a top level data tag in the JSON. This
  * class represents that JSON structure since we can't pass the list type to the clerk result.
  *

--- a/source/api/src/main/kotlin/com/clerk/api/phonenumber/PhoneNumber.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/phonenumber/PhoneNumber.kt
@@ -184,3 +184,30 @@ suspend fun PhoneNumber.setReservedForSecondFactor(
 suspend fun PhoneNumber.makeDefaultSecondFactor(): ClerkResult<PhoneNumber, ClerkErrorResponse> {
   return ClerkApi.user.makeDefaultSecondFactor(phoneNumberId = this.id, defaultSecondFactor = true)
 }
+
+/**
+ * Sends a verification code to this phone number via SMS.
+ *
+ * This is a convenience method that calls [prepareVerification]. A one-time verification code will
+ * be sent to this phone number via SMS. Use [verifyCode] to complete the verification process.
+ *
+ * @return A [ClerkResult] containing the updated [PhoneNumber] on success, or a
+ *   [ClerkErrorResponse] on failure
+ */
+suspend fun PhoneNumber.sendCode(): ClerkResult<PhoneNumber, ClerkErrorResponse> {
+  return prepareVerification()
+}
+
+/**
+ * Verifies this phone number using the provided verification code.
+ *
+ * This is a convenience method that calls [attemptVerification] with the provided code. The
+ * verification code is typically received via SMS after calling [sendCode].
+ *
+ * @param code The one-time verification code received via SMS
+ * @return A [ClerkResult] containing the updated [PhoneNumber] on success, or a
+ *   [ClerkErrorResponse] on failure
+ */
+suspend fun PhoneNumber.verifyCode(code: String): ClerkResult<PhoneNumber, ClerkErrorResponse> {
+  return attemptVerification(code)
+}


### PR DESCRIPTION
## Summary of changes
Implements new convenience methods for email, phone number, and organization domain verification (MOBILE-382).

These methods (`sendCode`, `verifyCode`, `sendEmailCode`) simplify the verification flows by providing more intuitive aliases that delegate to the existing `prepareVerification` and `attemptVerification` methods, aligning with the project goal of a more platform-idiomatic and simplified API.

---
Linear Issue: [MOBILE-382](https://linear.app/clerk/issue/MOBILE-382/implement-verification-methods-for-email-and-phone-numbers)

<a href="https://cursor.com/background-agent?bcId=bc-1b2bbc0c-daed-4740-8fab-0488e525a387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b2bbc0c-daed-4740-8fab-0488e525a387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

