### PR TITLE
treat pending sessions as signed out by default

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -114,6 +114,28 @@ class Auth internal constructor() {
 
   // endregion
 
+  // region Signed-in Session Access
+
+  /**
+   * All signed-in sessions for the current client.
+   *
+   * Returns an empty list if the SDK is not initialized.
+   */
+  val signedInSessions: List<Session>
+    get() = Clerk.signedInSessions
+
+  /**
+   * The current signed-in session, if available.
+   *
+   * Returns `null` when no signed-in session exists or if the SDK is not initialized. By default,
+   * signed-in sessions include only active sessions. Set [Clerk.treatPendingAsSignedOut] to
+   * `false` to include pending sessions.
+   */
+  val signedInSession: Session?
+    get() = Clerk.signedInSession
+
+  // endregion
+
   // region Sign In
 
   /**

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
@@ -237,7 +237,7 @@ internal class ConfigurationManager {
       scope.launch {
         while (isActive) {
           try {
-            val session = Clerk.session
+            val session = Clerk.activeSession
             if (session != null) {
               if (Clerk.debugMode) {
                 ClerkLog.d("Refreshing token for session: ${session.id}")
@@ -324,7 +324,7 @@ internal class ConfigurationManager {
             // Launch dependent operations concurrently
             launch {
               // Start token refresh as soon as client is available
-              if (Clerk.session != null) {
+              if (Clerk.activeSession != null) {
                 startTokenRefresh()
               }
             }

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/client/Client.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/client/Client.kt
@@ -45,6 +45,29 @@ data class Client(
   fun activeSessions(): List<Session> =
     sessions.filter { it.status == Session.SessionStatus.ACTIVE }
 
+  /**
+   * Signed-in sessions for this client.
+   *
+   * By default, signed-in sessions include only active sessions. Use
+   * [signedInSessions] with `treatPendingAsSignedOut = false` to include pending sessions.
+   */
+  fun signedInSessions(): List<Session> = signedInSessions(treatPendingAsSignedOut = true)
+
+  /**
+   * Signed-in sessions for this client.
+   *
+   * When [treatPendingAsSignedOut] is `true`, only active sessions are included.
+   * When `false`, both active and pending sessions are included.
+   */
+  fun signedInSessions(treatPendingAsSignedOut: Boolean): List<Session> =
+    if (treatPendingAsSignedOut) {
+      activeSessions()
+    } else {
+      sessions.filter {
+        it.status == Session.SessionStatus.ACTIVE || it.status == Session.SessionStatus.PENDING
+      }
+    }
+
   companion object {
     /** Fetches the current client object from the Clerk API. */
     suspend fun get(): ClerkResult<Client, ClerkErrorResponse> = ClerkApi.client.get()

--- a/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
@@ -62,6 +62,10 @@ data class Session(
   val tasks: List<SessionTask> = emptyList(),
   @SerialName("last_active_token") val lastActiveToken: TokenResource? = null,
 ) {
+  /** The current task for this session, if any. */
+  val currentTask: SessionTask?
+    get() = tasks.firstOrNull()
+
   @Serializable
   enum class SessionStatus {
     @SerialName("abandoned") ABANDONED,

--- a/source/api/src/test/java/com/clerk/api/network/model/client/ClientTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/model/client/ClientTest.kt
@@ -1,0 +1,39 @@
+package com.clerk.api.network.model.client
+
+import com.clerk.api.session.Session
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClientTest {
+  private fun session(id: String, status: Session.SessionStatus): Session =
+    Session(
+      id = id,
+      status = status,
+      expireAt = 0L,
+      lastActiveAt = 0L,
+      createdAt = 0L,
+      updatedAt = 0L,
+  )
+
+  @Test
+  fun `signedInSessions returns active sessions by default`() {
+    val active = session(id = "active", status = Session.SessionStatus.ACTIVE)
+    val pending = session(id = "pending", status = Session.SessionStatus.PENDING)
+    val ended = session(id = "ended", status = Session.SessionStatus.ENDED)
+
+    val client = Client(sessions = listOf(active, pending, ended))
+
+    assertEquals(listOf(active), client.signedInSessions())
+  }
+
+  @Test
+  fun `signedInSessions includes pending when configured`() {
+    val active = session(id = "active", status = Session.SessionStatus.ACTIVE)
+    val pending = session(id = "pending", status = Session.SessionStatus.PENDING)
+    val ended = session(id = "ended", status = Session.SessionStatus.ENDED)
+
+    val client = Client(sessions = listOf(active, pending, ended))
+
+    assertEquals(listOf(active, pending), client.signedInSessions(treatPendingAsSignedOut = false))
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -64,6 +64,7 @@ class ClerkTest {
     // Set up basic client mock properties
     every { mockClient.sessions } returns emptyList()
     every { mockClient.activeSessions() } returns emptyList()
+    every { mockClient.signedInSessions() } returns emptyList()
     every { mockClient.lastActiveSessionId } returns null
     every { mockClient.signIn } returns null
     every { mockClient.signUp } returns null
@@ -105,6 +106,7 @@ class ClerkTest {
         val uninitializedClient = mockk<Client>()
         every { uninitializedClient.sessions } returns emptyList()
         every { uninitializedClient.activeSessions() } returns emptyList()
+        every { uninitializedClient.signedInSessions() } returns emptyList()
         every { uninitializedClient.lastActiveSessionId } returns null
         every { uninitializedClient.signIn } returns null
         every { uninitializedClient.signUp } returns null
@@ -165,6 +167,7 @@ class ClerkTest {
     val uninitializedClient = mockk<Client>()
     every { uninitializedClient.sessions } returns emptyList()
     every { uninitializedClient.activeSessions() } returns emptyList()
+    every { uninitializedClient.signedInSessions() } returns emptyList()
     every { uninitializedClient.lastActiveSessionId } returns null
     every { uninitializedClient.signIn } returns null
     every { uninitializedClient.signUp } returns null
@@ -204,6 +207,7 @@ class ClerkTest {
     every { mockClient.lastActiveSessionId } returns null
     every { mockClient.sessions } returns listOf(mockSession)
     every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
     initializeClerkWithClient(mockClient)
 
     // When
@@ -222,6 +226,7 @@ class ClerkTest {
     every { mockClient.lastActiveSessionId } returns activeSessionId
     every { mockClient.sessions } returns listOf(mockSession)
     every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
     every { mockSession.id } returns differentSessionId
     initializeClerkWithClient(mockClient)
 
@@ -240,6 +245,7 @@ class ClerkTest {
     every { mockClient.lastActiveSessionId } returns activeSessionId
     every { mockClient.sessions } returns listOf(mockSession)
     every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
     every { mockSession.id } returns activeSessionId
     initializeClerkWithClient(mockClient)
 
@@ -248,6 +254,44 @@ class ClerkTest {
 
     // Then
     assertEquals(mockSession, session)
+  }
+
+  @Test
+  fun `session returns pending session when signed-in session is pending`() = runTest {
+    // Given
+    val pendingSessionId = "pending_session_id"
+
+    every { mockClient.lastActiveSessionId } returns pendingSessionId
+    every { mockClient.sessions } returns listOf(mockSession)
+    every { mockClient.activeSessions() } returns emptyList()
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
+    every { mockSession.id } returns pendingSessionId
+    initializeClerkWithClient(mockClient)
+
+    // When
+    val session = Clerk.session
+
+    // Then
+    assertEquals(mockSession, session)
+  }
+
+  @Test
+  fun `activeSession returns null when no active session exists`() = runTest {
+    // Given
+    val pendingSessionId = "pending_session_id"
+
+    every { mockClient.lastActiveSessionId } returns pendingSessionId
+    every { mockClient.sessions } returns listOf(mockSession)
+    every { mockClient.activeSessions() } returns emptyList()
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
+    every { mockSession.id } returns pendingSessionId
+    initializeClerkWithClient(mockClient)
+
+    // When
+    val activeSession = Clerk.activeSession
+
+    // Then
+    assertNull(activeSession)
   }
 
   @Test
@@ -270,6 +314,7 @@ class ClerkTest {
     every { mockClient.lastActiveSessionId } returns activeSessionId
     every { mockClient.sessions } returns listOf(mockSession)
     every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
     every { mockSession.id } returns activeSessionId
     every { mockSession.user } returns mockUser
     initializeClerkWithClient(mockClient)
@@ -301,6 +346,7 @@ class ClerkTest {
     every { mockClient.lastActiveSessionId } returns activeSessionId
     every { mockClient.sessions } returns listOf(mockSession)
     every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
     every { mockSession.id } returns activeSessionId
     initializeClerkWithClient(mockClient)
 
@@ -456,6 +502,7 @@ class ClerkTest {
     every { mockClient.lastActiveSessionId } returns activeSessionId
     every { mockClient.sessions } returns listOf(mockSession)
     every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
     every { mockSession.id } returns activeSessionId
     every { mockSession.user } returns mockUser
     initializeClerkWithClient(mockClient)
@@ -486,6 +533,7 @@ class ClerkTest {
     every { mockClient.lastActiveSessionId } returns activeSessionId
     every { mockClient.sessions } returns listOf(mockSession)
     every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
     every { mockSession.id } returns activeSessionId
     initializeClerkWithClient(mockClient)
 
@@ -506,6 +554,7 @@ class ClerkTest {
     every { mockClient.lastActiveSessionId } returns activeSessionId
     every { mockClient.sessions } returns listOf(mockSession)
     every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
     every { mockSession.id } returns activeSessionId
     every { mockSession.user } returns mockUser
     initializeClerkWithClient(mockClient)
@@ -531,6 +580,7 @@ class ClerkTest {
     every { mockClient.lastActiveSessionId } returns activeSessionId
     every { mockClient.sessions } returns listOf(mockSession)
     every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
     every { mockSession.id } returns activeSessionId
     every { mockSession.user } returns mockUser
     Clerk.updateClient(mockClient)

--- a/source/api/src/test/java/com/clerk/api/signout/SignOutServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signout/SignOutServiceTest.kt
@@ -95,6 +95,7 @@ class SignOutServiceTest {
     every { mockClient.lastActiveSessionId } returns activeSessionId
     every { mockClient.sessions } returns listOf(mockSession)
     every { mockClient.activeSessions() } returns listOf(mockSession)
+    every { mockClient.signedInSessions() } returns listOf(mockSession)
     every { mockClient.signIn } returns null
     every { mockClient.signUp } returns null
     every { mockClient.id } returns "test_client_id"
@@ -205,6 +206,7 @@ class SignOutServiceTest {
     every { emptyClient.lastActiveSessionId } returns null
     every { emptyClient.sessions } returns emptyList()
     every { emptyClient.activeSessions() } returns emptyList()
+    every { emptyClient.signedInSessions() } returns emptyList()
     every { emptyClient.signIn } returns null
     every { emptyClient.signUp } returns null
     every { emptyClient.id } returns null


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced `treatPendingAsSignedOut` configuration option to control how pending sessions are handled
  - Added new session access properties (`signedInSessions`, `signedInSession`, `activeSession`) for enhanced session management
  - Added `currentTask` property to sessions for convenient access to the current active task

<!-- end of auto-generated comment: release notes by coderabbit.ai -->