### PR TITLE
feat(api): add Google One Tap sign-up helper

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -448,6 +448,26 @@ class Auth internal constructor() {
   }
 
   /**
+   * Signs up with Google One Tap.
+   *
+   * This native Google flow may resolve to either a sign-up or a sign-in, depending on whether the
+   * selected Google account already exists in Clerk.
+   *
+   * @return A [ClerkResult] containing the [OAuthResult] on success, or a [ClerkErrorResponse] on
+   *   failure.
+   *
+   * ### Example usage:
+   * ```kotlin
+   * val result = clerk.auth.signUpWithGoogleOneTap()
+   * ```
+   */
+  suspend fun signUpWithGoogleOneTap(): ClerkResult<OAuthResult, ClerkErrorResponse> {
+    val result = SignIn.authenticateWithGoogleOneTap()
+    result.onFailure { emitAuthError(it) }
+    return result
+  }
+
+  /**
    * Signs up with an ID token from an identity provider.
    *
    * @param token The ID token from the identity provider.

--- a/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
+++ b/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
@@ -1,0 +1,82 @@
+package com.clerk.api.auth
+
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.model.error.Error
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signup.SignUp
+import com.clerk.api.sso.OAuthResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AuthTest {
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `signUpWithGoogleOneTap delegates to transferable Google One Tap flow`() = runTest {
+    mockkObject(SignIn.Companion)
+    val signUp = mockk<SignUp>(relaxed = true)
+    val oauthResult = OAuthResult(signUp = signUp)
+    coEvery { SignIn.authenticateWithGoogleOneTap(true) } returns ClerkResult.success(oauthResult)
+
+    val result = Auth().signUpWithGoogleOneTap()
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(oauthResult, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
+  }
+
+  @Test
+  fun `signUpWithGoogleOneTap emits auth error event on failure`() = runTest {
+    mockkObject(SignIn.Companion)
+    val error =
+      ClerkErrorResponse(
+        errors =
+          listOf(
+            Error(
+              code = "external_account_exists",
+              message = "Account already exists",
+              longMessage = "Account already exists. Use sign in instead.",
+            )
+          ),
+        clerkTraceId = "trace_123",
+      )
+    coEvery { SignIn.authenticateWithGoogleOneTap(true) } returns ClerkResult.apiFailure(error)
+
+    val auth = Auth()
+    val events = mutableListOf<AuthEvent>()
+    val eventJob =
+      launch(start = CoroutineStart.UNDISPATCHED) { auth.events.take(1).toList(events) }
+
+    val result = auth.signUpWithGoogleOneTap()
+
+    withTimeout(1_000) { eventJob.join() }
+
+    assertTrue(result is ClerkResult.Failure)
+    assertEquals(error, (result as ClerkResult.Failure).error)
+    assertTrue(events.single() is AuthEvent.Error)
+    assertEquals(
+      "Account already exists. Use sign in instead.",
+      (events.single() as AuthEvent.Error).message,
+    )
+    coVerify(exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
+  }
+}


### PR DESCRIPTION
## What changed
- add `Auth.signUpWithGoogleOneTap()` as a public Android auth entrypoint
- delegate it to the existing transferable `SignIn.authenticateWithGoogleOneTap()` flow
- add API-level regression tests for delegation and auth error event emission

## Why
The Android SDK already supports native Google One Tap, but it did not expose a dedicated sign-up convenience method parallel to the iOS surface. This makes the Android API easier to document and lets docs mirror the iOS structure more closely.

## Behavior
This helper intentionally matches the iOS pattern rather than forcing a sign-up-only result. The Google One Tap flow may still resolve to either sign-up or sign-in depending on whether the selected Google account already exists in Clerk.

## Impact
Android apps can now call a dedicated native Google sign-up helper without reimplementing the transfer-flow behavior themselves.

## Validation
- `./gradlew :source:api:spotlessCheck`
- `./gradlew :source:api:detekt`
- `./gradlew :source:api:lintDebug`
- `./gradlew :source:api:testDebugUnitTest --tests "com.clerk.api.auth.AuthTest"`