### PR TITLE
fix(ui): Filter disabled social providers in toOAuthProvidersList()

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -669,7 +669,9 @@ data class DeviceAttestationOptions(val applicationId: String, val cloudProjectN
  *   [UserSettings.SocialConfig].
  */
 fun Map<String, UserSettings.SocialConfig>.toOAuthProvidersList(): List<OAuthProvider> =
-  this.map { OAuthProvider.fromStrategy(it.value.strategy) }
+  this.values
+    .filter { it.enabled && it.authenticatable }
+    .map { OAuthProvider.fromStrategy(it.strategy) }
 
 fun SignIn.identifyingFirstFactor(strategy: String): Factor? =
   supportedFirstFactors?.firstOrNull { it.strategy == strategy && it.safeIdentifier == identifier }

--- a/source/api/src/test/java/com/clerk/api/sdk/ToOAuthProvidersListTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ToOAuthProvidersListTest.kt
@@ -1,0 +1,79 @@
+package com.clerk.api.sdk
+
+import com.clerk.api.network.model.environment.UserSettings
+import com.clerk.api.sso.OAuthProvider
+import com.clerk.api.toOAuthProvidersList
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ToOAuthProvidersListTest {
+
+  private fun socialConfig(
+    strategy: String,
+    enabled: Boolean = true,
+    authenticatable: Boolean = true,
+  ) =
+    UserSettings.SocialConfig(
+      enabled = enabled,
+      required = false,
+      authenticatable = authenticatable,
+      strategy = strategy,
+      notSelectable = false,
+      name = strategy.removePrefix("oauth_"),
+      logoUrl = null,
+    )
+
+  @Test
+  fun `returns only enabled and authenticatable providers`() {
+    val providers =
+      mapOf(
+        "oauth_google" to socialConfig("oauth_google", enabled = true, authenticatable = true),
+        "oauth_apple" to socialConfig("oauth_apple", enabled = false, authenticatable = true),
+        "oauth_facebook" to socialConfig("oauth_facebook", enabled = true, authenticatable = false),
+        "oauth_github" to socialConfig("oauth_github", enabled = false, authenticatable = false),
+      )
+
+    val result = providers.toOAuthProvidersList()
+
+    assertEquals(1, result.size)
+    assertEquals(OAuthProvider.GOOGLE, result[0])
+  }
+
+  @Test
+  fun `returns empty list when no providers are enabled and authenticatable`() {
+    val providers =
+      mapOf(
+        "oauth_google" to socialConfig("oauth_google", enabled = false, authenticatable = true),
+        "oauth_apple" to socialConfig("oauth_apple", enabled = true, authenticatable = false),
+      )
+
+    val result = providers.toOAuthProvidersList()
+
+    assertTrue(result.isEmpty())
+  }
+
+  @Test
+  fun `returns empty list for empty map`() {
+    val providers = emptyMap<String, UserSettings.SocialConfig>()
+
+    val result = providers.toOAuthProvidersList()
+
+    assertTrue(result.isEmpty())
+  }
+
+  @Test
+  fun `returns all providers when all are enabled and authenticatable`() {
+    val providers =
+      mapOf(
+        "oauth_google" to socialConfig("oauth_google"),
+        "oauth_apple" to socialConfig("oauth_apple"),
+      )
+
+    val result = providers.toOAuthProvidersList()
+
+    assertEquals(2, result.size)
+    assertTrue(result.contains(OAuthProvider.GOOGLE))
+    assertTrue(result.contains(OAuthProvider.APPLE))
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #500. The `toOAuthProvidersList()` extension function was returning **all** social providers without checking `enabled` or `authenticatable`, causing disabled social login buttons to appear in:

- **SignInFactorAlternativeMethodsView** ("Use another method" screen)
- **SignInFactorOneForgotPasswordView** (forgot password screen)

PR #500 fixed this in `AuthStartViewHelper` but missed these two call sites that use `toOAuthProvidersList()` directly.

## Changes

- **`Clerk.kt`**: Updated `toOAuthProvidersList()` to filter by `enabled && authenticatable` before mapping to `OAuthProvider`. This fixes all current callers and prevents future callers from hitting the same issue.
- **`ToOAuthProvidersListTest.kt`**: Added unit tests for the extension function covering enabled/disabled/authenticatable combinations.

## Root cause

`toOAuthProvidersList()` did zero filtering - it mapped every entry in the social providers map to an `OAuthProvider`. The initial sign-in screen (`AuthStartViewHelper`) had its own manual filtering (added in #500), but the alternative methods and forgot password screens relied on the unfiltered extension.

## Test plan

- [x] Unit tests pass for `toOAuthProvidersList()` (4 tests, all pass)
- [ ] Verify "Use another method" screen no longer shows disabled social providers
- [ ] Verify forgot password screen no longer shows disabled social providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth provider selection to exclude providers that are disabled or not authenticatable, preventing broken sign-in flows.

* **Tests**
  * Added comprehensive test coverage for OAuth provider filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->