### PR TITLE
Fix reset password flow loop

### DIFF
--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -3,8 +3,6 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:ClerkComposeTheme.kt$@Composable private fun generateComputedColors(colors: ClerkColors): ComputedColors</ID>
-    <ID>LongMethod:AuthStartView.kt$@Composable internal fun AuthStartViewImpl( onAuthComplete: () -> Unit, modifier: Modifier = Modifier, authViewHelper: AuthStartViewHelper = AuthStartViewHelper(), clerkTheme: ClerkTheme? = null, authStartViewModel: AuthStartViewModel = viewModel(), )</ID>
-    <ID>LongMethod:AuthView.kt$@Composable fun AuthView(modifier: Modifier = Modifier, clerkTheme: ClerkTheme? = null)</ID>
     <ID>LongMethod:ClerkButton.kt$@PreviewLightDark @Composable private fun PreviewButton()</ID>
     <ID>LongMethod:ClerkPhoneNumberField.kt$@Composable private fun PhoneNumberInput( computedColors: ComputedColors, value: String, onValueChange: (String) -> Unit, countryCode: String, errorText: String? = null, )</ID>
     <ID>LongMethod:ClerkStandardButtonSnapshotTest.kt$ClerkStandardButtonSnapshotTest$@Test fun clerkButtonGallery()</ID>
@@ -14,13 +12,11 @@
     <ID>LongMethod:ClerkTextFieldSnapshotTest.kt$ClerkTextFieldSnapshotTest$@Test fun testClerkTextFieldError()</ID>
     <ID>LongMethod:ClerkTextFieldSnapshotTest.kt$ClerkTextFieldSnapshotTest$@Test fun testClerkTextFieldUnfocused()</ID>
     <ID>LongMethod:ConfigurationManager.kt$ConfigurationManager$private fun refreshClientAndEnvironment(options: ClerkConfigurationOptions?, retryCount: Int)</ID>
-    <ID>LongMethod:ConfigurationManager.kt$ConfigurationManager$private fun refreshClientAndEnvironment(options: ClerkConfigurationOptions?, retryCount: Int)</ID>
-    <ID>LongMethod:SignInFactorCodeView.kt$@Composable private fun SignInFactorCodeViewImpl( factor: Factor, modifier: Modifier = Modifier, viewModel: SignInFactorCodeViewModel = viewModel(), isSecondFactor: Boolean = false, isClientTrust: Boolean = false, onAuthComplete: () -> Unit, )</ID>
+    <ID>LongMethod:SignInFactorCodeView.kt$@Composable private fun SignInFactorCodeViewImpl( factor: Factor, modifier: Modifier = Modifier, isSecondFactor: Boolean = false, isClientTrust: Boolean = false, onAuthComplete: () -> Unit, )</ID>
     <ID>LongMethod:SignUpCollectFieldView.kt$@Composable private fun SignUpCollectFieldViewImpl( collectField: CollectField, collectFieldHelper: CollectFieldHelper, onAuthComplete: () -> Unit, modifier: Modifier = Modifier, viewModel: CollectFieldViewModel = viewModel(), )</ID>
     <ID>LongMethod:SignUpCompleteProfileView.kt$@Composable private fun InputRow( firstEnabled: Boolean, lastEnabled: Boolean, first: String, last: String, onFirstChange: (String) -> Unit, onLastChange: (String) -> Unit, onFocusChange: (CompleteProfileField) -> Unit = {}, )</ID>
     <ID>LongMethod:SignUpCompleteProfileView.kt$@Composable private fun SignUpCompleteProfileImpl( onAuthComplete: () -> Unit, modifier: Modifier = Modifier, firstName: String = "", lastName: String = "", firstNameEnabled: Boolean = false, lastNameEnabled: Boolean = false, legalConsentMissing: Boolean = false, viewModel: CompleteProfileViewModel = viewModel(), )</ID>
     <ID>LongMethod:UserProfileSecurityView.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun UserProfileSecurityMainContent( isPasswordEnabled: Boolean, isPasskeyEnabled: Boolean, isMfaEnabled: Boolean, isDeleteSelfEnabled: Boolean, snackbarHostState: SnackbarHostState, sessions: ImmutableList&lt;Session>, )</ID>
-    <ID>LongParameterList:AuthStartView.kt$( authViewHelper: AuthStartViewHelper, phoneNumberFieldIsActive: Boolean, authStartPhoneNumber: String, authStartIdentifier: String, onPhoneNumberChange: (String) -> Unit, onIdentifierChange: (String) -> Unit, )</ID>
     <ID>LongParameterList:ClerkButton.kt$( isLoading: Boolean, icons: ClerkButtonIcons, isEnabled: Boolean, text: String?, size: ClerkButtonConfiguration.Size, paddingValues: PaddingValues, tokens: ButtonStyleTokens, )</ID>
     <ID>LongParameterList:ClerkButton.kt$( text: String?, onClick: () -> Unit, clerkButtonState: ClerkButtonState, configuration: ClerkButtonConfiguration, paddingValues: PaddingValues, interactionSource: MutableInteractionSource, modifier: Modifier = Modifier, icons: ClerkButtonIcons = ClerkButtonDefaults.icons(), clerkTheme: ClerkTheme? = null, )</ID>
     <ID>LongParameterList:ClerkTypographyDefaults.kt$ClerkTypographyBuilder$( var displaySmall: TextStyle, var headlineLarge: TextStyle, var headlineMedium: TextStyle, var headlineSmall: TextStyle, var titleMedium: TextStyle, var titleSmall: TextStyle, var bodyLarge: TextStyle, var bodyMedium: TextStyle, var bodySmall: TextStyle, var labelMedium: TextStyle, var labelSmall: TextStyle, )</ID>
@@ -37,7 +33,6 @@
     <ID>MagicNumber:DeviceAttestationHelper.kt$DeviceAttestationHelper$8</ID>
     <ID>MagicNumber:UiActivity1.kt$UiActivity1$0xFFF9F9F9</ID>
     <ID>MagicNumber:UiActivity2.kt$UiActivity2$0xFFF9F9F9</ID>
-    <ID>MatchingDeclarationName:ColorUtils.kt$DangerPalette</ID>
     <ID>NestedBlockDepth:ClientSyncingMiddleware.kt$ClientSyncingMiddleware$override fun intercept(chain: Interceptor.Chain): Response</ID>
     <ID>ReturnCount:ConfigurationManager.kt$ConfigurationManager$fun reinitialize(): Boolean</ID>
     <ID>ReturnCount:DeviceAssertionMiddleware.kt$DeviceAssertionInterceptor.DeviceAttestationManager$suspend fun performDeviceAssertion(request: Request, error: ClerkError): Boolean</ID>

--- a/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeView.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.clerk.api.Clerk
 import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.R
@@ -82,17 +83,18 @@ fun SignInFactorCodeView(
  *
  * @param factor The authentication factor to process
  * @param modifier Optional modifier for styling
- * @param viewModel The view model managing the sign-in state (injected via Compose)
  */
 @Composable
 private fun SignInFactorCodeViewImpl(
   factor: Factor,
   modifier: Modifier = Modifier,
-  viewModel: SignInFactorCodeViewModel = viewModel(),
   isSecondFactor: Boolean = false,
   isClientTrust: Boolean = false,
   onAuthComplete: () -> Unit,
 ) {
+  val signInId = Clerk.auth.currentSignIn?.id ?: "no-sign-in"
+  val viewModel: SignInFactorCodeViewModel =
+    viewModel(key = "sign-in-code-$signInId-$isSecondFactor")
   val authState = LocalAuthState.current
   val state by viewModel.state.collectAsStateWithLifecycle()
   val verificationTextState by viewModel.verificationUiState.collectAsStateWithLifecycle()
@@ -104,12 +106,11 @@ private fun SignInFactorCodeViewImpl(
     authState = authState,
     state = state,
     snackbarHostState = snackbarHostState,
-    onAuthComplete = {
-      onAuthComplete()
+    onAuthComplete = onAuthComplete,
+    onReset = {
       viewModel.resetState()
       viewModel.resetVerificationState()
     },
-    onReset = { viewModel.resetState() },
   )
   ClerkThemedAuthScaffold(
     modifier = modifier,
@@ -128,6 +129,7 @@ private fun SignInFactorCodeViewImpl(
       onTextChange = {
         if (verificationTextState is VerificationUiState.Error) {
           viewModel.resetState()
+          viewModel.resetVerificationState()
         }
         if (it.length == 6) {
           viewModel.attempt(factor, isSecondFactor = isSecondFactor, code = it)

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/forgot/SignInFactorOneForgotPasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/forgot/SignInFactorOneForgotPasswordView.kt
@@ -77,7 +77,6 @@ fun SignInFactorOneForgotPasswordView(
  * @param alternativeFactors A list of alternative factors the user can use to sign in.
  * @param socialProviders A list of social providers available for sign-in.
  * @param modifier The [Modifier] to be applied to the view.
- * @param viewModel The [ForgotPasswordViewModel] for handling the view's logic.
  * @param onClickFactor A callback to be invoked when the user selects an alternative factor.
  */
 @Composable
@@ -86,10 +85,11 @@ private fun SignInFactorOneForgotPasswordViewImpl(
   socialProviders: ImmutableList<OAuthProvider>,
   onClickFactor: (Factor) -> Unit,
   modifier: Modifier = Modifier,
-  viewModel: ForgotPasswordViewModel = viewModel(),
   textIconHelper: TextIconHelper = TextIconHelper(),
   onAuthComplete: () -> Unit,
 ) {
+  val signInId = Clerk.auth.currentSignIn?.id ?: "no-sign-in"
+  val viewModel: ForgotPasswordViewModel = viewModel(key = "forgot-password-$signInId")
   val authState = LocalAuthState.current
   val context = LocalContext.current
   val state by viewModel.state.collectAsStateWithLifecycle()
@@ -97,17 +97,28 @@ private fun SignInFactorOneForgotPasswordViewImpl(
 
   LaunchedEffect(state) {
     when (val s = state) {
-      is ResetPasswordViewState.Error ->
+      is ResetPasswordViewState.Error -> {
         snackbarHostState.showSnackbar(
           s.message ?: context.getString(R.string.something_went_wrong_please_try_again)
         )
-      ResetPasswordViewState.NotStarted -> authState.clearBackStack()
-      is ResetPasswordViewState.ResetFactor ->
+        viewModel.resetState()
+      }
+      ResetPasswordViewState.NotStarted -> {
+        authState.clearBackStack()
+        viewModel.resetState()
+      }
+      is ResetPasswordViewState.ResetFactor -> {
         authState.navigateTo(AuthDestination.SignInFactorOne(factor = s.factor))
-      is ResetPasswordViewState.Success.SignIn ->
+        viewModel.resetState()
+      }
+      is ResetPasswordViewState.Success.SignIn -> {
         authState.setToStepForStatus(s.signIn, onAuthComplete)
-      is ResetPasswordViewState.Success.SignUp ->
+        viewModel.resetState()
+      }
+      is ResetPasswordViewState.Success.SignUp -> {
         authState.setToStepForStatus(s.signUp, onAuthComplete)
+        viewModel.resetState()
+      }
       else -> {}
     }
   }

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.clerk.api.Clerk
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.R
 import com.clerk.ui.auth.AuthState
@@ -59,25 +60,31 @@ fun SignInSetNewPasswordView(
  * The internal implementation of the [SignInSetNewPasswordView].
  *
  * @param modifier The [Modifier] to be applied to the view.
- * @param viewModel The [ResetPasswordViewModel] used to manage the state and actions of the view.
  */
 @Composable
 private fun SignInSetNewPasswordViewImpl(
   modifier: Modifier = Modifier,
-  viewModel: ResetPasswordViewModel = viewModel(),
   onAuthComplete: () -> Unit,
 ) {
+  val signInId = Clerk.auth.currentSignIn?.id ?: "no-sign-in"
+  val viewModel: ResetPasswordViewModel = viewModel(key = "reset-password-$signInId")
   val authState = LocalAuthState.current
   val snackbarHostState = remember { SnackbarHostState() }
-  var passwordsMatch by remember { mutableStateOf(true) }
   var signOutOtherDevices by remember { mutableStateOf(false) }
   val state by viewModel.state.collectAsStateWithLifecycle()
+  val passwordsMatch by
+    remember(authState.signInNewPassword, authState.signInConfirmNewPassword) {
+      derivedStateOf {
+        authState.signInNewPassword == authState.signInConfirmNewPassword ||
+          authState.signInConfirmNewPassword.isBlank()
+      }
+    }
 
   val isButtonEnabled by remember {
     derivedStateOf {
-      authState.signInNewPassword.isNotBlank() ||
-        authState.signInConfirmNewPassword.isNotBlank() ||
-        !passwordsMatch
+      authState.signInNewPassword.isNotBlank() &&
+        authState.signInConfirmNewPassword.isNotBlank() &&
+        passwordsMatch
     }
   }
 
@@ -105,8 +112,6 @@ private fun SignInSetNewPasswordViewImpl(
       onClick = {
         if (authState.signInNewPassword == authState.signInConfirmNewPassword) {
           viewModel.setNewPassword(authState.signInNewPassword, signOutOtherDevices)
-        } else {
-          passwordsMatch = false
         }
       },
       isLoading = state is AuthenticationViewState.Loading,
@@ -119,6 +124,7 @@ private fun SignInSetNewPasswordViewImpl(
 
 @Composable
 private fun PasswordInputs(authState: AuthState, passwordsMatch: Boolean) {
+  val showPasswordMismatchError = authState.signInConfirmNewPassword.isNotBlank() && !passwordsMatch
   ClerkTextField(
     value = authState.signInNewPassword,
     onValueChange = { authState.signInNewPassword = it },
@@ -133,8 +139,8 @@ private fun PasswordInputs(authState: AuthState, passwordsMatch: Boolean) {
     label = stringResource(R.string.confirm_password),
     visualTransformation = PasswordVisualTransformation(),
     inputContentType = ContentType.Password,
-    isError = !passwordsMatch,
-    supportingText = if (!passwordsMatch) "Passwords don't match" else null,
+    isError = showPasswordMismatchError,
+    supportingText = if (showPasswordMismatchError) "Passwords don't match" else null,
   )
 }
 


### PR DESCRIPTION
## Summary of changes
This pull request primarily refactors how view models are provided and managed in several authentication-related Compose views, ensuring that each view model instance is correctly scoped to the current sign-in session. It also improves state reset handling and enhances the password matching logic for better UX and reliability. The most important changes are grouped below:

### ViewModel Scoping and Initialization

* Refactored all relevant Compose authentication views (`SignInFactorCodeViewImpl`, `SignInFactorOneForgotPasswordViewImpl`, and `SignInSetNewPasswordViewImpl`) to initialize their view models using a unique key based on the current sign-in session (e.g., `sign-in-code-$signInId-$isSecondFactor`). This ensures that view models are properly scoped and do not leak state between sign-in attempts. [[1]](diffhunk://#diff-89caaa67470e52d7b369847a4c65640c3e2ae9bb2180475280fa175a138609d4L85-R97) [[2]](diffhunk://#diff-85b90945912414dc47858dc88c05e91a5be21d2d547877213d06c7f52f29e045L89-R121) [[3]](diffhunk://#diff-1547c83257dd8c1a1ddd71a73b45e8dbfd5b16a7e5587b83ec9de3150a0b802dL62-R87)

### State Management and Reset Handling

* Improved state reset logic in authentication flows by ensuring that view model state is reset after error or navigation events, preventing stale state from affecting subsequent authentication attempts. This includes resetting both the main and verification states where appropriate. [[1]](diffhunk://#diff-89caaa67470e52d7b369847a4c65640c3e2ae9bb2180475280fa175a138609d4L107-L112) [[2]](diffhunk://#diff-89caaa67470e52d7b369847a4c65640c3e2ae9bb2180475280fa175a138609d4R132) [[3]](diffhunk://#diff-85b90945912414dc47858dc88c05e91a5be21d2d547877213d06c7f52f29e045L89-R121)

### Password Matching UX Improvements

* Enhanced the password matching logic in the "Set New Password" screen: the "passwords don't match" error is now only shown when the confirm password field is not blank and the passwords differ, and the submit button is only enabled when both fields are filled and match. [[1]](diffhunk://#diff-1547c83257dd8c1a1ddd71a73b45e8dbfd5b16a7e5587b83ec9de3150a0b802dL62-R87) [[2]](diffhunk://#diff-1547c83257dd8c1a1ddd71a73b45e8dbfd5b16a7e5587b83ec9de3150a0b802dL108-L109) [[3]](diffhunk://#diff-1547c83257dd8c1a1ddd71a73b45e8dbfd5b16a7e5587b83ec9de3150a0b802dR127) [[4]](diffhunk://#diff-1547c83257dd8c1a1ddd71a73b45e8dbfd5b16a7e5587b83ec9de3150a0b802dL136-R143)

### Documentation and Baseline Updates

* Updated KDoc comments to reflect the removal of direct view model parameters from composable functions, clarifying that view models are now internally managed. [[1]](diffhunk://#diff-85b90945912414dc47858dc88c05e91a5be21d2d547877213d06c7f52f29e045L80) [[2]](diffhunk://#diff-1547c83257dd8c1a1ddd71a73b45e8dbfd5b16a7e5587b83ec9de3150a0b802dL62-R87) [[3]](diffhunk://#diff-89caaa67470e52d7b369847a4c65640c3e2ae9bb2180475280fa175a138609d4L85-R97)
* Cleaned up the Detekt baseline by removing entries for methods and parameters that no longer exist after refactoring, ensuring code quality tools reflect the current codebase. [[1]](diffhunk://#diff-da3b370e5e24bd214517daea228fa1e73d82da98e9134978ffb0ee66af3a7a01L6-L7) [[2]](diffhunk://#diff-da3b370e5e24bd214517daea228fa1e73d82da98e9134978ffb0ee66af3a7a01L17-L23) [[3]](diffhunk://#diff-da3b370e5e24bd214517daea228fa1e73d82da98e9134978ffb0ee66af3a7a01L40)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state management in authentication flows to prevent stale state during sign-in transitions.
  * Enhanced password mismatch error handling in password reset flow.
  * Fixed state reset behavior in forgot password and sign-in code verification flows to ensure proper cleanup between operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->