### PR TITLE
fix(api): seed currentActivity on initialize + add attachActivity API (MOBILE-485)

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -3,6 +3,7 @@ package com.clerk.api
 import android.app.Activity
 import android.app.Application
 import android.content.Context
+import android.content.ContextWrapper
 import com.clerk.api.Clerk.activeSession
 import com.clerk.api.Clerk.activeUser
 import com.clerk.api.Clerk.initialize
@@ -589,6 +590,15 @@ object Clerk {
       application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
       trackedApplication = application
     }
+    // Seed currentActivity from the passed context if it (or a wrapper around
+    // it) is an Activity. Without this, callers that initialize() after the
+    // host Activity has already passed onResume — e.g. React Native bridges,
+    // late-init flows behind a permission gate, or any framework that boots
+    // Clerk after activity creation — would see currentActivity stay null
+    // until the next OS-driven resume cycle, breaking the first Credential
+    // Manager call (Google sign-in, passkeys). Callers without an Activity
+    // context can use [attachActivity] instead.
+    context.findActivityOrNull()?.let { currentActivity = WeakReference(it) }
     this.customTheme = theme
     this.telemetryEnabled = options?.telemetryEnabled ?: true
     configurationManager.configure(
@@ -596,6 +606,47 @@ object Clerk {
       publishableKey = publishableKey,
       options = options,
     )
+  }
+
+  /**
+   * Provides the current foreground [Activity] to Clerk explicitly.
+   *
+   * Useful for framework integrations — e.g. React Native bridges, plug-in
+   * SDKs, or any host that calls [initialize] with a non-Activity [Context]
+   * after the host Activity has already passed [Activity.onResume]. In that
+   * case the [Application.ActivityLifecycleCallbacks] registered by
+   * [initialize] miss the initial resume, leaving Clerk's tracked activity
+   * null — which makes the first Credential Manager call (Google sign-in,
+   * passkeys) fail with a `MissingActivity` error until the user backgrounds
+   * and foregrounds the app.
+   *
+   * Calling this with the current Activity immediately after [initialize]
+   * eliminates that gap. Subsequent activity changes are still observed via
+   * the registered lifecycle callbacks; this method only seeds the initial
+   * value.
+   *
+   * @param activity The current foreground Activity. Held as a [WeakReference]
+   *   so it can still be garbage-collected when destroyed.
+   */
+  fun attachActivity(activity: Activity) {
+    currentActivity = WeakReference(activity)
+  }
+
+  /**
+   * Walks a [Context]/[ContextWrapper] chain looking for an [Activity].
+   *
+   * Returns the first Activity found, or null if the chain bottoms out at the
+   * Application context (or any other non-Activity context). Used by
+   * [initialize] so callers that pass an Activity (or a wrapper around one)
+   * automatically seed [currentActivity].
+   */
+  private fun Context.findActivityOrNull(): Activity? {
+    var ctx: Context? = this
+    while (ctx is ContextWrapper) {
+      if (ctx is Activity) return ctx
+      ctx = ctx.baseContext
+    }
+    return null
   }
 
   /**

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkAttachActivityTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkAttachActivityTest.kt
@@ -1,0 +1,118 @@
+package com.clerk.api.sdk
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import com.clerk.api.Clerk
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Verifies the activity-tracking guarantees that callers rely on for
+ * Credential Manager flows (Google sign-in, passkeys). Without these,
+ * `Clerk.credentialActivity()` returns null on cold start in any host that
+ * calls [Clerk.initialize] after the host Activity has already passed
+ * onResume — e.g. React Native bridges, late-init flows behind a permission
+ * gate.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ClerkAttachActivityTest {
+
+  @After
+  fun tearDown() {
+    // Clear the Clerk-singleton state we mutated.
+    val field = Clerk::class.java.getDeclaredField("currentActivity")
+    field.isAccessible = true
+    field.set(Clerk, null)
+    unmockkAll()
+  }
+
+  @Test
+  fun `attachActivity seeds credentialActivity`() {
+    val activity = mockk<Activity>(relaxed = true)
+    Clerk.attachActivity(activity)
+
+    val seeded = readCredentialActivity()
+
+    assertSame(activity, seeded)
+  }
+
+  @Test
+  fun `attachActivity holds Activity weakly`() {
+    var activity: Activity? = mockk<Activity>(relaxed = true)
+    Clerk.attachActivity(activity!!)
+
+    val ref = Clerk::class.java.getDeclaredField("currentActivity")
+      .apply { isAccessible = true }
+      .get(Clerk) as java.lang.ref.WeakReference<*>?
+
+    // Same instance through the WeakReference while it's alive.
+    assertSame(activity, ref?.get())
+
+    // Drop the strong reference; we don't assert collection happens (the GC
+    // is non-deterministic in unit tests), only that the field type lets it.
+    activity = null
+    @Suppress("UNUSED_EXPRESSION") activity
+  }
+
+  @Test
+  fun `credentialActivity returns null when no activity attached`() {
+    val seeded = readCredentialActivity()
+
+    assertNull(seeded)
+  }
+
+  /**
+   * `credentialActivity` is a Kotlin `internal` function on the Clerk
+   * singleton. Kotlin mangles its JVM name with a build-flavor suffix
+   * (`$api_debug` in tests, `$api_release` in published artifacts), so we
+   * locate it dynamically by base name rather than hardcoding the suffix.
+   */
+  private fun readCredentialActivity(): Activity? {
+    val method = Clerk::class.java.declaredMethods
+      .first { it.name == "credentialActivity" || it.name.startsWith("credentialActivity\$") }
+      .apply { isAccessible = true }
+    return method.invoke(Clerk) as Activity?
+  }
+
+  /**
+   * Smoke test for the [Context]-walk inside [Clerk.initialize]. We exercise
+   * the helper directly rather than going through `initialize()` (which would
+   * spin up the configuration manager); the helper's contract is the
+   * load-bearing piece for the seeding guarantee.
+   */
+  @Test
+  fun `Context findActivityOrNull walks ContextWrapper chain`() {
+    val activity = mockk<Activity>(relaxed = true)
+    val outer: Context = object : ContextWrapper(activity) {}
+
+    val helper = Clerk::class.java.getDeclaredMethod(
+      "findActivityOrNull",
+      Context::class.java,
+    ).apply { isAccessible = true }
+
+    val found = helper.invoke(Clerk, outer) as Activity?
+    assertSame(activity, found)
+  }
+
+  @Test
+  fun `Context findActivityOrNull returns null when no Activity in chain`() {
+    val plain = mockk<Context>(relaxed = true)
+    every { plain.applicationContext } returns plain
+
+    val helper = Clerk::class.java.getDeclaredMethod(
+      "findActivityOrNull",
+      Context::class.java,
+    ).apply { isAccessible = true }
+
+    val found = helper.invoke(Clerk, plain) as Activity?
+    assertNull(found)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes [MOBILE-485](https://linear.app/clerk/issue/MOBILE-485/new-reproducible-bug-on-android-with-google-sign-in-in-authview).

`Clerk.initialize()` registers `ActivityLifecycleCallbacks` to track the current foreground `Activity` for Credential Manager flows (Google sign-in, passkeys). Those callbacks only fire on subsequent `onActivityCreated/Started/Resumed` events — they don't observe the host Activity's *current* state at the moment `initialize()` runs.

This breaks any consumer that initializes the SDK after the host Activity has already passed `onResume`. Most notably:

- **React Native** — `<ClerkProvider />` mounts in JS only after `MainActivity` is fully resumed, so when its `configure()` call reaches `Clerk.initialize()`, `currentActivity` stays null until the next OS-driven resume cycle. The first Credential Manager call fails with `CredentialFlowException.MissingActivity` until the user backgrounds and foregrounds the app.
- **Late-initialized native apps** — anything that defers `Clerk.initialize()` past `Activity.onCreate` (permission gates, A/B flag fetch, etc.).

This was reported by a Business customer (M2X Group, ticket T-57530) on `@clerk/expo@3.2.2`. Reproduced first-hand on emulator with `@clerk/expo@3.2.7` (clerk-android-ui 1.0.13).

## Changes

Two complementary additions cover the cases:

1. **`initialize()` walks the passed `Context`'s `ContextWrapper` chain** looking for an `Activity`. Direct-Android consumers who pass an `Activity` (or a wrapper around one) get `currentActivity` seeded transparently — no behavior change for `Application.onCreate` callers since their context isn't an Activity.

2. **New public `Clerk.attachActivity(activity)`** for hosts that pass an `Application`-typed `Context` to `initialize()` but have a current `Activity` available. The companion `@clerk/expo` bridge will adopt this in its next release.

Adds five focused unit tests covering the new API and the `Context`-walk helper.

## Test plan

- [x] `./gradlew :source:api:testDebugUnitTest` — full api test suite passes
- [x] New `ClerkAttachActivityTest` (5 tests) covers:
  - `attachActivity` seeds `credentialActivity()`
  - `attachActivity` holds the Activity weakly
  - `credentialActivity()` returns null when no Activity attached
  - `Context.findActivityOrNull()` walks `ContextWrapper` chain
  - `Context.findActivityOrNull()` returns null when no Activity in chain
- [x] All sample apps assemble against the patched SDK (`quickstart`, `workbench`, `linear-clone`, `prebuilt-ui`, `custom-flows`)
- [x] Local Maven publish succeeds, AAR contains `attachActivity` symbol
- [x] End-to-end: built `@clerk/expo` against this branch (consuming via local Maven), patched its `ClerkExpoModule.configure()` and `ClerkAuthNativeView` to call `Clerk.attachActivity()`, ran the customer's exact reproduction:
  - Cold-launch the quickstart on a Pixel 9 Pro emulator (`pm clear` for clean state)
  - Tap "Sign in with Google" as the first action
  - **Before**: `E/ClerkLog: Clerk error: Google sign-in cannot start: Credential Manager requires an active Activity context.` — silent failure on JS, stuck on AuthView
  - **After**: `I/CredentialManager: starting executeGetCredential` → `[GetGoogleIdOperation] Operation succeeded` → Google account picker opens, sign-in completes