### PR TITLE
fix(ui): hide signed-in profile button on auth start

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -143,6 +143,7 @@ internal fun AuthStartViewImpl(
     ClerkThemedAuthScaffold(
       modifier = modifier,
       hasBackButton = false,
+      showSignedInUserButton = false,
       title = authViewHelper.titleString(authState.mode),
       subtitle = authViewHelper.subtitleString(authState.mode),
       snackbarHostState = snackbarHostState,


### PR DESCRIPTION
### Motivation
- Prevent the signed-in user avatar/profile button from appearing on the initial auth start screen because that control is intended for session-task surfaces, not the auth entry view.

### Description
- Pass `showSignedInUserButton = false` into `ClerkThemedAuthScaffold` in `source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt` to disable the trailing signed-in avatar on the auth start screen.

### Testing
- Attempted `./gradlew spotlessCheck` and `./gradlew :source:ui:test --tests "com.clerk.ui.auth.AuthStartViewHelperTest"`, but both commands failed in this environment with Gradle error `25.0.1` (no successful automated test run available here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ce7bcba08322bec40a656e0a8f6b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden the signed-in user button in the authentication start screen to improve the user experience during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->