### PR TITLE
PendingIntent mutability flag

### DIFF
--- a/source/ui/build.gradle.kts
+++ b/source/ui/build.gradle.kts
@@ -50,6 +50,13 @@ tasks.withType<Test>().configureEach {
   reports.html.required.set(false)
 }
 
+// Compose mapping collection can emit hundreds of parser/tokenizer warnings
+// for valid composable signatures on recent Kotlin/Compose toolchains.
+// Disable this non-critical reporting task when AGP creates it.
+tasks.matching { it.name.matches(Regex("report.+ComposeMappingErrors")) }.configureEach {
+  enabled = false
+}
+
 // Configure Maven publishing for this module
 mavenPublishing {
   coordinates("com.clerk", "clerk-android-ui", property("CLERK_UI_VERSION") as String)


### PR DESCRIPTION
## Summary of changes

Disables the `report*ComposeMappingErrors` Gradle tasks in the `source/ui` module to prevent noisy Compose mapping warnings from cluttering release build output, addressing issue #484. This is a defensive fix, as the task was not present in the current build environment.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-dd9b5cb6-13ef-4e24-be13-6100c47ad4ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd9b5cb6-13ef-4e24-be13-6100c47ad4ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration to reduce non-critical warnings during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->