### PR TITLE
Handle session-invalidation errors in SessionTokenFetcher and clear local state

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
@@ -1,9 +1,12 @@
 package com.clerk.api.session
 
+import com.clerk.api.Clerk
 import com.clerk.api.Constants
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.token.TokenResource
+import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.successOrElse
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Deferred
@@ -24,6 +27,19 @@ import kotlinx.coroutines.coroutineScope
  * @param jwtManager The JWT manager used for token parsing and validation
  */
 internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManagerImpl()) {
+  private companion object {
+    val sessionInvalidationErrorCodes =
+      setOf(
+        "session_revoked",
+        "session_expired",
+        "session_ended",
+        "session_removed",
+        "session_replaced",
+        "session_not_found",
+        "session_invalid",
+      )
+  }
+
   /** Map of cache keys to deferred token fetch tasks for request deduplication */
   private val tokenTasks = ConcurrentHashMap<String, Deferred<TokenResource?>>()
 
@@ -128,13 +144,36 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
         }
 
       val result =
-        tokensRequest.successOrElse { throw IllegalStateException("Failed to fetch token") }
+        tokensRequest.successOrElse { failure ->
+          handleSessionInvalidationOnFailure(session, failure)
+          throw IllegalStateException("Failed to fetch token")
+        }
 
       SessionTokensCache.setToken(cacheKey, result)
       result
     } catch (e: Exception) {
       ClerkLog.e("Failed to fetch token: ${e.message}")
       null
+    }
+  }
+
+  private fun handleSessionInvalidationOnFailure(
+    session: Session,
+    failure: ClerkResult.Failure<ClerkErrorResponse>,
+  ) {
+    val shouldClearSessionState =
+      failure.error?.errors
+        .orEmpty()
+        .mapNotNull { it.code?.lowercase() }
+        .any { it in sessionInvalidationErrorCodes }
+
+    if (!shouldClearSessionState) return
+
+    if (Clerk.session?.id == session.id) {
+      ClerkLog.w(
+        "Session ${session.id} can no longer issue tokens. Clearing local session and user state."
+      )
+      Clerk.clearSessionAndUserState()
     }
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
@@ -146,7 +146,7 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
       val result =
         tokensRequest.successOrElse { failure ->
           handleSessionInvalidationOnFailure(session, failure)
-          throw IllegalStateException("Failed to fetch token")
+          error("Failed to fetch token")
         }
 
       SessionTokensCache.setToken(cacheKey, result)
@@ -162,7 +162,8 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
     failure: ClerkResult.Failure<ClerkErrorResponse>,
   ) {
     val shouldClearSessionState =
-      failure.error?.errors
+      failure.error
+        ?.errors
         .orEmpty()
         .mapNotNull { it.code?.lowercase() }
         .any { it in sessionInvalidationErrorCodes }

--- a/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
@@ -1,6 +1,7 @@
 package com.clerk.api.session
 
 import com.auth0.android.jwt.JWT
+import com.clerk.api.Clerk
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.api.SessionApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
@@ -14,6 +15,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkAll
+import io.mockk.verify
 import java.util.Date
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -58,6 +60,11 @@ class SessionTokenFetcherTest {
     // Mock ClerkApi
     mockkObject(ClerkApi)
     every { ClerkApi.session } returns mockClerkApiService
+
+    // Mock Clerk state access
+    mockkObject(Clerk)
+    every { Clerk.session } returns mockSession
+    every { Clerk.clearSessionAndUserState() } returns Unit
 
     // Mock SessionTokensCache
     mockkObject(SessionTokensCache)
@@ -195,6 +202,43 @@ class SessionTokenFetcherTest {
     assertNull(result)
     coVerify { mockClerkApiService.tokens("session_123") }
     coVerify(exactly = 0) { SessionTokensCache.setToken(any(), any()) }
+    verify(exactly = 0) { Clerk.clearSessionAndUserState() }
+  }
+
+  @Test
+  fun `getToken clears local session state when token endpoint returns unauthorized`() = runTest {
+    // Given
+    val error = Error(code = "session_revoked", message = "Session revoked")
+    val errorResponse = ClerkErrorResponse(errors = listOf(error), clerkTraceId = "trace_unauth")
+
+    coEvery { SessionTokensCache.getToken(any()) } returns null
+    coEvery { mockClerkApiService.tokens("session_123") } returns
+      ClerkResult.httpFailure(code = 401, error = errorResponse)
+
+    // When
+    val result = sessionTokenFetcher.getToken(mockSession)
+
+    // Then
+    assertNull(result)
+    verify(exactly = 1) { Clerk.clearSessionAndUserState() }
+  }
+
+  @Test
+  fun `getToken does not clear local session state for non-session unauthorized errors`() = runTest {
+    // Given
+    val error = Error(code = "not_authorized", message = "Unauthorized")
+    val errorResponse = ClerkErrorResponse(errors = listOf(error), clerkTraceId = "trace_unauth")
+
+    coEvery { SessionTokensCache.getToken(any()) } returns null
+    coEvery { mockClerkApiService.tokens("session_123") } returns
+      ClerkResult.httpFailure(code = 401, error = errorResponse)
+
+    // When
+    val result = sessionTokenFetcher.getToken(mockSession)
+
+    // Then
+    assertNull(result)
+    verify(exactly = 0) { Clerk.clearSessionAndUserState() }
   }
 
   @Test


### PR DESCRIPTION
### Motivation

- Ensure the client clears local session and user state when the token endpoint responds with errors that indicate the remote session is no longer valid. 

### Description

- Added a set of session invalidation error codes and a `handleSessionInvalidationOnFailure` helper that inspects `ClerkResult.Failure<ClerkErrorResponse>` and calls `Clerk.clearSessionAndUserState()` when the current session is affected. 
- Updated `getToken` to invoke the handler inside `successOrElse` on API failures before throwing an `IllegalStateException`. 
- Added `Clerk` object mocking and imports, and updated tests to verify the new invalidation behavior and that unrelated errors do not clear local state. 

### Testing

- Updated and added unit tests in `SessionTokenFetcherTest`, including `getToken clears local session state when token endpoint returns unauthorized` and `getToken does not clear local session state for non-session unauthorized errors`. 
- Existing tests for caching, network success, and network failure were retained and exercised. 
- All unit tests in `SessionTokenFetcherTest` passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb08839b3c83228fd44695e7c3a4d5)