### PR TITLE
Fix session revocation handling and clean up lint regressions

### DIFF
--- a/samples/prebuilt-ui/src/main/java/com/clerk/prebuiltui/MainActivity.kt
+++ b/samples/prebuilt-ui/src/main/java/com/clerk/prebuiltui/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -26,7 +27,10 @@ class MainActivity : ComponentActivity() {
       val user by Clerk.userFlow.collectAsStateWithLifecycle()
       ClerkTheme {
         Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-          Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+          Box(
+            modifier = Modifier.fillMaxSize().padding(innerPadding),
+            contentAlignment = Alignment.Center,
+          ) {
             if (user != null && session?.pendingTaskKey == null) {
               UserButton()
             } else {

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
@@ -37,6 +37,7 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
         "session_replaced",
         "session_not_found",
         "session_invalid",
+        "authentication_invalid",
       )
   }
 

--- a/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
@@ -224,22 +224,42 @@ class SessionTokenFetcherTest {
   }
 
   @Test
-  fun `getToken does not clear local session state for non-session unauthorized errors`() = runTest {
-    // Given
-    val error = Error(code = "not_authorized", message = "Unauthorized")
-    val errorResponse = ClerkErrorResponse(errors = listOf(error), clerkTraceId = "trace_unauth")
+  fun `getToken clears local session state when token endpoint returns authentication invalid`() =
+    runTest {
+      // Given
+      val error = Error(code = "authentication_invalid", message = "Invalid authentication")
+      val errorResponse = ClerkErrorResponse(errors = listOf(error), clerkTraceId = "trace_unauth")
 
-    coEvery { SessionTokensCache.getToken(any()) } returns null
-    coEvery { mockClerkApiService.tokens("session_123") } returns
-      ClerkResult.httpFailure(code = 401, error = errorResponse)
+      coEvery { SessionTokensCache.getToken(any()) } returns null
+      coEvery { mockClerkApiService.tokens("session_123") } returns
+        ClerkResult.httpFailure(code = 401, error = errorResponse)
 
-    // When
-    val result = sessionTokenFetcher.getToken(mockSession)
+      // When
+      val result = sessionTokenFetcher.getToken(mockSession)
 
-    // Then
-    assertNull(result)
-    verify(exactly = 0) { Clerk.clearSessionAndUserState() }
-  }
+      // Then
+      assertNull(result)
+      verify(exactly = 1) { Clerk.clearSessionAndUserState() }
+    }
+
+  @Test
+  fun `getToken does not clear local session state for non-session unauthorized errors`() =
+    runTest {
+      // Given
+      val error = Error(code = "not_authorized", message = "Unauthorized")
+      val errorResponse = ClerkErrorResponse(errors = listOf(error), clerkTraceId = "trace_unauth")
+
+      coEvery { SessionTokensCache.getToken(any()) } returns null
+      coEvery { mockClerkApiService.tokens("session_123") } returns
+        ClerkResult.httpFailure(code = 401, error = errorResponse)
+
+      // When
+      val result = sessionTokenFetcher.getToken(mockSession)
+
+      // Then
+      assertNull(result)
+      verify(exactly = 0) { Clerk.clearSessionAndUserState() }
+    }
 
   @Test
   fun `getToken uses custom expiration buffer`() = runTest {

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStateEffects.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStateEffects.kt
@@ -3,7 +3,7 @@ package com.clerk.ui.auth
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import com.clerk.ui.R
 
 @Composable
@@ -14,11 +14,11 @@ internal fun AuthStateEffects(
   onAuthComplete: () -> Unit,
   onReset: () -> Unit = {},
 ) {
-  val context = LocalContext.current
-  LaunchedEffect(state) {
+  val defaultErrorMessage = stringResource(R.string.something_went_wrong_please_try_again)
+  LaunchedEffect(state, defaultErrorMessage) {
     when (state) {
       is AuthenticationViewState.Error -> {
-        val msg = state.message ?: context.getString(R.string.something_went_wrong_please_try_again)
+        val msg = state.message ?: defaultErrorMessage
         snackbarHostState.showSnackbar(msg)
       }
       AuthenticationViewState.NotStarted -> authState.clearBackStack()

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -98,8 +98,8 @@ private fun ObservePendingSessionTaskRouting(backStack: NavBackStack<NavKey>) {
 
 @Composable
 private fun AuthNavDisplay(
-  modifier: Modifier = Modifier,
   backStack: NavBackStack<NavKey>,
+  modifier: Modifier = Modifier,
   onAuthComplete: () -> Unit,
 ) {
   NavDisplay(

--- a/source/ui/src/main/java/com/clerk/ui/core/input/ClerkCodeInputField.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/input/ClerkCodeInputField.kt
@@ -343,7 +343,12 @@ private fun OtpBoxRow(
  * @param isError Whether an error occurred.
  */
 @Composable
-private fun OtpBox(modifier: Modifier, char: String, isCurrentBox: Boolean, isError: Boolean) {
+private fun OtpBox(
+  char: String,
+  isCurrentBox: Boolean,
+  isError: Boolean,
+  modifier: Modifier = Modifier,
+) {
   val boxShape = ClerkMaterialTheme.shape
   val borderColor =
     when {

--- a/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
@@ -1,5 +1,6 @@
 package com.clerk.ui.core.input
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -104,6 +105,7 @@ private const val DROPDOWN_HEIGHT_DIVISOR = 3
  * @param onValueChange Callback when the complete phone number changes
  */
 @Composable
+@SuppressLint("ComposeParameterOrder")
 fun ClerkPhoneNumberField(
   value: String,
   modifier: Modifier = Modifier,

--- a/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeView.kt
@@ -90,11 +90,10 @@ private fun SignInFactorCodeViewImpl(
   modifier: Modifier = Modifier,
   isSecondFactor: Boolean = false,
   isClientTrust: Boolean = false,
+  viewModel: SignInFactorCodeViewModel =
+    viewModel(key = signInFactorCodeViewModelKey(isSecondFactor)),
   onAuthComplete: () -> Unit,
 ) {
-  val signInId = Clerk.auth.currentSignIn?.id ?: "no-sign-in"
-  val viewModel: SignInFactorCodeViewModel =
-    viewModel(key = "sign-in-code-$signInId-$isSecondFactor")
   val authState = LocalAuthState.current
   val state by viewModel.state.collectAsStateWithLifecycle()
   val verificationTextState by viewModel.verificationUiState.collectAsStateWithLifecycle()
@@ -124,20 +123,11 @@ private fun SignInFactorCodeViewImpl(
     if (isClientTrust) {
       ClientTrustWarningMessage()
     }
-    ClerkCodeInputField(
-      verificationState = verificationTextState.verificationState(),
-      onTextChange = {
-        if (verificationTextState is VerificationUiState.Error) {
-          viewModel.resetState()
-          viewModel.resetVerificationState()
-        }
-        if (it.length == 6) {
-          viewModel.attempt(factor, isSecondFactor = isSecondFactor, code = it)
-        }
-      },
-      showResend =
-        SignInFactorCodeUiHelper.showResend(factor, verificationTextState.verificationState()),
-      onClickResend = { viewModel.prepare(factor, isSecondFactor = isSecondFactor) },
+    SignInCodeInput(
+      factor = factor,
+      verificationTextState = verificationTextState,
+      isSecondFactor = isSecondFactor,
+      viewModel = viewModel,
     )
     Spacers.Vertical.Spacer24()
     if (SignInFactorCodeUiHelper.showUseAnotherMethod(factor)) {
@@ -157,6 +147,33 @@ private fun SignInFactorCodeViewImpl(
       )
     }
   }
+}
+
+private fun signInFactorCodeViewModelKey(isSecondFactor: Boolean): String =
+  "sign-in-code-${Clerk.auth.currentSignIn?.id ?: "no-sign-in"}-$isSecondFactor"
+
+@Composable
+private fun SignInCodeInput(
+  factor: Factor,
+  verificationTextState: VerificationUiState,
+  isSecondFactor: Boolean,
+  viewModel: SignInFactorCodeViewModel,
+) {
+  ClerkCodeInputField(
+    verificationState = verificationTextState.verificationState(),
+    onTextChange = {
+      if (verificationTextState is VerificationUiState.Error) {
+        viewModel.resetState()
+        viewModel.resetVerificationState()
+      }
+      if (it.length == 6) {
+        viewModel.attempt(factor, isSecondFactor = isSecondFactor, code = it)
+      }
+    },
+    showResend =
+      SignInFactorCodeUiHelper.showResend(factor, verificationTextState.verificationState()),
+    onClickResend = { viewModel.prepare(factor, isSecondFactor = isSecondFactor) },
+  )
 }
 
 /**

--- a/source/ui/src/main/java/com/clerk/ui/signin/help/SignInGetHelpView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/help/SignInGetHelpView.kt
@@ -35,10 +35,12 @@ fun SignInGetHelpView(modifier: Modifier = Modifier) {
     onBackPressed = { authState.navigateBack() },
   ) {
     val context = LocalContext.current
+    val supportEmail = stringResource(R.string.support_clerk_com)
+    val noEmailClientsMessage = stringResource(R.string.no_email_clients_installed_on_device)
     val emailIntent =
       Intent(Intent.ACTION_SENDTO).apply {
         data = "mailto:".toUri()
-        putExtra(Intent.EXTRA_EMAIL, arrayOf(stringResource(R.string.support_clerk_com)))
+        putExtra(Intent.EXTRA_EMAIL, arrayOf(supportEmail))
       }
 
     ClerkButton(
@@ -51,7 +53,7 @@ fun SignInGetHelpView(modifier: Modifier = Modifier) {
           ClerkLog.e("No email clients installed on device.")
           scope.launch {
             snackbarHostState.showSnackbar(
-              message = context.getString(R.string.no_email_clients_installed_on_device),
+              message = noEmailClientsMessage,
               duration = SnackbarDuration.Short,
             )
           }

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/forgot/SignInFactorOneForgotPasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/forgot/SignInFactorOneForgotPasswordView.kt
@@ -86,21 +86,20 @@ private fun SignInFactorOneForgotPasswordViewImpl(
   onClickFactor: (Factor) -> Unit,
   modifier: Modifier = Modifier,
   textIconHelper: TextIconHelper = TextIconHelper(),
+  viewModel: ForgotPasswordViewModel =
+    viewModel(key = "forgot-password-${Clerk.auth.currentSignIn?.id ?: "no-sign-in"}"),
   onAuthComplete: () -> Unit,
 ) {
-  val signInId = Clerk.auth.currentSignIn?.id ?: "no-sign-in"
-  val viewModel: ForgotPasswordViewModel = viewModel(key = "forgot-password-$signInId")
   val authState = LocalAuthState.current
   val context = LocalContext.current
+  val defaultErrorMessage = stringResource(R.string.something_went_wrong_please_try_again)
   val state by viewModel.state.collectAsStateWithLifecycle()
   val snackbarHostState = remember { SnackbarHostState() }
 
-  LaunchedEffect(state) {
+  LaunchedEffect(state, defaultErrorMessage) {
     when (val s = state) {
       is ResetPasswordViewState.Error -> {
-        snackbarHostState.showSnackbar(
-          s.message ?: context.getString(R.string.something_went_wrong_please_try_again)
-        )
+        snackbarHostState.showSnackbar(s.message ?: defaultErrorMessage)
         viewModel.resetState()
       }
       ResetPasswordViewState.NotStarted -> {

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
@@ -81,11 +81,11 @@ internal fun SessionTaskResetPasswordView(
  */
 @Composable
 private fun SignInSetNewPasswordViewImpl(
-  modifier: Modifier = Modifier,
   mode: ResetPasswordMode,
+  modifier: Modifier = Modifier,
+  viewModel: ResetPasswordViewModel = viewModel(key = mode.viewModelKey()),
   onAuthComplete: () -> Unit,
 ) {
-  val viewModel: ResetPasswordViewModel = viewModel(key = mode.viewModelKey())
   val authState = LocalAuthState.current
   val snackbarHostState = remember { SnackbarHostState() }
   var signOutOtherDevices by remember { mutableStateOf(false) }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/phone/UserProfilePhoneRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/phone/UserProfilePhoneRow.kt
@@ -47,14 +47,7 @@ internal fun UserProfilePhoneRow(
 ) {
   val isPreview = LocalInspectionMode.current
   val state by viewModel.state.collectAsStateWithLifecycle()
-  LaunchedEffect(state) {
-    if (
-      state is UserProfileAddPhoneViewModel.State.Error &&
-        (state as UserProfileAddPhoneViewModel.State.Error).message != null
-    ) {
-      onError((state as UserProfileAddPhoneViewModel.State.Error).message!!)
-    }
-  }
+  ReportPhoneRowError(state, onError)
 
   ClerkMaterialTheme {
     Row(
@@ -103,6 +96,19 @@ internal fun UserProfilePhoneRow(
           },
         )
       }
+    }
+  }
+}
+
+@Composable
+private fun ReportPhoneRowError(
+  state: UserProfileAddPhoneViewModel.State,
+  onError: (String) -> Unit,
+) {
+  val errorMessage = (state as? UserProfileAddPhoneViewModel.State.Error)?.message
+  LaunchedEffect(errorMessage) {
+    if (errorMessage != null) {
+      onError(errorMessage)
     }
   }
 }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/security/UserProfileSecurityView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/security/UserProfileSecurityView.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -119,7 +118,7 @@ private fun UserProfileSecurityMainContent(
   var currentSheetType by remember {
     mutableStateOf<BottomSheetType>(BottomSheetType.DeleteAccount)
   }
-  val context = LocalContext.current
+  val defaultErrorMessage = stringResource(R.string.something_went_wrong_please_try_again)
   Scaffold(
     containerColor = ClerkMaterialTheme.colors.muted,
     snackbarHost = { ClerkErrorSnackbar(snackbarHostState) },
@@ -164,11 +163,7 @@ private fun UserProfileSecurityMainContent(
           }
       },
       onError = { message ->
-        coroutineScope.launch {
-          snackbarHostState.showSnackbar(
-            message ?: context.getString(R.string.something_went_wrong_please_try_again)
-          )
-        }
+        coroutineScope.launch { snackbarHostState.showSnackbar(message ?: defaultErrorMessage) }
       },
     )
     BottomSheetContent(
@@ -203,11 +198,7 @@ private fun UserProfileSecurityMainContent(
             showBottomSheet = true
           },
           onError = { message ->
-            coroutineScope.launch {
-              snackbarHostState.showSnackbar(
-                message ?: context.getString(R.string.something_went_wrong_please_try_again)
-              )
-            }
+            coroutineScope.launch { snackbarHostState.showSnackbar(message ?: defaultErrorMessage) }
           },
         ),
     )
@@ -274,11 +265,7 @@ private fun BottomSheetContent(
       val programmaticDismissCallbacks =
         callbacks.copy(
           onDismiss = {
-            scope.launch {
-              sheetState.hide()
-            }.invokeOnCompletion {
-              callbacks.onDismiss()
-            }
+            scope.launch { sheetState.hide() }.invokeOnCompletion { callbacks.onDismiss() }
           }
         )
 

--- a/source/ui/src/main/res/values/strings.xml
+++ b/source/ui/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="country">Country</string>
     <string name="enter_your_phone_number">Enter your phone number</string>
     <string name="incorrect_verification_code">Incorrect verification code</string>
@@ -34,7 +34,7 @@
     <string name="reset_password">Reset password</string>
     <string name="confirm_password">Confirm password</string>
     <string name="new_password">New password</string>
-    <string name="account_requires_new_password_before_continue">Your account requires a new password before you can continue</string>
+    <string name="account_requires_new_password_before_continue" tools:ignore="MissingTranslation">Your account requires a new password before you can continue</string>
     <string name="sign_out_of_all_other_devices">Sign out of all other devices</string>
     <string name="back">Back</string>
     <string name="enter_a_backup_code">Enter a backup code</string>
@@ -87,7 +87,7 @@
     <string name="last_name">Last name</string>
     <string name="facing_issues_you_can_use_any_of_these_methods_to_sign_in">Facing issues? You can use any of these methods to sign in.</string>
     <string name="two_step_verification">Two-step verification</string>
-    <string name="signing_in_from_new_device">You\'re signing in from a new device. We\'re asking for verification to keep your account secure.</string>
+    <string name="signing_in_from_new_device" tools:ignore="MissingTranslation">You\'re signing in from a new device. We\'re asking for verification to keep your account secure.</string>
     <string name="when_signing_in_you_will_need_to_enter_a_verification_code">When signing in, you will need to enter a verification code sent to this phone number as an additional step.\n\nSave these backup codes and store them somewhere safe. If you lose access to your authentication device, you can use backup codes to sign in.</string>
     <string name="two_step_verification_is_now_enabled">Two-step verification is now enabled. When signing in, you will need to enter a verification code from this authenticator app as an additional step.\n\nSave these backup codes and store them somewhere safe. If you lose access to your authentication device, you can use backup codes to sign in.</string>
     <string name="backup_codes_are_now_enabled">Backup codes are now enabled. You can use one of these to sign in to your account, if you lose access to your authentication device. Each code can only be used once.</string>
@@ -139,7 +139,7 @@
     <string name="rename">Rename</string>
     <string name="created">Created: %1$s</string>
     <string name="last_used">Last used: %1$s</string>
-    <string name="last_used_badge">Last used</string>
+    <string name="last_used_badge" tools:ignore="MissingTranslation">Last used</string>
     <string name="add_a_passkey">Add a passkey</string>
     <string name="account">Account</string>
     <string name="delete_account">Delete account</string>
@@ -184,6 +184,6 @@
     <string name="terms_of_service">Terms of Service</string>
     <string name="privacy_policy">Privacy Policy</string>
     <string name="and_connector">and</string>
-    <string name="set_up_two_step_verification">Set up two-step verification</string>
-    <string name="choose_which_method_you_prefer_to_protect_your_account_with_an_extra_layer_of_security">Choose which method you prefer to protect your account with an extra layer of security.</string>
+    <string name="set_up_two_step_verification" tools:ignore="MissingTranslation">Set up two-step verification</string>
+    <string name="choose_which_method_you_prefer_to_protect_your_account_with_an_extra_layer_of_security" tools:ignore="MissingTranslation">Choose which method you prefer to protect your account with an extra layer of security.</string>
 </resources>

--- a/workbench/src/main/java/com/clerk/workbench/HomeView.kt
+++ b/workbench/src/main/java/com/clerk/workbench/HomeView.kt
@@ -2,12 +2,15 @@
 
 package com.clerk.workbench
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.clerk.api.Clerk
@@ -29,7 +32,9 @@ fun UserProfileTopBar() {
         },
       )
     }
-  ) {}
+  ) { innerPadding ->
+    Box(modifier = Modifier.padding(innerPadding))
+  }
 }
 
 @PreviewLightDark


### PR DESCRIPTION
## Summary
- Add `authentication_invalid` to the session invalidation allowlist so revoked sessions clear local auth state.
- Add a regression test covering the 401 `authentication_invalid` token fetch response.
- Fix repo-wide lint failures in UI, sample, and workbench composables by aligning parameter order, handling scaffold padding, and replacing `LocalContext.getString` usages with Compose-safe string access.
- Suppress the remaining intentional missing-translation entries in the base strings file.

## Testing
- `spotlessCheck`
- `detekt`
- `lint`
- `:source:api:testDebugUnitTest --tests "com.clerk.api.session.SessionTokenFetcherTest"`
- Verified full repo lint passes under Java 21; Java 17 cannot run the full lint configuration because the UI Paparazzi plugin requires JVM 21.