### PR TITLE
Add -o flag to unzip in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Unzip and prepare docs
       run: |
         ls -la artifacts/
-        unzip "artifacts/Docs.zip" -d docs/docs
+        unzip -o "artifacts/Docs.zip" -d docs/docs
     - name: Update git config
       working-directory: docs
       run: |


### PR DESCRIPTION
## Summary of changes

Add the `-o` (overwrite) flag to the `unzip` command in the docs publish job so it doesn't prompt for confirmation when overwriting existing files, which would hang in CI.