### PR TITLE
Account for pending sessions in Clerk SDK (MOBILE-399)

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/auth/AuthEvent.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/AuthEvent.kt
@@ -23,9 +23,12 @@ sealed interface AuthEvent {
   data object SignedOut : AuthEvent
 
   /**
-   * Emitted when the active session changes.
+   * Emitted when the current session changes.
    *
-   * @property session The new active session, or null if no session is active.
+   * This event fires whenever [Clerk.session] changes, which is based on
+   * [Client.lastActiveSessionId]. The session may have any status (including PENDING).
+   *
+   * @property session The new current session, or null if no session exists.
    */
   data class SessionChanged(val session: Session?) : AuthEvent
 

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -541,4 +541,134 @@ class ClerkTest {
     assertEquals(mockSession, Clerk.session)
     assertEquals(mockUser, Clerk.user)
   }
+
+  // region Pending Session Tests
+
+  @Test
+  fun `session returns matching session even when status is pending`() = runTest {
+    // Given - session with pending status matching lastActiveSessionId
+    val sessionId = "pending_session_id"
+    val pendingSession = mockk<Session>(relaxed = true)
+
+    every { pendingSession.id } returns sessionId
+    every { pendingSession.status } returns Session.SessionStatus.PENDING
+    every { pendingSession.user } returns mockUser
+    every { mockClient.lastActiveSessionId } returns sessionId
+    every { mockClient.sessions } returns listOf(pendingSession)
+    every { mockClient.activeSessions() } returns emptyList() // No active sessions
+    initializeClerkWithClient(mockClient)
+
+    // When
+    val session = Clerk.session
+
+    // Then - session should be returned even though it's pending
+    assertEquals(pendingSession, session)
+  }
+
+  @Test
+  fun `user returns user even when session is pending`() = runTest {
+    // Given - session with pending status
+    val sessionId = "pending_session_id"
+    val pendingSession = mockk<Session>(relaxed = true)
+
+    every { pendingSession.id } returns sessionId
+    every { pendingSession.status } returns Session.SessionStatus.PENDING
+    every { pendingSession.user } returns mockUser
+    every { mockClient.lastActiveSessionId } returns sessionId
+    every { mockClient.sessions } returns listOf(pendingSession)
+    every { mockClient.activeSessions() } returns emptyList()
+    initializeClerkWithClient(mockClient)
+
+    // When
+    val user = Clerk.user
+
+    // Then - user should be returned even though session is pending
+    assertEquals(mockUser, user)
+  }
+
+  @Test
+  fun `activeSession returns null when session is pending`() = runTest {
+    // Given - session with pending status
+    val sessionId = "pending_session_id"
+    val pendingSession = mockk<Session>(relaxed = true)
+
+    every { pendingSession.id } returns sessionId
+    every { pendingSession.status } returns Session.SessionStatus.PENDING
+    every { pendingSession.user } returns mockUser
+    every { mockClient.lastActiveSessionId } returns sessionId
+    every { mockClient.sessions } returns listOf(pendingSession)
+    every { mockClient.activeSessions() } returns emptyList()
+    initializeClerkWithClient(mockClient)
+
+    // When
+    val activeSession = Clerk.activeSession
+
+    // Then - activeSession should be null because session is pending
+    assertNull(activeSession)
+  }
+
+  @Test
+  fun `activeSession returns session when status is active`() = runTest {
+    // Given - session with active status
+    val sessionId = "active_session_id"
+    val activeSession = mockk<Session>(relaxed = true)
+
+    every { activeSession.id } returns sessionId
+    every { activeSession.status } returns Session.SessionStatus.ACTIVE
+    every { activeSession.user } returns mockUser
+    every { mockClient.lastActiveSessionId } returns sessionId
+    every { mockClient.sessions } returns listOf(activeSession)
+    every { mockClient.activeSessions() } returns listOf(activeSession)
+    initializeClerkWithClient(mockClient)
+
+    // When
+    val result = Clerk.activeSession
+
+    // Then - activeSession should be returned
+    assertEquals(activeSession, result)
+  }
+
+  @Test
+  fun `activeUser returns null when session is pending`() = runTest {
+    // Given - session with pending status
+    val sessionId = "pending_session_id"
+    val pendingSession = mockk<Session>(relaxed = true)
+
+    every { pendingSession.id } returns sessionId
+    every { pendingSession.status } returns Session.SessionStatus.PENDING
+    every { pendingSession.user } returns mockUser
+    every { mockClient.lastActiveSessionId } returns sessionId
+    every { mockClient.sessions } returns listOf(pendingSession)
+    every { mockClient.activeSessions() } returns emptyList()
+    initializeClerkWithClient(mockClient)
+
+    // When
+    val activeUser = Clerk.activeUser
+
+    // Then - activeUser should be null because session is pending
+    assertNull(activeUser)
+  }
+
+  @Test
+  fun `activeUser returns user when session is active`() = runTest {
+    // Given - session with active status
+    val sessionId = "active_session_id"
+    val activeSession = mockk<Session>(relaxed = true)
+
+    every { activeSession.id } returns sessionId
+    every { activeSession.status } returns Session.SessionStatus.ACTIVE
+    every { activeSession.user } returns mockUser
+    every { mockClient.lastActiveSessionId } returns sessionId
+    every { mockClient.sessions } returns listOf(activeSession)
+    every { mockClient.activeSessions() } returns listOf(activeSession)
+    initializeClerkWithClient(mockClient)
+
+    // When
+    val activeUser = Clerk.activeUser
+
+    // Then - activeUser should be returned
+    assertEquals(mockUser, activeUser)
+  }
+
+  // endregion
 }

--- a/source/ui/src/test/java/com/clerk/ui/signin/code/SignInFactorCodeViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/code/SignInFactorCodeViewModelTest.kt
@@ -81,41 +81,40 @@ class SignInFactorCodeViewModelTest {
   }
 
   @Test
-  fun attemptWithEmailCodeStrategyShouldCallAttemptEmailCodeAndSetSuccessState() =
-    runTest {
-      val factor = Factor(strategy = StrategyKeys.EMAIL_CODE)
-      val code = "123456"
+  fun attemptWithEmailCodeStrategyShouldCallAttemptEmailCodeAndSetSuccessState() = runTest {
+    val factor = Factor(strategy = StrategyKeys.EMAIL_CODE)
+    val code = "123456"
 
-      coEvery {
-        mockAttemptHandler.attemptEmailCode(
-          inProgressSignIn = mockSignIn,
-          code = code,
-          isSecondFactor = false,
-          onSuccessCallback = any(),
-          onErrorCallback = any(),
-        )
-      } coAnswers
-        {
-          val onSuccess = args[3] as suspend (SignIn) -> Unit
-          onSuccess(mockSignIn)
-        }
-
-      viewModel.attempt(factor, isSecondFactor = false, code)
-      testDispatcher.scheduler.advanceUntilIdle()
-
-      coVerify {
-        mockAttemptHandler.attemptEmailCode(
-          inProgressSignIn = mockSignIn,
-          code = code,
-          isSecondFactor = false,
-          onSuccessCallback = any(),
-          onErrorCallback = any(),
-        )
+    coEvery {
+      mockAttemptHandler.attemptEmailCode(
+        inProgressSignIn = mockSignIn,
+        code = code,
+        isSecondFactor = false,
+        onSuccessCallback = any(),
+        onErrorCallback = any(),
+      )
+    } coAnswers
+      {
+        val onSuccess = args[3] as suspend (SignIn) -> Unit
+        onSuccess(mockSignIn)
       }
-      viewModel.state.test {
-        assertEquals(AuthenticationViewState.Success.SignIn(mockSignIn), awaitItem())
-      }
+
+    viewModel.attempt(factor, isSecondFactor = false, code)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    coVerify {
+      mockAttemptHandler.attemptEmailCode(
+        inProgressSignIn = mockSignIn,
+        code = code,
+        isSecondFactor = false,
+        onSuccessCallback = any(),
+        onErrorCallback = any(),
+      )
     }
+    viewModel.state.test {
+      assertEquals(AuthenticationViewState.Success.SignIn(mockSignIn), awaitItem())
+    }
+  }
 
   @Test
   fun attemptWithPhoneCodeStrategyShouldCallAttemptFirstFactorPhoneCodeAndSetSuccessState() =


### PR DESCRIPTION
This pull request adds a new configuration option to the `Clerk` authentication SDK that controls how sessions with a `PENDING` status are treated. By default, pending sessions are considered signed out, but this can now be configured. The change includes updates to the session and user state logic, exposes the setting via `ClerkConfigurationOptions`, and adds comprehensive tests for the new behavior.

**Configuration and State Management Enhancements:**

* Added a new property `treatPendingAsSignedOut` to the `Clerk` object, allowing developers to configure whether sessions with status `PENDING` should be treated as signed out (default: `true`). This is set via `ClerkConfigurationOptions` during initialization. [[1]](diffhunk://#diff-19fa35ccb02c10b3c997c885afebe0df9916e4b05cc0c78cd267776f40b10124R120-R134) [[2]](diffhunk://#diff-19fa35ccb02c10b3c997c885afebe0df9916e4b05cc0c78cd267776f40b10124R492) [[3]](diffhunk://#diff-19fa35ccb02c10b3c997c885afebe0df9916e4b05cc0c78cd267776f40b10124R612-R624)
* Updated the session and user state logic in `updateSessionAndUserState` to respect the `treatPendingAsSignedOut` setting. When enabled and the session is pending, the user is treated as signed out (`null`).

**Testing Improvements:**

* Added a suite of tests to `ClerkTest` verifying the behavior of pending sessions and the `treatPendingAsSignedOut` configuration, including default behavior, toggling the setting, and edge cases.

## Summary of changes
