### PR TITLE
Fix AuthView Google sign-in activity bootstrap on Android

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -3,6 +3,8 @@ package com.clerk.api
 import android.app.Activity
 import android.app.Application
 import android.content.Context
+import android.content.ContextWrapper
+import androidx.annotation.RestrictTo
 import com.clerk.api.Clerk.activeSession
 import com.clerk.api.Clerk.activeUser
 import com.clerk.api.Clerk.initialize
@@ -718,6 +720,23 @@ object Clerk {
   }
 
   // endregion
+}
+
+/**
+ * Updates Clerk's current activity reference from a UI context when the SDK was initialized after
+ * the host activity had already reached the resumed state.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun updateActivityContext(context: Context) {
+  context.findActivity()?.let { Clerk.currentActivity = WeakReference(it) }
+}
+
+private fun Context.findActivity(): Activity? {
+  return when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+  }
 }
 
 /**

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -1,7 +1,11 @@
 package com.clerk.api.sdk
 
+import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
+import androidx.test.core.app.ApplicationProvider
 import com.clerk.api.Clerk
+import com.clerk.api.updateActivityContext
 import com.clerk.api.auth.AuthEvent
 import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.environment.DisplayConfig
@@ -33,6 +37,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -105,6 +110,9 @@ class ClerkTest {
 
   private fun resetClerkState() {
     try {
+      Clerk.currentActivity = null
+      Clerk.applicationContext = null
+
       // Reset lateinit properties using reflection
       val clerkClass = Clerk::class.java
 
@@ -772,6 +780,27 @@ class ClerkTest {
 
     // Then - activeUser should be returned
     assertEquals(mockUser, activeUser)
+  }
+
+  @Test
+  fun `updateActivityContext stores activity from wrapped context`() {
+    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    val wrappedContext = ContextWrapper(ContextWrapper(activity))
+
+    updateActivityContext(wrappedContext)
+
+    assertEquals(activity, Clerk.credentialActivity())
+  }
+
+  @Test
+  fun `updateActivityContext ignores contexts without an activity`() {
+    val applicationContext = ApplicationProvider.getApplicationContext<Context>()
+    val existingActivity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    Clerk.currentActivity = java.lang.ref.WeakReference(existingActivity)
+
+    updateActivityContext(applicationContext)
+
+    assertEquals(existingActivity, Clerk.credentialActivity())
   }
 
   // endregion

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.ContextWrapper
 import androidx.test.core.app.ApplicationProvider
 import com.clerk.api.Clerk
-import com.clerk.api.updateActivityContext
 import com.clerk.api.auth.AuthEvent
 import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.environment.DisplayConfig
@@ -14,6 +13,7 @@ import com.clerk.api.network.model.environment.UserSettings
 import com.clerk.api.session.Session
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
+import com.clerk.api.updateActivityContext
 import com.clerk.api.user.User
 import io.mockk.every
 import io.mockk.mockk

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -20,11 +20,11 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import com.clerk.api.Clerk
-import com.clerk.api.updateActivityContext
 import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.session.SessionTaskKey
 import com.clerk.api.session.pendingTaskKey
 import com.clerk.api.ui.ClerkTheme
+import com.clerk.api.updateActivityContext
 import com.clerk.telemetry.TelemetryEvents
 import com.clerk.telemetry.telemetryPayload
 import com.clerk.ui.core.composition.AuthStateProvider

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -7,8 +7,10 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.IntOffset
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -18,6 +20,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import com.clerk.api.Clerk
+import com.clerk.api.updateActivityContext
 import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.session.SessionTaskKey
 import com.clerk.api.session.pendingTaskKey
@@ -61,6 +64,7 @@ fun AuthView(
   onAuthComplete: () -> Unit = {},
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
+    PublishCredentialActivity()
     val fullScreenModifier = Modifier.fillMaxSize().then(modifier)
     val backStack = rememberNavBackStack(AuthDestination.AuthStart)
     val identifierConfig =
@@ -83,6 +87,12 @@ fun AuthView(
 }
 
 @Composable
+private fun PublishCredentialActivity() {
+  val context = LocalContext.current
+  SideEffect { updateActivityContext(context) }
+}
+
+@Composable
 private fun ObservePendingSessionTaskRouting(backStack: NavBackStack<NavKey>) {
   val session = Clerk.sessionFlow.collectAsStateWithLifecycle().value
   val pendingTaskKey = session?.pendingTaskKey
@@ -98,8 +108,8 @@ private fun ObservePendingSessionTaskRouting(backStack: NavBackStack<NavKey>) {
 
 @Composable
 private fun AuthNavDisplay(
-  modifier: Modifier = Modifier,
   backStack: NavBackStack<NavKey>,
+  modifier: Modifier = Modifier,
   onAuthComplete: () -> Unit,
 ) {
   NavDisplay(


### PR DESCRIPTION
## Summary
- Publish the host `Activity` from `AuthView` so Google sign-in can start even when Clerk initializes after the screen is already resumed.
- Add a small API hook in `source/api` to refresh Clerk's credential activity from a UI `Context`.
- Add regression coverage for wrapped contexts and non-activity contexts.

## Testing
- Not run (not requested)