### PR TITLE
[codex] Update account screen labels

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
@@ -137,7 +137,7 @@ private fun AvatarHeaderView(
       Spacers.Vertical.Spacer8()
       ClerkButton(
         modifier = Modifier.defaultMinSize(minWidth = 120.dp),
-        text = stringResource(R.string.update_profile),
+        text = stringResource(R.string.edit_profile),
         onClick = onClickEdit,
         isEnabled = true,
         configuration =
@@ -163,7 +163,7 @@ private fun MainProfileActions(onClick: (UserProfileAction) -> Unit) {
   Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
     UserProfileIconActionRow(
       iconResId = R.drawable.ic_user,
-      text = stringResource(R.string.profile),
+      text = stringResource(R.string.manage_account),
       onClick = { onClick(UserProfileAction.Profile) },
     )
     HorizontalDivider(thickness = dp1, color = ClerkMaterialTheme.computedColors.border)

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/detail/UserProfileDetailView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/detail/UserProfileDetailView.kt
@@ -76,7 +76,7 @@ private fun UserProfileDetailViewImpl(
       topBar = {
         ClerkTopAppBar(
           onBackPressed = { userProfileState.navigateBack() },
-          title = stringResource(R.string.profile),
+          title = stringResource(R.string.manage_account),
           hasLogo = false,
         )
       },

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/update/UserProfileUpdateProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/update/UserProfileUpdateProfileView.kt
@@ -73,7 +73,7 @@ private fun UserProfileUpdateProfileViewImpl(
   ClerkMaterialTheme {
     ClerkThemedProfileScaffold(
       modifier = modifier,
-      title = stringResource(R.string.account),
+      title = stringResource(R.string.edit_profile),
       hasBackButton = true,
       horizontalPadding = dp0,
       onBackPressed = { userProfileState.navigateBack() },

--- a/source/ui/src/main/res/values-ar/strings.xml
+++ b/source/ui/src/main/res/values-ar/strings.xml
@@ -141,8 +141,8 @@
     <string name="account">الحساب</string>
     <string name="delete_account">حذف الحساب</string>
     <string name="security">الأمان</string>
-    <string name="update_profile">تحديث الملف الشخصي</string>
-    <string name="profile">الملف الشخصي</string>
+    <string name="edit_profile">تعديل الملف الشخصي</string>
+    <string name="manage_account">إدارة الحساب</string>
     <string name="log_out">تسجيل الخروج</string>
     <string name="take_a_photo">التقاط صورة</string>
     <string name="choose_photo">اختر صورة</string>

--- a/source/ui/src/main/res/values-de/strings.xml
+++ b/source/ui/src/main/res/values-de/strings.xml
@@ -141,8 +141,8 @@
     <string name="account">Konto</string>
     <string name="delete_account">Konto löschen</string>
     <string name="security">Sicherheit</string>
-    <string name="update_profile">Profil aktualisieren</string>
-    <string name="profile">Profil</string>
+    <string name="edit_profile">Profil bearbeiten</string>
+    <string name="manage_account">Konto verwalten</string>
     <string name="log_out">Abmelden</string>
     <string name="take_a_photo">Foto aufnehmen</string>
     <string name="choose_photo">Foto auswählen</string>

--- a/source/ui/src/main/res/values-el/strings.xml
+++ b/source/ui/src/main/res/values-el/strings.xml
@@ -141,8 +141,8 @@
     <string name="account">Λογαριασμός</string>
     <string name="delete_account">Διαγραφή λογαριασμού</string>
     <string name="security">Ασφάλεια</string>
-    <string name="update_profile">Ενημέρωση προφίλ</string>
-    <string name="profile">Προφίλ</string>
+    <string name="edit_profile">Επεξεργασία προφίλ</string>
+    <string name="manage_account">Διαχείριση λογαριασμού</string>
     <string name="log_out">Αποσύνδεση</string>
     <string name="take_a_photo">Λήψη φωτογραφίας</string>
     <string name="choose_photo">Επιλογή φωτογραφίας</string>

--- a/source/ui/src/main/res/values-es/strings.xml
+++ b/source/ui/src/main/res/values-es/strings.xml
@@ -141,8 +141,8 @@
     <string name="account">Cuenta</string>
     <string name="delete_account">Eliminar cuenta</string>
     <string name="security">Seguridad</string>
-    <string name="update_profile">Actualizar perfil</string>
-    <string name="profile">Perfil</string>
+    <string name="edit_profile">Editar perfil</string>
+    <string name="manage_account">Gestionar cuenta</string>
     <string name="log_out">Cerrar sesión</string>
     <string name="take_a_photo">Tomar una foto</string>
     <string name="choose_photo">Elegir foto</string>

--- a/source/ui/src/main/res/values-fr/strings.xml
+++ b/source/ui/src/main/res/values-fr/strings.xml
@@ -141,8 +141,8 @@
     <string name="account">Compte</string>
     <string name="delete_account">Supprimer le compte</string>
     <string name="security">Sécurité</string>
-    <string name="update_profile">Mettre à jour le profil</string>
-    <string name="profile">Profil</string>
+    <string name="edit_profile">Modifier le profil</string>
+    <string name="manage_account">Gérer le compte</string>
     <string name="log_out">Se déconnecter</string>
     <string name="take_a_photo">Prendre une photo</string>
     <string name="choose_photo">Choisir une photo</string>

--- a/source/ui/src/main/res/values-hi/strings.xml
+++ b/source/ui/src/main/res/values-hi/strings.xml
@@ -141,8 +141,8 @@
     <string name="account">खाता</string>
     <string name="delete_account">खाता हटाएं</string>
     <string name="security">सुरक्षा</string>
-    <string name="update_profile">प्रोफ़ाइल अपडेट करें</string>
-    <string name="profile">प्रोफ़ाइल</string>
+    <string name="edit_profile">प्रोफ़ाइल संपादित करें</string>
+    <string name="manage_account">खाता प्रबंधित करें</string>
     <string name="log_out">लॉग आउट करें</string>
     <string name="take_a_photo">फोटो लें</string>
     <string name="choose_photo">फोटो चुनें</string>

--- a/source/ui/src/main/res/values-it/strings.xml
+++ b/source/ui/src/main/res/values-it/strings.xml
@@ -141,8 +141,8 @@
     <string name="account">Account</string>
     <string name="delete_account">Elimina account</string>
     <string name="security">Sicurezza</string>
-    <string name="update_profile">Aggiorna profilo</string>
-    <string name="profile">Profilo</string>
+    <string name="edit_profile">Modifica profilo</string>
+    <string name="manage_account">Gestisci account</string>
     <string name="log_out">Esci</string>
     <string name="take_a_photo">Scatta una foto</string>
     <string name="choose_photo">Scegli foto</string>

--- a/source/ui/src/main/res/values-ja/strings.xml
+++ b/source/ui/src/main/res/values-ja/strings.xml
@@ -141,8 +141,8 @@
     <string name="account">アカウント</string>
     <string name="delete_account">アカウントを削除</string>
     <string name="security">セキュリティ</string>
-    <string name="update_profile">プロフィールを更新</string>
-    <string name="profile">プロフィール</string>
+    <string name="edit_profile">プロフィールを編集</string>
+    <string name="manage_account">アカウント管理</string>
     <string name="log_out">ログアウト</string>
     <string name="take_a_photo">写真を撮る</string>
     <string name="choose_photo">写真を選択</string>

--- a/source/ui/src/main/res/values-ko/strings.xml
+++ b/source/ui/src/main/res/values-ko/strings.xml
@@ -141,8 +141,8 @@
     <string name="account">계정</string>
     <string name="delete_account">계정 삭제</string>
     <string name="security">보안</string>
-    <string name="update_profile">프로필 업데이트</string>
-    <string name="profile">프로필</string>
+    <string name="edit_profile">프로필 편집</string>
+    <string name="manage_account">계정 관리</string>
     <string name="log_out">로그아웃</string>
     <string name="take_a_photo">사진 찍기</string>
     <string name="choose_photo">사진 선택</string>

--- a/source/ui/src/main/res/values-pt/strings.xml
+++ b/source/ui/src/main/res/values-pt/strings.xml
@@ -141,8 +141,8 @@
     <string name="account">Conta</string>
     <string name="delete_account">Excluir conta</string>
     <string name="security">Segurança</string>
-    <string name="update_profile">Atualizar perfil</string>
-    <string name="profile">Perfil</string>
+    <string name="edit_profile">Editar perfil</string>
+    <string name="manage_account">Gerenciar conta</string>
     <string name="log_out">Sair</string>
     <string name="take_a_photo">Tirar uma foto</string>
     <string name="choose_photo">Escolher foto</string>

--- a/source/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/source/ui/src/main/res/values-zh-rCN/strings.xml
@@ -141,8 +141,8 @@
     <string name="account">账户</string>
     <string name="delete_account">删除账户</string>
     <string name="security">安全</string>
-    <string name="update_profile">更新个人资料</string>
-    <string name="profile">个人资料</string>
+    <string name="edit_profile">编辑个人资料</string>
+    <string name="manage_account">管理账户</string>
     <string name="log_out">退出登录</string>
     <string name="take_a_photo">拍照</string>
     <string name="choose_photo">选择照片</string>

--- a/source/ui/src/main/res/values/strings.xml
+++ b/source/ui/src/main/res/values/strings.xml
@@ -143,8 +143,8 @@
     <string name="account">Account</string>
     <string name="delete_account">Delete account</string>
     <string name="security">Security</string>
-    <string name="update_profile">Update profile</string>
-    <string name="profile">Profile</string>
+    <string name="edit_profile">Edit profile</string>
+    <string name="manage_account">Manage account</string>
     <string name="log_out">Log out</string>
     <string name="take_a_photo">Take a photo</string>
     <string name="choose_photo">Choose photo</string>


### PR DESCRIPTION
This change ports the copy updates from the iOS commit `92290f011659985e641b5e2396469b5291178740` into `clerk-android` so that account management labels are consistent across platforms.

The issue users were seeing is that Android still displayed older profile wording in the user profile flow while iOS had already moved to updated terminology from product feedback. In practice, this meant Android showed "Profile" and "Update profile" in key account surfaces, which made the account section feel inconsistent and less clear compared with the newer wording.

The root cause was that Android UI components and resource bundles were still wired to legacy string keys (`profile` and `update_profile`) and their older translations. The iOS update introduced new copy keys and values (`Manage account` and `Edit profile`) but Android had not received the equivalent migration.

The fix updates all Android call sites in the account/profile flow to use new string resources and aligns localized values with iOS for every currently supported UI locale. Specifically, the account action row and profile detail title now use `manage_account`, while edit entry points and the update-profile page title now use `edit_profile`. Resource files were updated in `values`, `values-ar`, `values-de`, `values-el`, `values-es`, `values-fr`, `values-hi`, `values-it`, `values-ja`, `values-ko`, `values-pt`, and `values-zh-rCN`.

Validation was performed with a full UI module assemble: `./gradlew :source:ui:assemble`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated UI text labels for user profile management screens for improved clarity. Changed "Update Profile" to "Edit Profile" and "Profile" to "Manage Account" across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->