### PR TITLE
Downgrade Kotlin toolchain to 2.1.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ adsMobileSdk = "0.21.0-beta01"
 activityKtx = "1.12.4"
 agp = "8.13.2"
 appcompat = "1.7.1"
-automap = "0.1.2"
+automap = "0.1.1"
 composeBom = "2026.02.01"
 core = "1.7.0"
 coreKtxVersion = "1.7.0"
@@ -11,14 +11,14 @@ detekt = "1.23.8"
 dokka = "2.1.0"
 firebase-appDistrubution = "5.2.1"
 googleGms = "4.4.4"
-ksp = "2.3.6"
+ksp = "2.1.20-1.0.31"
 lifecycleProcess = "2.10.0"
 material3 = "1.4.0"
-materialKolor = "4.1.1"
-mavenPublish = "0.36.0"
+materialKolor = "2.1.1"
+mavenPublish = "0.35.0"
 navigation3 = "1.0.1"
 navigationCompose = "2.9.7"
-okhttp = "5.3.2"
+okhttp = "4.12.0"
 retrofit = "3.0.0"
 robolectric = "4.16.1"
 runner = "1.7.0"
@@ -26,14 +26,14 @@ sortDependencies = "0.16"
 spotless = "8.3.0"
 turbineVersion = "1.2.1"
 uiToolingPreviewAndroid = "1.10.4"
-kotlinStdlib = "2.3.10"
-kotlinTest = "2.3.10"
-paparazziPlugin = "2.0.0-alpha04"
+kotlinStdlib = "2.1.20"
+kotlinTest = "2.1.20"
+paparazziPlugin = "2.0.0-alpha02"
 
 # Build Versions -- Do not delete
 jdk = "17"
 jvmTarget = "17"
-kotlin = "2.3.10"
+kotlin = "2.1.20"
 minSdk = "24"
 compileSdk = "36"
 
@@ -64,8 +64,8 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 clerk-automap-annotations = { module = "com.clerk:automap-annotations", version.ref = "automap" }
 clerk-automap-processor = { module = "com.clerk:automap-processor", version.ref = "automap" }
-coil = "io.coil-kt.coil3:coil-compose:3.4.0"
-coil-okhttp = "io.coil-kt.coil3:coil-network-okhttp:3.4.0"
+coil = "io.coil-kt.coil3:coil-compose:3.2.0"
+coil-okhttp = "io.coil-kt.coil3:coil-network-okhttp:3.2.0"
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 compose-lints = "com.slack.lint.compose:compose-lint-checks:1.4.2"
 core-ktx = { module = "androidx.test:core-ktx", version.ref = "coreKtxVersion" }
@@ -80,12 +80,12 @@ kotlinx-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2"
 kotlinx-coroutines-test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
 kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.7.1-0.6.x-compat"
 kotlinx-immutable = "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0"
-kotlinx-serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0"
+kotlinx-serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1"
 ksp-api = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "ksp" }
-ktor-client-core = "io.ktor:ktor-client-core:3.4.1"
-ktor-client-negototiation = "io.ktor:ktor-client-content-negotiation:3.4.1"
-ktor-client-okhttp = "io.ktor:ktor-client-okhttp:3.4.1"
-ktor-serialization-kotlinx-json = "io.ktor:ktor-serialization-kotlinx-json:3.4.1"
+ktor-client-core = "io.ktor:ktor-client-core:3.1.3"
+ktor-client-negototiation = "io.ktor:ktor-client-content-negotiation:3.1.3"
+ktor-client-okhttp = "io.ktor:ktor-client-okhttp:3.1.3"
+ktor-serialization-kotlinx-json = "io.ktor:ktor-serialization-kotlinx-json:3.1.3"
 material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
 materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
 mockito = "org.mockito:mockito-core:5.22.0"
@@ -101,7 +101,7 @@ turbine = { module = "app.cash.turbine:turbine", version.ref = "turbineVersion" 
 versioning-plugin = { module = "org.jetbrains.dokka:versioning-plugin", version.ref = "dokka" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "ui-tooling-preview-android", version.ref = "uiToolingPreviewAndroid" }
-paparazzi = "app.cash.paparazzi:paparazzi:2.0.0-alpha04"
+paparazzi = "app.cash.paparazzi:paparazzi:2.0.0-alpha02"
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activityKtx" }
 
 [plugins]


### PR DESCRIPTION
Summary
- align Kotlin, stdlib, and related tooling (KSP, kotlinx serialization, Ktor, Coil, Paparazzi, MaterialKolor, okHttp, Maven Publish plugin) with Kotlin 2.1.20
- ensure dependency versions match the downgraded toolchain and Kotlin compatibility matrix
- keep Gradle version catalog coherent with the requested Kotlin version roll-back

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple library and plugin dependencies to version-aligned releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->