### PR TITLE
Fix docs workflow artifact version mismatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         ref: docs
         path: docs
-    - uses: actions/download-artifact@v7
+    - uses: actions/download-artifact@v6
       with:
         path: artifacts
     - name: Unzip and prepare docs


### PR DESCRIPTION
## Summary of changes

Fixed version mismatch in the docs workflow where `actions/upload-artifact@v6` and `actions/download-artifact@v7` are incompatible. The v7 download action expects a different artifact storage format than what v6 produces, causing the unzip step to fail. Updated to use matching versions (v6 for both).

This resolves the error: "cannot find or open artifacts/main/Docs.zip"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration.

**Note:** This is an internal infrastructure update with no impact on user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->