### PR TITLE
fix(ui): Filter social providers by enabled AND authenticatable

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewHelper.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewHelper.kt
@@ -30,7 +30,7 @@ internal class AuthStartViewHelper {
         testSocialProviders!!
       } else {
         Clerk.socialProviders.values
-          .filter { it.authenticatable }
+          .filter { it.enabled && it.authenticatable }
           .map { OAuthProvider.fromStrategy(it.strategy) }
       }
     }
@@ -63,7 +63,7 @@ internal class AuthStartViewHelper {
       return socialProviders.any {
         // For testing, assume all test social providers are authenticatable
         if (testSocialProviders != null) true
-        else (it as? UserSettings.SocialConfig)?.authenticatable == true
+        else (it as? UserSettings.SocialConfig)?.let { config -> config.enabled && config.authenticatable } == true
       } && showIdentifierField
     }
 


### PR DESCRIPTION
## Summary

Social login buttons (Apple, Facebook, Google) were displayed even when those providers were disabled in the Clerk Dashboard. Clicking these buttons resulted in HTTP 422 errors.

## Root Cause

`AuthStartViewHelper.authenticatableSocialProviders` was only filtering by `authenticatable`, but disabled providers can still have `authenticatable: true`. The `enabled` flag also needs to be checked.

## Changes

- Filter `authenticatableSocialProviders` by both `enabled` AND `authenticatable`
- Update `showOrDivider` to also check the `enabled` flag

## Test plan

- [x] Disable all social providers in Clerk Dashboard
- [x] Verify AuthView no longer shows Apple/Facebook/Google buttons
- [x] Verify "or" divider is also hidden when no social providers are enabled
- [x] Enable a social provider and verify the button appears

Fixes #498

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected social authentication provider availability logic to enforce proper configuration validation during sign-in.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->