### PR TITLE
fix(ui): remove unused ads-mobile-sdk dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-adsMobileSdk = "0.21.0-beta01"
 activityKtx = "1.13.0"
 agp = "8.13.2"
 appcompat = "1.7.1"
@@ -40,7 +39,6 @@ compileSdk = "36"
 
 [libraries]
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityKtx" }
-ads-mobile-sdk = { group = "com.google.android.libraries.ads.mobile.sdk", name = "ads-mobile-sdk", version.ref = "adsMobileSdk" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-arch-test = "androidx.arch.core:core-testing:2.2.0"
 androidx-browser = "androidx.browser:browser:1.10.0"

--- a/source/ui/build.gradle.kts
+++ b/source/ui/build.gradle.kts
@@ -100,7 +100,6 @@ dependencies {
   api(projects.source.telemetry)
 
   implementation(platform(libs.compose.bom))
-  implementation(libs.ads.mobile.sdk)
   implementation(libs.androidx.appcompat)
   implementation(libs.androidx.compose.foundation)
   implementation(libs.androidx.compose.icons)


### PR DESCRIPTION
## Summary

- Remove the unused `ads-mobile-sdk` transitive dependency from `clerk-android-ui`
- This dependency (`com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:0.21.0-beta01`) was explicitly declared but never imported in any source file
- It causes duplicate class errors when used alongside `react-native-google-mobile-ads` or any library depending on `play-services-ads-api`, because both packages contain the same `com.google.android.gms.ads.*` classes

## Reproducing the issue

Using `@clerk/expo@3.1.6` + `react-native-google-mobile-ads@15.8.3`, running `./gradlew checkDebugDuplicateClasses` produces ~50 duplicate class errors:

```
Duplicate class com.google.android.gms.ads.AdError found in modules
  ads-mobile-sdk-0.21.0-beta01.aar
  play-services-ads-api-24.6.0.aar
```

After this fix, the build passes cleanly.

## Test plan

- [x] Reproduced duplicate class error with a clean Expo project (`@clerk/expo@3.1.6` + `react-native-google-mobile-ads@15.8.3`)
- [x] Applied fix (clerk-android-ui built from this branch) — `checkDebugDuplicateClasses` passes
- [x] Verified `ads-mobile-sdk` has zero imports in the `source/ui/src` codebase
- [x] Verified the published POM no longer includes `ads-mobile-sdk`

Fixes clerk/javascript#8237