### PR TITLE
Restrict last-used badge hiding to password strategy

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/LastUsedAuth.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/LastUsedAuth.kt
@@ -166,10 +166,7 @@ private fun shouldShowBadge(
     return storedIdentifierType.matches(strategies)
   }
 
-  val identifierStrategies = emailStrategies + phoneStrategies + usernameStrategies
-  if (
-    identifierStrategies.contains(lastAuth) && !canShowLastUsedBadge(enabledFirstFactorAttributes)
-  ) {
+  if (lastAuth == StrategyKeys.PASSWORD && !canShowLastUsedBadge(enabledFirstFactorAttributes)) {
     return false
   }
 

--- a/source/ui/src/test/java/com/clerk/ui/auth/LastUsedAuthTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/LastUsedAuthTest.kt
@@ -109,7 +109,7 @@ class LastUsedAuthTest {
   }
 
   @Test
-  fun fromReturnsNullWhenIdentifierStrategiesDisallowedByBadgeRules() {
+  fun fromReturnsPhoneWhenPhoneStrategyEvenIfBadgeRulesWouldDisallow() {
     val result =
       LastUsedAuth.from(
         lastAuthenticationStrategy = "phone_code",
@@ -118,7 +118,7 @@ class LastUsedAuthTest {
         storedIdentifierType = null,
       )
 
-    assertNull(result)
+    assertEquals(LastUsedAuth.Phone, result)
   }
 
   @Test


### PR DESCRIPTION
Only hide the last-used authentication badge for password strategy when `canShowLastUsedBadge` returns false. Non-password identifier strategies (email, phone, username) now show the badge regardless of the badge rules.

## Summary of changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the authentication badge display logic to correctly show phone as the last used authentication method when phone strategy is enabled and available. This enhancement improves the user experience by providing accurate visibility of all available authentication options for signing in, regardless of other multi-factor authentication configuration settings applied to your account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->