### PR TITLE
Improve credential flows and auth UI based on Expo feedback

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -1,5 +1,7 @@
 package com.clerk.api
 
+import android.app.Activity
+import android.app.Application
 import android.content.Context
 import com.clerk.api.Clerk.activeSession
 import com.clerk.api.Clerk.activeUser
@@ -76,6 +78,43 @@ object Clerk {
 
   /** Application context used for setting up deep links and SSO Receivers */
   internal var applicationContext: WeakReference<Context>? = null
+
+  /** The current foreground activity used for Credential Manager operations. */
+  internal var currentActivity: WeakReference<Activity>? = null
+
+  private var trackedApplication: Application? = null
+
+  private val activityLifecycleCallbacks =
+    object : Application.ActivityLifecycleCallbacks {
+      override fun onActivityCreated(activity: Activity, savedInstanceState: android.os.Bundle?) {
+        currentActivity = WeakReference(activity)
+      }
+
+      override fun onActivityStarted(activity: Activity) {
+        currentActivity = WeakReference(activity)
+      }
+
+      override fun onActivityResumed(activity: Activity) {
+        currentActivity = WeakReference(activity)
+      }
+
+      override fun onActivityPaused(activity: Activity) = Unit
+
+      override fun onActivityStopped(activity: Activity) {
+        if (currentActivity?.get() == activity && !activity.isChangingConfigurations) {
+          currentActivity = null
+        }
+      }
+
+      override fun onActivitySaveInstanceState(activity: Activity, outState: android.os.Bundle) =
+        Unit
+
+      override fun onActivityDestroyed(activity: Activity) {
+        if (currentActivity?.get() == activity) {
+          currentActivity = null
+        }
+      }
+    }
 
   internal var applicationId: String? = null
 
@@ -520,9 +559,16 @@ object Clerk {
     options: ClerkConfigurationOptions? = null,
     theme: ClerkTheme? = null,
   ) {
+    val appContext = context.applicationContext
     this.debugMode = options?.enableDebugMode == true
     this.proxyUrl = options?.proxyUrl
-    this.applicationContext = WeakReference(context)
+    this.applicationContext = WeakReference(appContext)
+    val application = appContext as? Application
+    if (application != null && trackedApplication !== application) {
+      trackedApplication?.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
+      application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+      trackedApplication = application
+    }
     this.customTheme = theme
     this.telemetryEnabled = options?.telemetryEnabled ?: true
     configurationManager.configure(
@@ -593,6 +639,8 @@ object Clerk {
   internal fun updateEnvironment(environment: Environment) {
     this.environment = environment
   }
+
+  internal fun credentialActivity(): Activity? = currentActivity?.get()
 
   /**
    * Internal method to update the client and trigger state updates.

--- a/source/api/src/main/kotlin/com/clerk/api/credentials/CredentialFlowException.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/credentials/CredentialFlowException.kt
@@ -86,16 +86,16 @@ internal fun classifyCreateCredentialFailure(
   return ClerkResult.unknownFailure(classified)
 }
 
-internal val ClerkResult.Failure<ClerkErrorResponse>.credentialFlowUiMessage: String?
+private val ClerkResult.Failure<ClerkErrorResponse>.credentialFlowUiMessage: String?
   get() =
     (throwable as? CredentialFlowException)?.userMessage
       ?: error?.errors?.firstOrNull()?.longMessage
       ?: error?.errors?.firstOrNull()?.message
 
-internal val ClerkResult.Failure<ClerkErrorResponse>.shouldSuppressCredentialFlowError: Boolean
+val ClerkResult.Failure<ClerkErrorResponse>.shouldSuppressCredentialFlowError: Boolean
   get() = (throwable as? CredentialFlowException)?.suppressUserFacingError == true
 
-internal val ClerkResult.Failure<ClerkErrorResponse>.resolvedCredentialFlowMessage: String
+val ClerkResult.Failure<ClerkErrorResponse>.resolvedCredentialFlowMessage: String
   get() = credentialFlowUiMessage ?: errorMessage
 
 private fun Throwable.isActivityContextFailure(): Boolean {

--- a/source/api/src/main/kotlin/com/clerk/api/credentials/CredentialFlowException.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/credentials/CredentialFlowException.kt
@@ -1,0 +1,105 @@
+package com.clerk.api.credentials
+
+import androidx.credentials.exceptions.CreateCredentialCancellationException
+import androidx.credentials.exceptions.CreateCredentialException
+import androidx.credentials.exceptions.CreateCredentialProviderConfigurationException
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException
+import androidx.credentials.exceptions.NoCredentialException
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.network.serialization.errorMessage
+import com.clerk.api.signin.SignIn
+
+internal sealed class CredentialFlowException(
+  message: String,
+  internal open val userMessage: String? = null,
+  internal open val suppressUserFacingError: Boolean = false,
+) : IllegalStateException(message) {
+
+  internal class NoGoogleAccount :
+    CredentialFlowException(
+      message = "No Google account is available on this device.",
+      userMessage =
+        "No Google account available. Add one in Settings or use another sign-in method.",
+    )
+
+  internal class NoSavedCredential :
+    CredentialFlowException(
+      message = "No saved credentials are available on this device.",
+      userMessage = "No saved credentials are available on this device. Try another sign-in method.",
+    )
+
+  internal class UserCancelled :
+    CredentialFlowException(
+      message = "The credential flow was cancelled by the user.",
+      suppressUserFacingError = true,
+    )
+
+  internal class MissingActivity :
+    CredentialFlowException(
+      message = "Credential Manager requires an active Activity context.",
+      userMessage = "Authentication requires an active screen. Try again from the app.",
+    )
+
+  internal class ProviderUnavailable :
+    CredentialFlowException(
+      message = "Credential Manager is not available for this flow.",
+      userMessage =
+        "This sign-in method is not available on this device right now. Try another sign-in method.",
+    )
+}
+
+internal fun classifyGetCredentialFailure(
+  exception: GetCredentialException,
+  credentialTypes: List<SignIn.CredentialType>,
+): ClerkResult.Failure<ClerkErrorResponse> {
+  val classified =
+    when {
+      exception is GetCredentialCancellationException -> CredentialFlowException.UserCancelled()
+      exception is NoCredentialException &&
+        credentialTypes == listOf(SignIn.CredentialType.GOOGLE) ->
+        CredentialFlowException.NoGoogleAccount()
+      exception is NoCredentialException -> CredentialFlowException.NoSavedCredential()
+      exception is GetCredentialProviderConfigurationException ->
+        CredentialFlowException.ProviderUnavailable()
+      exception.isActivityContextFailure() -> CredentialFlowException.MissingActivity()
+      else -> exception
+    }
+
+  return ClerkResult.unknownFailure(classified)
+}
+
+internal fun classifyCreateCredentialFailure(
+  exception: CreateCredentialException
+): ClerkResult.Failure<ClerkErrorResponse> {
+  val classified =
+    when {
+      exception is CreateCredentialCancellationException -> CredentialFlowException.UserCancelled()
+      exception is CreateCredentialProviderConfigurationException ->
+        CredentialFlowException.ProviderUnavailable()
+      exception.isActivityContextFailure() -> CredentialFlowException.MissingActivity()
+      else -> exception
+    }
+
+  return ClerkResult.unknownFailure(classified)
+}
+
+internal val ClerkResult.Failure<ClerkErrorResponse>.credentialFlowUiMessage: String?
+  get() =
+    (throwable as? CredentialFlowException)?.userMessage
+      ?: error?.errors?.firstOrNull()?.longMessage
+      ?: error?.errors?.firstOrNull()?.message
+
+internal val ClerkResult.Failure<ClerkErrorResponse>.shouldSuppressCredentialFlowError: Boolean
+  get() = (throwable as? CredentialFlowException)?.suppressUserFacingError == true
+
+internal val ClerkResult.Failure<ClerkErrorResponse>.resolvedCredentialFlowMessage: String
+  get() = credentialFlowUiMessage ?: errorMessage
+
+private fun Throwable.isActivityContextFailure(): Boolean {
+  val detail = message.orEmpty()
+  return detail.contains("Activity-based context", ignoreCase = true) ||
+    detail.contains("selector UI", ignoreCase = true)
+}

--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
@@ -1,6 +1,5 @@
 package com.clerk.api.passkeys
 
-import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.credentials.Credential
 import androidx.credentials.CredentialOption
@@ -10,9 +9,12 @@ import androidx.credentials.GetPasswordOption
 import androidx.credentials.GetPublicKeyCredentialOption
 import androidx.credentials.PasswordCredential
 import androidx.credentials.PublicKeyCredential
+import androidx.credentials.exceptions.GetCredentialException
 import androidx.credentials.exceptions.NoCredentialException
 import com.clerk.api.Clerk
 import com.clerk.api.Constants.Fields.STRATEGY
+import com.clerk.api.credentials.CredentialFlowException
+import com.clerk.api.credentials.classifyGetCredentialFailure
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
@@ -111,27 +113,42 @@ internal object GoogleCredentialAuthenticationService {
     credentialTypes: List<SignIn.CredentialType>,
     allowedCredentialIds: List<String> = emptyList(),
   ): ClerkResult<SignIn, ClerkErrorResponse> {
-    if (credentialTypes.isEmpty()) {
-      return ClerkResult.unknownFailure(IllegalStateException("No credential types specified"))
-    }
     ClerkLog.d("Starting passkey sign-in")
-
-    val context = Clerk.applicationContext!!.get()!!
-    return when (val createResult = createSignIn()) {
-      is ClerkResult.Success -> {
-        val signIn = createResult.value
-        try {
-          val credential =
-            getCredentialFromManager(context, signIn, allowedCredentialIds, credentialTypes)
-          handleCredential(credential, signIn)
-        } catch (e: Exception) {
-          ClerkLog.e("Passkey sign-in failed: ${e.message}")
-          ClerkResult.unknownFailure(e)
-        }
+    return when {
+      credentialTypes.isEmpty() -> {
+        ClerkResult.unknownFailure(IllegalStateException("No credential types specified"))
       }
-      is ClerkResult.Failure -> {
-        ClerkLog.e("Failed to create SignIn: ${createResult.error}")
-        createResult
+
+      Clerk.credentialActivity() == null -> {
+        ClerkLog.e("Passkey sign-in requires an active Activity")
+        ClerkResult.unknownFailure(CredentialFlowException.MissingActivity())
+      }
+
+      else -> {
+        val activity = Clerk.credentialActivity()!!
+        when (val createResult = createSignIn()) {
+          is ClerkResult.Success -> {
+            val signIn = createResult.value
+            try {
+              val credential =
+                getCredentialFromManager(activity, signIn, allowedCredentialIds, credentialTypes)
+              handleCredential(credential, signIn)
+            } catch (e: GetCredentialException) {
+              ClerkLog.e("Passkey sign-in failed: ${e.message}")
+              classifyGetCredentialFailure(e, credentialTypes)
+            } catch (e: CredentialFlowException) {
+              ClerkLog.e("Passkey sign-in cannot start: ${e.message}")
+              ClerkResult.unknownFailure(e)
+            } catch (e: Exception) {
+              ClerkLog.e("Passkey sign-in failed: ${e.message}")
+              ClerkResult.unknownFailure(e)
+            }
+          }
+          is ClerkResult.Failure -> {
+            ClerkLog.e("Failed to create SignIn: ${createResult.error}")
+            createResult
+          }
+        }
       }
     }
   }
@@ -182,7 +199,7 @@ internal object GoogleCredentialAuthenticationService {
    *   errors.
    */
   private suspend fun getCredentialFromManager(
-    context: Context,
+    activity: android.app.Activity,
     signIn: SignIn,
     allowedCredentialIds: List<String> = emptyList(),
     credentialRequestTypes: List<SignIn.CredentialType>,
@@ -192,7 +209,7 @@ internal object GoogleCredentialAuthenticationService {
 
     val result =
       try {
-        credentialManager.getCredential(context, credentialRequest)
+        credentialManager.getCredential(activity, credentialRequest)
       } catch (e: NoCredentialException) {
         ClerkLog.e("No credential available: ${e.message}")
         throw e

--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/PasskeyCreationService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/PasskeyCreationService.kt
@@ -3,7 +3,10 @@ package com.clerk.api.passkeys
 import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.exceptions.CreateCredentialException
 import com.clerk.api.Clerk
+import com.clerk.api.credentials.CredentialFlowException
+import com.clerk.api.credentials.classifyCreateCredentialFailure
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
@@ -49,7 +52,12 @@ internal object PasskeyCreationService {
    */
   @SuppressLint("PublicKeyCredential")
   suspend fun createPasskey(): ClerkResult<Passkey, ClerkErrorResponse> {
-    val context = Clerk.applicationContext!!.get()!!
+    val activity = Clerk.credentialActivity()
+    if (activity == null) {
+      ClerkLog.e("Passkey creation requires an active Activity")
+      return ClerkResult.unknownFailure(CredentialFlowException.MissingActivity())
+    }
+
     return when (val createPasskeyResult = ClerkApi.user.createPasskey()) {
       is ClerkResult.Failure -> {
         ClerkLog.e("Passkey creation failed: ${createPasskeyResult.error}")
@@ -63,7 +71,7 @@ internal object PasskeyCreationService {
             )
           val result =
             credentialManager.createCredential(
-              context = context,
+              context = activity,
               request = createPublicKeyCredentialRequest,
             )
           val passkeyData = parsePasskeyDataDirectFromBundle(result.data)
@@ -77,6 +85,12 @@ internal object PasskeyCreationService {
             .onFailure { ClerkLog.e("Passkey creation failed: ${it}") }
           ClerkLog.d("Passkey creation result: ${result.data}")
           verificationResult
+        } catch (e: CreateCredentialException) {
+          ClerkLog.e("Passkey creation failed with exception: ${e.message}")
+          classifyCreateCredentialFailure(e)
+        } catch (e: CredentialFlowException) {
+          ClerkLog.e("Passkey creation cannot start: ${e.message}")
+          ClerkResult.unknownFailure(e)
         } catch (e: Exception) {
           ClerkLog.e("Passkey creation failed with exception: ${e.message}")
           ClerkResult.unknownFailure(e)

--- a/source/api/src/main/kotlin/com/clerk/api/sso/GoogleCredentialManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/GoogleCredentialManager.kt
@@ -5,6 +5,7 @@ import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetCredentialResponse
 import com.clerk.api.Clerk
+import com.clerk.api.credentials.CredentialFlowException
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import java.util.UUID
@@ -32,6 +33,7 @@ internal interface GoogleCredentialManager {
 
 class GoogleCredentialManagerImpl : GoogleCredentialManager {
   override suspend fun getSignInWithGoogleCredential(): GetCredentialResponse {
+    val activity = Clerk.credentialActivity() ?: throw CredentialFlowException.MissingActivity()
 
     val oneTapClientId =
       requireNotNull(Clerk.environment.displayConfig.googleOneTapClientId) {
@@ -48,12 +50,9 @@ class GoogleCredentialManagerImpl : GoogleCredentialManager {
 
     val request = GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
 
-    val credentialManager = CredentialManager.create(Clerk.applicationContext!!.get()!!)
+    val credentialManager = CredentialManager.create(activity)
 
-    return credentialManager.getCredential(
-      request = request,
-      context = Clerk.applicationContext!!.get()!!,
-    )
+    return credentialManager.getCredential(request = request, context = activity)
   }
 
   override fun getIdTokenFromCredential(credentialData: Bundle): String {

--- a/source/api/src/main/kotlin/com/clerk/api/sso/GoogleSignInService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/GoogleSignInService.kt
@@ -3,6 +3,8 @@ package com.clerk.api.sso
 import androidx.credentials.Credential
 import androidx.credentials.CustomCredential
 import androidx.credentials.exceptions.GetCredentialException
+import com.clerk.api.credentials.CredentialFlowException
+import com.clerk.api.credentials.classifyGetCredentialFailure
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
@@ -30,6 +32,9 @@ internal class GoogleSignInService(
       handleSignInResult(result.credential, transferable)
     } catch (e: GetCredentialException) {
       ClerkLog.e("Error retrieving Google ID token: ${e.message}")
+      classifyGetCredentialFailure(e, credentialTypes = listOf(SignIn.CredentialType.GOOGLE))
+    } catch (e: CredentialFlowException) {
+      ClerkLog.e("Google sign-in cannot start: ${e.message}")
       ClerkResult.unknownFailure(e)
     }
   }

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
@@ -1,13 +1,15 @@
 package com.clerk.api.passkeys
 
-import android.content.Context
+import android.app.Activity
 import androidx.credentials.Credential
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialResponse
 import androidx.credentials.PasswordCredential
 import androidx.credentials.PublicKeyCredential
+import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.credentials.exceptions.NoCredentialException
 import com.clerk.api.Clerk
+import com.clerk.api.credentials.CredentialFlowException
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.api.SignInApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
@@ -22,7 +24,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
-import java.lang.ref.WeakReference
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -36,7 +37,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class PasskeyAuthenticationServiceTest {
 
-  private lateinit var mockContext: Context
+  private lateinit var mockActivity: Activity
   private lateinit var mockCredentialManager: PasskeyCredentialManager
   private lateinit var mockGetCredentialResponse: GetCredentialResponse
   private lateinit var mockSignIn: SignIn
@@ -47,7 +48,7 @@ class PasskeyAuthenticationServiceTest {
 
   @Before
   fun setup() {
-    mockContext = mockk(relaxed = true)
+    mockActivity = mockk(relaxed = true)
     mockCredentialManager = mockk(relaxed = true)
     mockGetCredentialResponse = mockk(relaxed = true)
     mockSignIn = mockk(relaxed = true)
@@ -58,7 +59,7 @@ class PasskeyAuthenticationServiceTest {
 
     // Mock Clerk application context
     mockkObject(Clerk)
-    every { Clerk.applicationContext } returns WeakReference(mockContext)
+    every { Clerk.credentialActivity() } returns mockActivity
     every { Clerk.baseUrl } returns "https://test.clerk.com"
 
     // Mock ClerkApi and its nested objects
@@ -101,7 +102,7 @@ class PasskeyAuthenticationServiceTest {
     assertTrue(result is ClerkResult.Success)
     assertEquals(mockSignIn, (result as ClerkResult.Success).value)
     coVerify { ClerkApi.signIn.createSignIn(mapOf("strategy" to "passkey")) }
-    coVerify { mockCredentialManager.getCredential(mockContext, any()) }
+    coVerify { mockCredentialManager.getCredential(mockActivity, any()) }
     coVerify { mockSignIn.attemptFirstFactor(any()) }
   }
 
@@ -173,7 +174,43 @@ class PasskeyAuthenticationServiceTest {
 
     // Then
     assertTrue(result is ClerkResult.Failure)
-    assertEquals(ClerkResult.Failure.ErrorType.UNKNOWN, (result as ClerkResult.Failure).errorType)
+    val failure = result as ClerkResult.Failure
+    assertEquals(ClerkResult.Failure.ErrorType.UNKNOWN, failure.errorType)
+    assertTrue(failure.throwable is CredentialFlowException.NoSavedCredential)
+  }
+
+  @Test
+  fun `signInWithPasskey handles cancellation without generic failure`() = runTest {
+    val nonce = """{"challenge":"test-challenge"}"""
+
+    every { mockSignIn.firstFactorVerification } returns mockVerification
+    every { mockVerification.nonce } returns nonce
+
+    coEvery { ClerkApi.signIn.createSignIn(any()) } returns ClerkResult.success(mockSignIn)
+    coEvery { mockCredentialManager.getCredential(any(), any()) } throws
+      GetCredentialCancellationException()
+
+    val result =
+      GoogleCredentialAuthenticationService.signInWithGoogleCredential(
+        listOf(SignIn.CredentialType.PASSKEY)
+      )
+
+    assertTrue(result is ClerkResult.Failure)
+    assertTrue((result as ClerkResult.Failure).throwable is CredentialFlowException.UserCancelled)
+  }
+
+  @Test
+  fun `signInWithPasskey fails when no activity is available`() = runTest {
+    every { Clerk.credentialActivity() } returns null
+
+    val result =
+      GoogleCredentialAuthenticationService.signInWithGoogleCredential(
+        listOf(SignIn.CredentialType.PASSKEY)
+      )
+
+    assertTrue(result is ClerkResult.Failure)
+    assertTrue((result as ClerkResult.Failure).throwable is CredentialFlowException.MissingActivity)
+    coVerify(exactly = 0) { mockCredentialManager.getCredential(any(), any()) }
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyCreationServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyCreationServiceTest.kt
@@ -1,10 +1,12 @@
 package com.clerk.api.passkeys
 
-import android.content.Context
+import android.app.Activity
 import android.os.Bundle
 import androidx.credentials.CreateCredentialResponse
 import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.exceptions.CreateCredentialCancellationException
 import com.clerk.api.Clerk
+import com.clerk.api.credentials.CredentialFlowException
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
@@ -17,7 +19,6 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkAll
-import java.lang.ref.WeakReference
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -32,7 +33,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class PasskeyCreationServiceTest {
 
-  private lateinit var mockContext: Context
+  private lateinit var mockActivity: Activity
   private lateinit var mockCredentialManager: PasskeyCredentialManager
   private lateinit var mockCreateCredentialResponse: CreateCredentialResponse
   private lateinit var mockBundle: Bundle
@@ -41,7 +42,7 @@ class PasskeyCreationServiceTest {
 
   @Before
   fun setup() {
-    mockContext = mockk(relaxed = true)
+    mockActivity = mockk(relaxed = true)
     mockCredentialManager = mockk(relaxed = true)
     mockCreateCredentialResponse = mockk(relaxed = true)
     mockBundle = mockk(relaxed = true)
@@ -50,7 +51,7 @@ class PasskeyCreationServiceTest {
 
     // Mock Clerk application context
     mockkObject(Clerk)
-    every { Clerk.applicationContext } returns WeakReference(mockContext)
+    every { Clerk.credentialActivity() } returns mockActivity
 
     // Mock ClerkApi and its nested objects
     mockkObject(ClerkApi)
@@ -106,7 +107,7 @@ class PasskeyCreationServiceTest {
     // Then
     assertTrue(result is ClerkResult.Success)
     coVerify { ClerkApi.user.createPasskey() }
-    coVerify { mockCredentialManager.createCredential(eq(mockContext), any()) }
+    coVerify { mockCredentialManager.createCredential(eq(mockActivity), any()) }
     coVerify {
       ClerkApi.user.attemptPasskeyVerification(passkeyId = passkeyId, publicKeyCredential = any())
     }
@@ -164,7 +165,7 @@ class PasskeyCreationServiceTest {
 
     coEvery { ClerkApi.user.createPasskey() } returns ClerkResult.success(mockPasskey)
     coEvery {
-      mockCredentialManager.createCredential(eq(mockContext), capture(requestSlot))
+      mockCredentialManager.createCredential(eq(mockActivity), capture(requestSlot))
     } returns mockCreateCredentialResponse
     coEvery {
       ClerkApi.user.attemptPasskeyVerification(passkeyId = any(), publicKeyCredential = any())
@@ -177,7 +178,7 @@ class PasskeyCreationServiceTest {
     assertTrue(result is ClerkResult.Success)
     assertEquals(nonce, requestSlot.captured.requestJson)
     coVerify { ClerkApi.user.createPasskey() }
-    coVerify { mockCredentialManager.createCredential(eq(mockContext), any()) }
+    coVerify { mockCredentialManager.createCredential(eq(mockActivity), any()) }
     coVerify {
       ClerkApi.user.attemptPasskeyVerification(passkeyId = passkeyId, publicKeyCredential = any())
     }
@@ -234,6 +235,35 @@ class PasskeyCreationServiceTest {
       capturedJson.contains("test-attestation-object"),
     )
     assertTrue("Should contain client data JSON", capturedJson.contains("test-client-data-json"))
+  }
+
+  @Test
+  fun `createPasskey handles cancellation without surfacing unknown failure`() = runTest {
+    val nonce = """{"challenge":"test-challenge"}"""
+
+    every { mockVerification.nonce } returns nonce
+    every { mockPasskey.id } returns "test-passkey-id"
+    every { mockPasskey.verification } returns mockVerification
+
+    coEvery { ClerkApi.user.createPasskey() } returns ClerkResult.success(mockPasskey)
+    coEvery { mockCredentialManager.createCredential(any(), any()) } throws
+      CreateCredentialCancellationException()
+
+    val result = PasskeyCreationService.createPasskey()
+
+    assertTrue(result is ClerkResult.Failure)
+    assertTrue((result as ClerkResult.Failure).throwable is CredentialFlowException.UserCancelled)
+  }
+
+  @Test
+  fun `createPasskey fails when no activity is available`() = runTest {
+    every { Clerk.credentialActivity() } returns null
+
+    val result = PasskeyCreationService.createPasskey()
+
+    assertTrue(result is ClerkResult.Failure)
+    assertTrue((result as ClerkResult.Failure).throwable is CredentialFlowException.MissingActivity)
+    coVerify(exactly = 0) { mockCredentialManager.createCredential(any(), any()) }
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/sso/GoogleSignInServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/GoogleSignInServiceTest.kt
@@ -1,11 +1,13 @@
 package com.clerk.api.sso
 
-import android.content.Context
 import android.os.Bundle
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialResponse
+import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.credentials.exceptions.GetCredentialUnknownException
+import androidx.credentials.exceptions.NoCredentialException
 import com.clerk.api.Clerk
+import com.clerk.api.credentials.CredentialFlowException
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.environment.DisplayConfig
 import com.clerk.api.network.model.environment.Environment
@@ -33,7 +35,6 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class GoogleSignInServiceTest {
 
-  private lateinit var mockContext: Context
   private lateinit var mockGoogleCredentialManager: GoogleCredentialManager
   private lateinit var mockGetCredentialResponse: GetCredentialResponse
   private lateinit var mockCustomCredential: CustomCredential
@@ -46,7 +47,6 @@ class GoogleSignInServiceTest {
 
   @Before
   fun setup() {
-    mockContext = mockk(relaxed = true)
     mockGoogleCredentialManager = mockk(relaxed = true)
     mockGetCredentialResponse = mockk(relaxed = true)
     mockCustomCredential = mockk(relaxed = true)
@@ -210,6 +210,30 @@ class GoogleSignInServiceTest {
     assertTrue(result is ClerkResult.Failure)
     val failure = result as ClerkResult.Failure
     assertEquals(ClerkResult.Failure.ErrorType.UNKNOWN, failure.errorType)
+  }
+
+  @Test
+  fun `signInWithGoogle classifies missing Google account`() = runTest {
+    coEvery { mockGoogleCredentialManager.getSignInWithGoogleCredential() } throws
+      NoCredentialException("No credentials available")
+
+    val result = googleSignInService.signInWithGoogle()
+
+    assertTrue(result is ClerkResult.Failure)
+    val failure = result as ClerkResult.Failure
+    assertTrue(failure.throwable is CredentialFlowException.NoGoogleAccount)
+  }
+
+  @Test
+  fun `signInWithGoogle classifies user cancellation`() = runTest {
+    coEvery { mockGoogleCredentialManager.getSignInWithGoogleCredential() } throws
+      GetCredentialCancellationException()
+
+    val result = googleSignInService.signInWithGoogle()
+
+    assertTrue(result is ClerkResult.Failure)
+    val failure = result as ClerkResult.Failure
+    assertTrue(failure.throwable is CredentialFlowException.UserCancelled)
   }
 
   @Test

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -3,6 +3,8 @@ package com.clerk.ui.auth
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.clerk.api.Clerk
+import com.clerk.api.credentials.resolvedCredentialFlowMessage
+import com.clerk.api.credentials.shouldSuppressCredentialFlowError
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.errorMessage
@@ -183,7 +185,12 @@ internal class AuthStartViewModel : ViewModel() {
         }
         .onFailure {
           withContext(Dispatchers.Main) {
-            _state.value = AuthState.OAuthState.Error(it.errorMessage)
+            _state.value =
+              if (it.shouldSuppressCredentialFlowError) {
+                AuthState.Idle
+              } else {
+                AuthState.OAuthState.Error(it.resolvedCredentialFlowMessage)
+              }
           }
         }
     }

--- a/source/ui/src/main/java/com/clerk/ui/core/appbar/ClerkTopAppbar.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/appbar/ClerkTopAppbar.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.R
-import com.clerk.ui.core.avatar.OrganizationAvatar
+import com.clerk.ui.core.avatar.OrganizationLogo
 import com.clerk.ui.core.dimens.dp48
 import com.clerk.ui.core.dimens.dp8
 import com.clerk.ui.core.extensions.withMediumWeight
@@ -104,7 +104,7 @@ private fun RowScope.TopBarWithLogo(
   BackButton(hasBackButton = hasBackButton, onBackPressed = onBackPressed)
   Spacer(Modifier.weight(1f))
   TopBarTitle(title)
-  if (hasLogo) OrganizationAvatar(clerkTheme = clerkTheme)
+  if (hasLogo) OrganizationLogo(clerkTheme = clerkTheme)
   Spacer(Modifier.weight(1f))
   if (hasBackButton) {
     IconButton(onClick = {}) {}

--- a/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
@@ -211,6 +214,50 @@ internal fun OrganizationAvatar(
       modifier = modifier,
       avatarType = AvatarType.ORGANIZATION,
     )
+  }
+}
+
+@Composable
+internal fun OrganizationLogo(
+  modifier: Modifier = Modifier,
+  maxWidth: Dp = dp96,
+  height: Dp = dp24,
+  clerkTheme: ClerkTheme? = null,
+) {
+  val url = Clerk.organizationLogoUrl
+  ClerkMaterialTheme(clerkTheme = clerkTheme) {
+    if (url.isNullOrBlank()) {
+      Icon(
+        modifier = Modifier.size(height).then(modifier),
+        painter = painterResource(R.drawable.ic_organization),
+        contentDescription = stringResource(R.string.logo),
+        tint = ClerkMaterialTheme.colors.foreground,
+      )
+    } else {
+      Box(
+        modifier =
+          Modifier.defaultMinSize(minWidth = height)
+            .height(height)
+            .widthIn(max = maxWidth)
+            .then(modifier),
+        contentAlignment = Alignment.Center,
+      ) {
+        SubcomposeAsyncImage(
+          model = url,
+          contentDescription = stringResource(R.string.logo),
+          modifier = Modifier.fillMaxSize(),
+          contentScale = ContentScale.Fit,
+          loading = { CircularProgressIndicator(modifier = Modifier.size(height / 2)) },
+          error = {
+            Icon(
+              painter = painterResource(R.drawable.ic_organization),
+              contentDescription = null,
+              tint = ClerkMaterialTheme.colors.foreground,
+            )
+          },
+        )
+      }
+    }
   }
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/signin/passkey/PasskeyViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/passkey/PasskeyViewModel.kt
@@ -2,8 +2,9 @@ package com.clerk.ui.signin.passkey
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.clerk.api.credentials.resolvedCredentialFlowMessage
+import com.clerk.api.credentials.shouldSuppressCredentialFlowError
 import com.clerk.api.log.ClerkLog
-import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
 import com.clerk.api.signin.SignIn
@@ -24,7 +25,12 @@ internal class PasskeyViewModel : ViewModel() {
         .onSuccess { _state.value = AuthenticationViewState.Success.SignIn(it) }
         .onFailure {
           ClerkLog.e("Passkey authentication failed: $it")
-          _state.value = AuthenticationViewState.Error(it.errorMessage)
+          _state.value =
+            if (it.shouldSuppressCredentialFlowError) {
+              AuthenticationViewState.Idle
+            } else {
+              AuthenticationViewState.Error(it.resolvedCredentialFlowMessage)
+            }
         }
     }
   }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/detail/UserProfileDetailView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/detail/UserProfileDetailView.kt
@@ -44,6 +44,9 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 
+private const val EMAIL_IMMUTABLE_SNACKBAR_MESSAGE =
+  "Email addresses cannot be changed for this application."
+
 @Composable
 fun UserProfileDetailView(modifier: Modifier = Modifier) {
   val user by Clerk.userFlow.collectAsStateWithLifecycle()
@@ -89,8 +92,12 @@ private fun UserProfileDetailViewImpl(
         phoneNumbers = phoneNumbers,
         externalAccounts = externalAccounts,
         onShowBottomSheet = { type ->
-          bottomSheetType = type
-          showBottomSheet = true
+          if (type == BottomSheetMode.EmailAddress && Clerk.isEmailImmutable) {
+            scope.launch { snackbarHostState.showSnackbar(EMAIL_IMMUTABLE_SNACKBAR_MESSAGE) }
+          } else {
+            bottomSheetType = type
+            showBottomSheet = true
+          }
         },
         onError = { errorMessage -> scope.launch { snackbarHostState.showSnackbar(errorMessage) } },
       )
@@ -130,8 +137,10 @@ private fun ProfileContent(
         .padding(innerPadding)
         .verticalScroll(scrollState)
   ) {
-    val showEmailSection = Clerk.isEmailEnabled && !(Clerk.isEmailImmutable && emailAddresses.isEmpty())
-    val showPhoneSection = Clerk.isPhoneNumberEnabled && !(Clerk.isPhoneNumberImmutable && phoneNumbers.isEmpty())
+    val showEmailSection =
+      Clerk.isEmailEnabled && !(Clerk.isEmailImmutable && emailAddresses.isEmpty())
+    val showPhoneSection =
+      Clerk.isPhoneNumberEnabled && !(Clerk.isPhoneNumberImmutable && phoneNumbers.isEmpty())
 
     HorizontalDivider(thickness = dp1, color = ClerkMaterialTheme.computedColors.border)
     if (showEmailSection) {

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/email/AddEmailViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/email/AddEmailViewModel.kt
@@ -2,6 +2,7 @@ package com.clerk.ui.userprofile.email
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.clerk.api.Clerk
 import com.clerk.api.emailaddress.EmailAddress
 import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
@@ -13,12 +14,19 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+private const val ADD_EMAIL_IMMUTABLE_MESSAGE =
+  "Email addresses cannot be changed for this application."
+
 internal class AddEmailViewModel : ViewModel() {
 
   private val _state = MutableStateFlow<State>(State.Idle)
   val state = _state.asStateFlow()
 
   fun addEmail(email: String) {
+    if (Clerk.isEmailImmutable) {
+      _state.value = State.Error(ADD_EMAIL_IMMUTABLE_MESSAGE)
+      return
+    }
     _state.value = State.Loading
     guardUser(userDoesNotExist = { _state.value = State.Error("No current user found") }) { user ->
       viewModelScope.launch(Dispatchers.IO) {

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/email/EmailViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/email/EmailViewModel.kt
@@ -2,6 +2,7 @@ package com.clerk.ui.userprofile.email
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.clerk.api.Clerk
 import com.clerk.api.emailaddress.EmailAddress
 import com.clerk.api.emailaddress.delete
 import com.clerk.api.network.serialization.errorMessage
@@ -15,12 +16,19 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+private const val EMAIL_IMMUTABLE_MESSAGE =
+  "Email addresses cannot be changed for this application."
+
 internal class EmailViewModel : ViewModel() {
 
   private val _state = MutableStateFlow<State>(State.Idle)
   val state = _state.asStateFlow()
 
   fun setAsPrimary(emailAddress: EmailAddress) {
+    if (Clerk.isEmailImmutable) {
+      _state.value = State.Failure(EMAIL_IMMUTABLE_MESSAGE)
+      return
+    }
     _state.value = State.Loading
     guardUser(userDoesNotExist = {}) { user ->
       viewModelScope.launch(Dispatchers.IO) {
@@ -33,6 +41,10 @@ internal class EmailViewModel : ViewModel() {
   }
 
   fun remove(emailAddress: EmailAddress) {
+    if (Clerk.isEmailImmutable) {
+      _state.value = State.Failure(EMAIL_IMMUTABLE_MESSAGE)
+      return
+    }
     _state.value = State.Loading
     viewModelScope.launch(Dispatchers.IO) {
       emailAddress

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileEmailRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileEmailRow.kt
@@ -60,9 +60,10 @@ internal fun UserProfileEmailRow(
       verticalAlignment = Alignment.CenterVertically,
     ) {
       val canRemove = !Clerk.isEmailImmutable
+      val canSetAsPrimary = !Clerk.isEmailImmutable
       val isPrimary = emailAddress.isPrimary
       val isVerified = emailAddress.verification?.status == Verification.Status.VERIFIED
-      val shouldShowMenu = canRemove || !isPrimary || !isVerified
+      val shouldShowMenu = canRemove || (canSetAsPrimary && !isPrimary && isVerified) || !isVerified
 
       EmailWithBadge(isPrimary, emailAddress)
       Spacer(modifier = Modifier.weight(1f))
@@ -73,7 +74,7 @@ internal fun UserProfileEmailRow(
               DropDownItem(
                 id = EmailAction.SetAsPrimary,
                 text = stringResource(R.string.set_as_primary),
-                isHidden = isPrimary || !isVerified,
+                isHidden = !canSetAsPrimary || isPrimary || !isVerified,
               ),
               DropDownItem(
                 id = EmailAction.Verify,

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/security/passkey/UserProfilePasskeyViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/security/passkey/UserProfilePasskeyViewModel.kt
@@ -2,6 +2,8 @@ package com.clerk.ui.userprofile.security.passkey
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.clerk.api.credentials.resolvedCredentialFlowMessage
+import com.clerk.api.credentials.shouldSuppressCredentialFlowError
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
@@ -36,8 +38,13 @@ internal class UserProfilePasskeyViewModel : ViewModel() {
           .createPasskey()
           .onSuccess { _state.value = State.Success }
           .onFailure {
-            ClerkLog.e("Failed to create passkey: ${it.errorMessage}")
-            _state.value = State.Error(it.errorMessage)
+            ClerkLog.e("Failed to create passkey: ${it.resolvedCredentialFlowMessage}")
+            _state.value =
+              if (it.shouldSuppressCredentialFlowError) {
+                State.Idle
+              } else {
+                State.Error(it.resolvedCredentialFlowMessage)
+              }
           }
       }
     }

--- a/source/ui/src/test/java/com/clerk/snapshot/appbar/ClerkTopAppBarSnapshotTest.kt
+++ b/source/ui/src/test/java/com/clerk/snapshot/appbar/ClerkTopAppBarSnapshotTest.kt
@@ -1,0 +1,56 @@
+package com.clerk.snapshot.appbar
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.clerk.api.Clerk
+import com.clerk.base.BaseSnapshotTest
+import com.clerk.ui.core.appbar.ClerkTopAppBar
+import com.clerk.ui.theme.ClerkMaterialTheme
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class ClerkTopAppBarSnapshotTest : BaseSnapshotTest() {
+
+  @Before
+  fun setUpLogo() {
+    mockkObject(Clerk)
+    every { Clerk.organizationLogoUrl } returns WIDE_LOGO_DATA_URI
+  }
+
+  @After
+  fun tearDownLogo() {
+    unmockkAll()
+  }
+
+  @Test
+  fun authTopBar_preservesWideLogoAspectRatio() {
+    paparazzi.snapshot {
+      Box(Modifier.size(width = 360.dp, height = 72.dp)) {
+        ClerkMaterialTheme {
+          ClerkTopAppBar(
+            onBackPressed = {},
+            title = "Log in to M2X",
+            hasLogo = true,
+            hasBackButton = true,
+          )
+        }
+      }
+    }
+  }
+
+  private companion object {
+    private const val WIDE_LOGO_DATA_URI =
+      "data:image/svg+xml;utf8," +
+        "<svg xmlns='http://www.w3.org/2000/svg' width='120' height='24' viewBox='0 0 120 24'>" +
+        "<rect width='120' height='24' rx='4' fill='%2308163d'/>" +
+        "<rect x='6' y='4' width='16' height='16' rx='2' fill='%2391d43b'/>" +
+        "<rect x='28' y='6' width='78' height='12' rx='3' fill='%23ffffff'/>" +
+        "</svg>"
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/signin/passkey/PasskeyViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/passkey/PasskeyViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.clerk.ui.signin.passkey
 
 import app.cash.turbine.test
-import com.clerk.api.credentials.CredentialFlowException
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.signin.SignIn
 import com.clerk.ui.auth.AuthenticationViewState
@@ -35,7 +34,7 @@ class PasskeyViewModelTest {
   @Test
   fun authenticate_cancellation_resets_to_idle() = runTest {
     coEvery { SignIn.authenticateWithGoogleCredential(any()) } returns
-      ClerkResult.unknownFailure(CredentialFlowException.UserCancelled())
+      ClerkResult.unknownFailure(credentialFlowThrowable("UserCancelled"))
 
     val viewModel = PasskeyViewModel()
     viewModel.state.test {
@@ -49,7 +48,7 @@ class PasskeyViewModelTest {
   @Test
   fun authenticate_missing_activity_surfaces_retry_message() = runTest {
     coEvery { SignIn.authenticateWithGoogleCredential(any()) } returns
-      ClerkResult.unknownFailure(CredentialFlowException.MissingActivity())
+      ClerkResult.unknownFailure(credentialFlowThrowable("MissingActivity"))
 
     val viewModel = PasskeyViewModel()
     viewModel.state.test {
@@ -78,4 +77,10 @@ class PasskeyViewModelTest {
       assertEquals(AuthenticationViewState.Success.SignIn(signIn), awaitItem())
     }
   }
+
+  private fun credentialFlowThrowable(simpleName: String): Throwable =
+    Class.forName("com.clerk.api.credentials.CredentialFlowException\$$simpleName")
+      .getDeclaredConstructor()
+      .apply { isAccessible = true }
+      .newInstance() as Throwable
 }

--- a/source/ui/src/test/java/com/clerk/ui/signin/passkey/PasskeyViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/passkey/PasskeyViewModelTest.kt
@@ -1,0 +1,81 @@
+package com.clerk.ui.signin.passkey
+
+import app.cash.turbine.test
+import com.clerk.api.credentials.CredentialFlowException
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.ui.auth.AuthenticationViewState
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PasskeyViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(SignIn.Companion)
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun authenticate_cancellation_resets_to_idle() = runTest {
+    coEvery { SignIn.authenticateWithGoogleCredential(any()) } returns
+      ClerkResult.unknownFailure(CredentialFlowException.UserCancelled())
+
+    val viewModel = PasskeyViewModel()
+    viewModel.state.test {
+      assertEquals(AuthenticationViewState.Idle, awaitItem())
+      viewModel.authenticate()
+      assertEquals(AuthenticationViewState.Loading, awaitItem())
+      assertEquals(AuthenticationViewState.Idle, awaitItem())
+    }
+  }
+
+  @Test
+  fun authenticate_missing_activity_surfaces_retry_message() = runTest {
+    coEvery { SignIn.authenticateWithGoogleCredential(any()) } returns
+      ClerkResult.unknownFailure(CredentialFlowException.MissingActivity())
+
+    val viewModel = PasskeyViewModel()
+    viewModel.state.test {
+      assertEquals(AuthenticationViewState.Idle, awaitItem())
+      viewModel.authenticate()
+      assertEquals(AuthenticationViewState.Loading, awaitItem())
+      assertEquals(
+        AuthenticationViewState.Error(
+          "Authentication requires an active screen. Try again from the app."
+        ),
+        awaitItem(),
+      )
+    }
+  }
+
+  @Test
+  fun authenticate_success_emits_sign_in_success() = runTest {
+    val signIn = mockk<SignIn>(relaxed = true)
+    coEvery { SignIn.authenticateWithGoogleCredential(any()) } returns ClerkResult.success(signIn)
+
+    val viewModel = PasskeyViewModel()
+    viewModel.state.test {
+      assertEquals(AuthenticationViewState.Idle, awaitItem())
+      viewModel.authenticate()
+      assertEquals(AuthenticationViewState.Loading, awaitItem())
+      assertEquals(AuthenticationViewState.Success.SignIn(signIn), awaitItem())
+    }
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/email/AddEmailViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/email/AddEmailViewModelTest.kt
@@ -92,4 +92,19 @@ class AddEmailViewModelTest {
       assertEquals(AddEmailViewModel.State.Error("No current user found"), awaitItem())
     }
   }
+
+  @Test
+  fun addEmail_whenEmailIsImmutable_emitsErrorWithoutCallingApi() = runTest {
+    every { Clerk.isEmailImmutable } returns true
+
+    val viewModel = AddEmailViewModel()
+    viewModel.state.test {
+      assertEquals(AddEmailViewModel.State.Idle, awaitItem())
+      viewModel.addEmail("user@example.com")
+      assertEquals(
+        AddEmailViewModel.State.Error("Email addresses cannot be changed for this application."),
+        awaitItem(),
+      )
+    }
+  }
 }

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/passkey/UserProfilePasskeyViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/passkey/UserProfilePasskeyViewModelTest.kt
@@ -2,7 +2,6 @@ package com.clerk.ui.userprofile.security.passkey
 
 import app.cash.turbine.test
 import com.clerk.api.Clerk
-import com.clerk.api.credentials.CredentialFlowException
 import com.clerk.api.network.model.deleted.DeletedObject
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
@@ -109,7 +108,7 @@ class UserProfilePasskeyViewModelTest {
     val user = mockk<User>()
     every { Clerk.user } returns user
     coEvery { user.createPasskey() } returns
-      ClerkResult.unknownFailure(CredentialFlowException.UserCancelled())
+      ClerkResult.unknownFailure(credentialFlowThrowable("UserCancelled"))
 
     val viewModel = UserProfilePasskeyViewModel()
     viewModel.state.test {
@@ -125,7 +124,7 @@ class UserProfilePasskeyViewModelTest {
     val user = mockk<User>()
     every { Clerk.user } returns user
     coEvery { user.createPasskey() } returns
-      ClerkResult.unknownFailure(CredentialFlowException.MissingActivity())
+      ClerkResult.unknownFailure(credentialFlowThrowable("MissingActivity"))
 
     val viewModel = UserProfilePasskeyViewModel()
     viewModel.state.test {
@@ -139,4 +138,10 @@ class UserProfilePasskeyViewModelTest {
       )
     }
   }
+
+  private fun credentialFlowThrowable(simpleName: String): Throwable =
+    Class.forName("com.clerk.api.credentials.CredentialFlowException\$$simpleName")
+      .getDeclaredConstructor()
+      .apply { isAccessible = true }
+      .newInstance() as Throwable
 }

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/passkey/UserProfilePasskeyViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/passkey/UserProfilePasskeyViewModelTest.kt
@@ -2,6 +2,7 @@ package com.clerk.ui.userprofile.security.passkey
 
 import app.cash.turbine.test
 import com.clerk.api.Clerk
+import com.clerk.api.credentials.CredentialFlowException
 import com.clerk.api.network.model.deleted.DeletedObject
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
@@ -100,6 +101,42 @@ class UserProfilePasskeyViewModelTest {
       awaitItem() // initial Idle
       viewModel.createPasskey()
       assertEquals(UserProfilePasskeyViewModel.State.Error("User does not exist"), awaitItem())
+    }
+  }
+
+  @Test
+  fun createPasskey_cancellation_resetsToIdle() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    coEvery { user.createPasskey() } returns
+      ClerkResult.unknownFailure(CredentialFlowException.UserCancelled())
+
+    val viewModel = UserProfilePasskeyViewModel()
+    viewModel.state.test {
+      assertEquals(UserProfilePasskeyViewModel.State.Idle, awaitItem())
+      viewModel.createPasskey()
+      advanceUntilIdle()
+      expectNoEvents()
+    }
+  }
+
+  @Test
+  fun createPasskey_missingActivity_surfacesRetryMessage() = runTest {
+    val user = mockk<User>()
+    every { Clerk.user } returns user
+    coEvery { user.createPasskey() } returns
+      ClerkResult.unknownFailure(CredentialFlowException.MissingActivity())
+
+    val viewModel = UserProfilePasskeyViewModel()
+    viewModel.state.test {
+      assertEquals(UserProfilePasskeyViewModel.State.Idle, awaitItem())
+      viewModel.createPasskey()
+      assertEquals(
+        UserProfilePasskeyViewModel.State.Error(
+          "Authentication requires an active screen. Try again from the app."
+        ),
+        awaitItem(),
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary
- refine Google credential, passkey, and sign-in flow handling in the API layer
- tighten related error handling and update auth/profile view models to better reflect flow outcomes
- polish several UI components, including app bar, avatar, email, and passkey profile surfaces
- add and update unit and snapshot coverage for the changed credential, passkey, and UI behavior

## Testing
- Not run (not requested)