### PR TITLE
Add runtime Clerk configuration switching

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -10,11 +10,14 @@ import com.clerk.api.Clerk.initialize
 import com.clerk.api.Clerk.isInitialized
 import com.clerk.api.Clerk.session
 import com.clerk.api.Clerk.user
+import com.clerk.api.attestation.DeviceAttestationHelper
 import com.clerk.api.auth.Auth
 import com.clerk.api.configuration.ConfigurationManager
 import com.clerk.api.configuration.PublishableKeyHelper
+import com.clerk.api.externalaccount.ExternalAccountService
 import com.clerk.api.locale.LocaleProvider
 import com.clerk.api.log.ClerkLog
+import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.environment.Environment
 import com.clerk.api.network.model.environment.InstanceEnvironmentType
@@ -25,8 +28,12 @@ import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.network.model.factor.isResetFactor
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
+import com.clerk.api.session.SessionTokensCache
 import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
+import com.clerk.api.sso.SSOService
+import com.clerk.api.storage.StorageHelper
+import com.clerk.api.storage.StorageKey
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.api.user.User
 import com.clerk.sdk.BuildConfig
@@ -41,6 +48,7 @@ import kotlinx.coroutines.flow.asStateFlow
  * Provides access to authentication state, user information, and core functionality for managing
  * user sessions and sign-in flows.
  */
+@Suppress("TooManyFunctions")
 object Clerk {
 
   // region Configuration & Initialization
@@ -120,7 +128,7 @@ object Clerk {
   internal var applicationId: String? = null
 
   /** Internal environment configuration containing display settings and authentication options. */
-  internal lateinit var environment: Environment
+  internal var environment: Environment? = null
 
   /**
    * The Client object representing the current device and its authentication state.
@@ -190,7 +198,7 @@ object Clerk {
   val initializationError: StateFlow<Throwable?> = configurationManager.initializationError
 
   val applicationName: String?
-    get() = if (::environment.isInitialized) environment.displayConfig.applicationName else null
+    get() = environment?.displayConfig?.applicationName
 
   /**
    * The current version of the Clerk Android SDK.
@@ -217,11 +225,10 @@ object Clerk {
    *   empty list if the SDK is not initialized or if no first factor attributes are enabled.
    */
   val enabledFirstFactorAttributes: List<String>
-    get() =
-      if (::environment.isInitialized) environment.enabledFirstFactorAttributes() else emptyList()
+    get() = environment?.enabledFirstFactorAttributes().orEmpty()
 
   val isUserNameEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.usernameIsEnabled else false
+    get() = environment?.usernameIsEnabled ?: false
 
   /**
    * Indicates whether the 'First Name' field is enabled for user profiles.
@@ -232,7 +239,7 @@ object Clerk {
    *   the SDK is not yet initialized.
    */
   val isFirstNameEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.firstNameIsEnabled else false
+    get() = environment?.firstNameIsEnabled ?: false
 
   /**
    * Indicates whether the last name field is enabled for user profiles.
@@ -244,54 +251,43 @@ object Clerk {
    *   SDK is not yet initialized.
    */
   val isLastNameEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.lastNameIsEnabled else false
+    get() = environment?.lastNameIsEnabled ?: false
 
   val passwordIsEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.passwordIsEnabled else false
+    get() = environment?.passwordIsEnabled ?: false
 
   val mfaIsEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.mfaIsEnabled else false
+    get() = environment?.mfaIsEnabled ?: false
 
   val passkeyIsEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.passkeyIsEnabled else false
+    get() = environment?.passkeyIsEnabled ?: false
 
   val isEmailEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.emailIsEnabled else false
+    get() = environment?.emailIsEnabled ?: false
 
   val isPhoneNumberEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.phoneNumberIsEnabled else false
+    get() = environment?.phoneNumberIsEnabled ?: false
 
   val isEmailImmutable: Boolean
-    get() = if (::environment.isInitialized) environment.emailIsImmutable else false
+    get() = environment?.emailIsImmutable ?: false
 
   val isPhoneNumberImmutable: Boolean
-    get() = if (::environment.isInitialized) environment.phoneNumberIsImmutable else false
+    get() = environment?.phoneNumberIsImmutable ?: false
 
   val isUsernameImmutable: Boolean
-    get() = if (::environment.isInitialized) environment.usernameIsImmutable else false
+    get() = environment?.usernameIsImmutable ?: false
 
   val deleteSelfIsEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.userSettings.actions.deleteSelf else false
+    get() = environment?.userSettings?.actions?.deleteSelf ?: false
 
   val organizationCreationDefaultsIsEnabled: Boolean
-    get() =
-      if (::environment.isInitialized) {
-        environment.organizationSettings.organizationCreationDefaults.enabled
-      } else {
-        false
-      }
+    get() = environment?.organizationSettings?.organizationCreationDefaults?.enabled ?: false
 
   val organizationSelectionIsForced: Boolean
-    get() =
-      if (::environment.isInitialized) {
-        environment.organizationSettings.forceOrganizationSelection
-      } else {
-        false
-      }
+    get() = environment?.organizationSettings?.forceOrganizationSelection ?: false
 
   val organizationSlugIsEnabled: Boolean
-    get() =
-      if (::environment.isInitialized) !environment.organizationSettings.slug.disabled else true
+    get() = environment?.organizationSettings?.slug?.disabled?.not() ?: true
 
   /**
    * The image URL for the application logo used in authentication UI components.
@@ -301,7 +297,7 @@ object Clerk {
    * not yet initialized or no logo URL is configured.
    */
   val organizationLogoUrl: String?
-    get() = if (::environment.isInitialized) environment.displayConfig.logoImageUrl else null
+    get() = environment?.displayConfig?.logoImageUrl
 
   /**
    * Indicates whether Google One Tap sign-in is enabled for the application.
@@ -314,9 +310,7 @@ object Clerk {
    *   not yet initialized.
    */
   val isGoogleOneTapEnabled: Boolean
-    get() =
-      if (::environment.isInitialized) environment.displayConfig.googleOneTapClientId != null
-      else false
+    get() = environment?.displayConfig?.googleOneTapClientId != null
 
   /**
    * Indicates whether Clerk branding is enabled for the application.
@@ -328,7 +322,7 @@ object Clerk {
    *   initialized.
    */
   val isBranded: Boolean
-    get() = if (::environment.isInitialized) environment.displayConfig.branded else true
+    get() = environment?.displayConfig?.branded ?: true
 
   /**
    * The URL of the Terms of Service page for the application.
@@ -340,7 +334,7 @@ object Clerk {
    *   initialized.
    */
   val termsUrl: String?
-    get() = if (::environment.isInitialized) environment.displayConfig.termsUrl else null
+    get() = environment?.displayConfig?.termsUrl
 
   /**
    * The URL of the Privacy Policy page for the application.
@@ -352,7 +346,7 @@ object Clerk {
    *   not yet initialized.
    */
   val privacyPolicyUrl: String?
-    get() = if (::environment.isInitialized) environment.displayConfig.privacyPolicyUrl else null
+    get() = environment?.displayConfig?.privacyPolicyUrl
 
   /**
    * Indicates whether MFA (Multi-Factor Authentication) via phone code is enabled.
@@ -364,7 +358,7 @@ object Clerk {
    *   is not yet initialized.
    */
   val mfaPhoneCodeIsEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.mfaPhoneCodeIsEnabled else false
+    get() = environment?.mfaPhoneCodeIsEnabled ?: false
 
   /**
    * Indicates whether MFA (Multi-Factor Authentication) via backup codes is enabled.
@@ -376,10 +370,10 @@ object Clerk {
    *   SDK is not yet initialized.
    */
   val mfaBackupCodeIsEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.mfaBackupCodeIsEnabled else false
+    get() = environment?.mfaBackupCodeIsEnabled ?: false
 
   val mfaAuthenticatorAppIsEnabled: Boolean
-    get() = if (::environment.isInitialized) environment.mfaAuthenticatorAppIsEnabled else false
+    get() = environment?.mfaAuthenticatorAppIsEnabled ?: false
 
   // endregion
 
@@ -494,7 +488,7 @@ object Clerk {
    * @see [SignIn.create] for usage with OAuth authentication.
    */
   val socialProviders: Map<String, UserSettings.SocialConfig>
-    get() = if (::environment.isInitialized) environment.userSettings.social else emptyMap()
+    get() = environment?.userSettings?.social ?: emptyMap()
 
   // endregion
 
@@ -580,6 +574,16 @@ object Clerk {
     options: ClerkConfigurationOptions? = null,
     theme: ClerkTheme? = null,
   ) {
+    if (configurationManager.isConfigured()) {
+      context.findActivityOrNull()?.let { currentActivity = WeakReference(it) }
+      configurationManager.configure(
+        context = context,
+        publishableKey = publishableKey,
+        options = options,
+      )
+      return
+    }
+
     val appContext = context.applicationContext
     this.debugMode = options?.enableDebugMode == true
     this.proxyUrl = options?.proxyUrl
@@ -609,24 +613,73 @@ object Clerk {
   }
 
   /**
+   * Clears the active Clerk configuration and local runtime state.
+   *
+   * This is a local SDK reset: it cancels in-process refresh work, clears the configured API
+   * client, drops the device token, clears session/user flows, and removes cached authentication
+   * state. It does not revoke the server-side session. Call `Clerk.auth.signOut()` first if the
+   * current session should also be ended on Clerk's servers.
+   *
+   * After reset completes, call [initialize] again to configure a new publishable key or proxy URL.
+   */
+  fun reset() {
+    configurationManager.reset()
+    StorageHelper.deleteValue(StorageKey.DEVICE_TOKEN)
+    clearSessionAndUserState()
+    SessionTokensCache.clear()
+    SSOService.cancelPendingAuthentication()
+    ExternalAccountService.cancelPendingExternalAccountConnection()
+    DeviceAttestationHelper.clearCache()
+    LocaleProvider.cleanup()
+    ClerkApi.reset()
+    updateClient(Client())
+    environment = null
+    publishableKey = null
+    baseUrl = ""
+    proxyUrl = null
+    debugMode = false
+    telemetryEnabled = true
+    customTheme = null
+    applicationId = null
+    applicationContext = null
+    currentActivity = null
+    trackedApplication?.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
+    trackedApplication = null
+  }
+
+  /**
+   * Switches the active Clerk configuration in the current process.
+   *
+   * This performs a local [reset] and then calls [initialize] with the provided configuration. Like
+   * [initialize], the client/environment refresh happens asynchronously; observe [isInitialized] to
+   * know when the new configuration is ready.
+   */
+  fun switchConfiguration(
+    context: Context,
+    publishableKey: String,
+    options: ClerkConfigurationOptions? = null,
+    theme: ClerkTheme? = null,
+  ) {
+    reset()
+    initialize(context = context, publishableKey = publishableKey, options = options, theme = theme)
+  }
+
+  /**
    * Provides the current foreground [Activity] to Clerk explicitly.
    *
-   * Useful for framework integrations — e.g. React Native bridges, plug-in
-   * SDKs, or any host that calls [initialize] with a non-Activity [Context]
-   * after the host Activity has already passed [Activity.onResume]. In that
-   * case the [Application.ActivityLifecycleCallbacks] registered by
-   * [initialize] miss the initial resume, leaving Clerk's tracked activity
-   * null — which makes the first Credential Manager call (Google sign-in,
-   * passkeys) fail with a `MissingActivity` error until the user backgrounds
-   * and foregrounds the app.
+   * Useful for framework integrations — e.g. React Native bridges, plug-in SDKs, or any host that
+   * calls [initialize] with a non-Activity [Context] after the host Activity has already passed
+   * [Activity.onResume]. In that case the [Application.ActivityLifecycleCallbacks] registered by
+   * [initialize] miss the initial resume, leaving Clerk's tracked activity null — which makes the
+   * first Credential Manager call (Google sign-in, passkeys) fail with a `MissingActivity` error
+   * until the user backgrounds and foregrounds the app.
    *
-   * Calling this with the current Activity immediately after [initialize]
-   * eliminates that gap. Subsequent activity changes are still observed via
-   * the registered lifecycle callbacks; this method only seeds the initial
-   * value.
+   * Calling this with the current Activity immediately after [initialize] eliminates that gap.
+   * Subsequent activity changes are still observed via the registered lifecycle callbacks; this
+   * method only seeds the initial value.
    *
-   * @param activity The current foreground Activity. Held as a [WeakReference]
-   *   so it can still be garbage-collected when destroyed.
+   * @param activity The current foreground Activity. Held as a [WeakReference] so it can still be
+   *   garbage-collected when destroyed.
    */
   fun attachActivity(activity: Activity) {
     currentActivity = WeakReference(activity)
@@ -635,10 +688,9 @@ object Clerk {
   /**
    * Walks a [Context]/[ContextWrapper] chain looking for an [Activity].
    *
-   * Returns the first Activity found, or null if the chain bottoms out at the
-   * Application context (or any other non-Activity context). Used by
-   * [initialize] so callers that pass an Activity (or a wrapper around one)
-   * automatically seed [currentActivity].
+   * Returns the first Activity found, or null if the chain bottoms out at the Application context
+   * (or any other non-Activity context). Used by [initialize] so callers that pass an Activity (or
+   * a wrapper around one) automatically seed [currentActivity].
    */
   private fun Context.findActivityOrNull(): Activity? {
     var ctx: Context? = this

--- a/source/api/src/main/kotlin/com/clerk/api/attestation/DeviceAttestationHelper.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/attestation/DeviceAttestationHelper.kt
@@ -277,6 +277,8 @@ internal object DeviceAttestationHelper {
     preparedProviders.clear()
     hashCache.clear()
     integrityTokenProvider = null
+    integrityManager = null
+    isManagerInitialized = false
     ClerkLog.d("DeviceAttestationHelper cache cleared")
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
@@ -58,7 +58,6 @@ internal class ConfigurationManager {
     const val LIFECYCLE_REFRESH_MAX_DEFER_MS = 5_000L
   }
 
-
   /**
    * Coroutine scope with SupervisorJob for parallel API requests.
    *
@@ -107,7 +106,7 @@ internal class ConfigurationManager {
   internal lateinit var publishableKey: String
 
   /** Flag to track if configuration has been started to prevent duplicate initialization. */
-  private var hasConfigured = false
+  @Volatile private var hasConfigured = false
 
   /** Stored configuration options for use in retry attempts. */
   private var storedOptions: ClerkConfigurationOptions? = null
@@ -122,9 +121,20 @@ internal class ConfigurationManager {
   /** Internal job reference for ongoing initialization operations. */
   private var initializationJob: Job? = null
 
+  /** Monotonic token used to ignore stale refreshes from an older configuration. */
+  @Volatile private var configurationVersion = 0
+
   private enum class RefreshMode {
     INITIALIZATION,
     DEVICE_TOKEN_UPDATE,
+  }
+
+  private data class RefreshAttempt(
+    val options: ClerkConfigurationOptions?,
+    val retryCount: Int,
+    val expectedConfigurationVersion: Int,
+  ) {
+    fun nextRetry(): RefreshAttempt = copy(retryCount = retryCount + 1)
   }
 
   /** Ensures storage is initialized when needed. */
@@ -157,74 +167,103 @@ internal class ConfigurationManager {
    * @throws IllegalStateException if called multiple times.
    * @throws IllegalArgumentException if publishableKey format is invalid.
    */
-  fun configure(context: Context, publishableKey: String, options: ClerkConfigurationOptions?) {
+  @Synchronized
+  fun configure(
+    context: Context,
+    publishableKey: String,
+    options: ClerkConfigurationOptions?,
+  ): Boolean {
     if (hasConfigured) {
       ClerkLog.w(
         "ConfigurationManager.configure() called multiple times. Ignoring subsequent calls."
       )
-      return
+      return false
     }
 
     try {
-      this.context = WeakReference(context.applicationContext)
-      this.storedOptions = options
-      Clerk.publishableKey = publishableKey
-      LocaleProvider.initialize()
-
-      val baseUrl =
-        if (options?.proxyUrl != null) {
-          options.proxyUrl
-        } else {
-          PublishableKeyHelper().extractApiUrl(publishableKey)
-        }
-      Clerk.baseUrl = baseUrl
-      Clerk.applicationId = context.applicationContext.packageName
-
-      // Initialize storage synchronously before configuring ClerkApi to ensure interceptors
-      // can safely access StorageHelper without race conditions
-      ensureStorageInitialized()
-
-      ClerkApi.configure(Clerk.baseUrl, context.applicationContext)
-
-      // Mark as configured before starting async operations
-      hasConfigured = true
-
-      // Set up network connectivity monitoring for automatic retry on reconnection
-      configureConnectivityMonitor(context.applicationContext)
-
-      // Start all background initialization concurrently
-      initializationJob =
-        scope.launch {
-          // Initialize device ID after storage is ready (storage is already initialized above)
-          val deviceIdInitJob = async { DeviceIdGenerator.initialize() }
-
-          // Launch data refresh independently (doesn't depend on storage)
-          val dataRefreshJob = async { refreshClientAndEnvironment(options, retryCount = 0) }
-
-          // Wait for device ID init before setting up lifecycle monitoring
-          deviceIdInitJob.await()
-
-          // Set up lifecycle monitoring for automatic refresh
-          AppLifecycleListener.configure {
-            if (hasConfigured) {
-              scope.launch {
-                deferForegroundRefreshDuringPendingSso()
-                refreshClientAndEnvironment(options, retryCount = 0)
-                startTokenRefresh()
-              }
-            }
-          }
-
-          // Data refresh can continue independently
-          dataRefreshJob.await()
-        }
+      val configuredVersion = configureSdkState(context, publishableKey, options)
+      initializationJob = launchInitialization(options, configuredVersion)
 
       ClerkLog.d("ConfigurationManager configured successfully - background initialization started")
+      return true
     } catch (e: Exception) {
       hasConfigured = false
       ClerkLog.e("Failed to configure ConfigurationManager: ${e.message}")
       throw e
     }
+  }
+
+  private fun configureSdkState(
+    context: Context,
+    publishableKey: String,
+    options: ClerkConfigurationOptions?,
+  ): Int {
+    configurationVersion += 1
+    val configuredVersion = configurationVersion
+    this.context = WeakReference(context.applicationContext)
+    this.storedOptions = options
+    this.publishableKey = publishableKey
+    Clerk.publishableKey = publishableKey
+    LocaleProvider.initialize()
+
+    val baseUrl = options?.proxyUrl ?: PublishableKeyHelper().extractApiUrl(publishableKey)
+    Clerk.baseUrl = baseUrl
+    Clerk.applicationId = context.applicationContext.packageName
+
+    ensureStorageInitialized()
+    ClerkApi.configure(Clerk.baseUrl, context.applicationContext)
+    hasConfigured = true
+    configureConnectivityMonitor(context.applicationContext)
+    return configuredVersion
+  }
+
+  private fun launchInitialization(
+    options: ClerkConfigurationOptions?,
+    configuredVersion: Int,
+  ): Job =
+    scope.launch {
+      val attempt =
+        RefreshAttempt(
+          options = options,
+          retryCount = 0,
+          expectedConfigurationVersion = configuredVersion,
+        )
+      val deviceIdInitJob = async { DeviceIdGenerator.initialize() }
+      val dataRefreshJob = async {
+        refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+      }
+
+      deviceIdInitJob.await()
+      AppLifecycleListener.configure {
+        if (hasConfigured) {
+          scope.launch {
+            deferForegroundRefreshDuringPendingSso()
+            refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+            startTokenRefresh()
+          }
+        }
+      }
+      dataRefreshJob.await()
+    }
+
+  fun isConfigured(): Boolean = hasConfigured
+
+  @Synchronized
+  fun reset() {
+    configurationVersion += 1
+    initializationJob?.cancel()
+    refreshJob?.cancel()
+    initializationJob = null
+    refreshJob = null
+    context = null
+    storageInitialized = false
+    hasConfigured = false
+    storedOptions = null
+    publishableKey = ""
+    _isInitialized.value = false
+    _initializationError.value = null
+    NetworkConnectivityMonitor.stop()
+    AppLifecycleListener.stop()
   }
 
   private fun startTokenRefresh() {
@@ -272,8 +311,7 @@ internal class ConfigurationManager {
     StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, deviceToken)
 
     return refreshClientAndEnvironment(
-      options = storedOptions,
-      retryCount = 0,
+      attempt = currentRefreshAttempt(),
       mode = RefreshMode.DEVICE_TOKEN_UPDATE,
       skipClientId = true,
     )
@@ -295,15 +333,16 @@ internal class ConfigurationManager {
    * @param options Configuration options for the SDK.
    * @param retryCount Current retry attempt number (0 for initial attempt).
    */
+  private fun currentRefreshAttempt(): RefreshAttempt =
+    RefreshAttempt(
+      options = storedOptions,
+      retryCount = 0,
+      expectedConfigurationVersion = configurationVersion,
+    )
+
   // Launches in a new coroutine so retries triggered inside the mutex do not deadlock.
-  private fun refreshClientAndEnvironment(options: ClerkConfigurationOptions?, retryCount: Int) {
-    scope.launch {
-      refreshClientAndEnvironment(
-        options = options,
-        retryCount = retryCount,
-        mode = RefreshMode.INITIALIZATION,
-      )
-    }
+  private fun queueClientAndEnvironmentRefresh(attempt: RefreshAttempt = currentRefreshAttempt()) {
+    scope.launch { refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION) }
   }
 
   private fun validateDeviceTokenUpdate(
@@ -336,35 +375,29 @@ internal class ConfigurationManager {
   }
 
   private suspend fun refreshClientAndEnvironment(
-    options: ClerkConfigurationOptions?,
-    retryCount: Int,
+    attempt: RefreshAttempt,
     mode: RefreshMode,
     skipClientId: Boolean = false,
   ): ClerkResult<Unit, ClerkErrorResponse> {
-    val failure = validateRefreshPreconditions(mode)
+    val failure = validateRefreshPreconditions(mode, attempt.expectedConfigurationVersion)
     if (failure != null) return failure
 
     if (Clerk.debugMode) {
-      ClerkLog.d("Starting client and environment refresh (attempt ${retryCount + 1})")
+      ClerkLog.d("Starting client and environment refresh (attempt ${attempt.retryCount + 1})")
     }
 
     // Clear error state on new attempt
-    if (retryCount == 0 && mode == RefreshMode.INITIALIZATION) {
+    if (attempt.retryCount == 0 && mode == RefreshMode.INITIALIZATION) {
       _initializationError.value = null
     }
 
     return refreshMutex.withLock {
       try {
-        executeRefresh(
-          options = options,
-          retryCount = retryCount,
-          mode = mode,
-          skipClientId = skipClientId,
-        )
+        executeRefresh(attempt = attempt, mode = mode, skipClientId = skipClientId)
       } catch (e: Exception) {
         ClerkLog.e("Exception during client and environment refresh: ${e.message}")
         if (mode == RefreshMode.INITIALIZATION) {
-          handleInitializationFailure(error = e, options = options, retryCount = retryCount)
+          handleInitializationFailure(error = e, attempt = attempt)
         }
         ClerkResult.unknownFailure(e)
       }
@@ -372,9 +405,11 @@ internal class ConfigurationManager {
   }
 
   private fun validateRefreshPreconditions(
-    mode: RefreshMode
+    mode: RefreshMode,
+    expectedConfigurationVersion: Int,
   ): ClerkResult<Unit, ClerkErrorResponse>? =
     when {
+      expectedConfigurationVersion != configurationVersion -> staleConfigurationFailure()
       !hasConfigured -> {
         ClerkLog.w("Attempted to refresh before configuration. Skipping.")
         ClerkResult.unknownFailure(
@@ -395,13 +430,16 @@ internal class ConfigurationManager {
     }
 
   private suspend fun executeRefresh(
-    options: ClerkConfigurationOptions?,
-    retryCount: Int,
+    attempt: RefreshAttempt,
     mode: RefreshMode,
     skipClientId: Boolean,
   ): ClerkResult<Unit, ClerkErrorResponse> {
     return withTimeout((API_TIMEOUT_SECONDS * TIMEOUT_MULTIPLIER)) {
       val (clientResult, environmentResult) = fetchRefreshData(skipClientId)
+
+      if (attempt.expectedConfigurationVersion != configurationVersion || !hasConfigured) {
+        return@withTimeout staleConfigurationFailure()
+      }
 
       handleClientResult(clientResult)
       handleEnvironmentResult(environmentResult)
@@ -416,12 +454,17 @@ internal class ConfigurationManager {
           handleRefreshFailure(
             clientResult = clientResult,
             environmentResult = environmentResult,
-            options = options,
-            retryCount = retryCount,
             mode = mode,
+            attempt = attempt,
           )
       }
     }
+  }
+
+  private fun staleConfigurationFailure(): ClerkResult.Failure<ClerkErrorResponse> {
+    return ClerkResult.unknownFailure(
+      IllegalStateException("Clerk configuration changed during refresh")
+    )
   }
 
   private suspend fun fetchRefreshData(
@@ -463,9 +506,8 @@ internal class ConfigurationManager {
   private fun handleRefreshFailure(
     clientResult: ClerkResult<Client, ClerkErrorResponse>,
     environmentResult: ClerkResult<Environment, ClerkErrorResponse>,
-    options: ClerkConfigurationOptions?,
-    retryCount: Int,
     mode: RefreshMode,
+    attempt: RefreshAttempt,
   ): ClerkResult.Failure<ClerkErrorResponse> {
     val errorMessage =
       "Failed to refresh client and environment -" +
@@ -483,8 +525,7 @@ internal class ConfigurationManager {
     if (mode == RefreshMode.INITIALIZATION) {
       handleInitializationFailure(
         error = failure.throwable ?: IllegalStateException(errorMessage),
-        options = options,
-        retryCount = retryCount,
+        attempt = attempt,
       )
     }
 
@@ -515,16 +556,16 @@ internal class ConfigurationManager {
    * @param options Configuration options for retry.
    * @param retryCount Current retry attempt number.
    */
-  private fun handleInitializationFailure(
-    error: Throwable,
-    options: ClerkConfigurationOptions?,
-    retryCount: Int,
-  ) {
+  private fun handleInitializationFailure(error: Throwable, attempt: RefreshAttempt) {
+    if (attempt.expectedConfigurationVersion != configurationVersion) {
+      return
+    }
+
     _isInitialized.value = false
     _initializationError.value = error
 
-    if (retryCount < MAX_INITIALIZATION_RETRIES) {
-      scope.launch { retryInitialization(options, retryCount + 1) }
+    if (attempt.retryCount < MAX_INITIALIZATION_RETRIES) {
+      scope.launch { retryInitialization(attempt.nextRetry()) }
     } else {
       ClerkLog.e(
         "Max initialization retries ($MAX_INITIALIZATION_RETRIES) reached. " +
@@ -539,15 +580,20 @@ internal class ConfigurationManager {
    * @param options Configuration options for the SDK.
    * @param retryCount Current retry attempt number.
    */
-  private suspend fun retryInitialization(options: ClerkConfigurationOptions?, retryCount: Int) {
+  private suspend fun retryInitialization(attempt: RefreshAttempt) {
     // Exponential backoff: 5s, 10s, 20s
-    val delaySeconds = BACKOFF_BASE_DELAY_SECONDS * (EXPONENTIAL_BACKOFF_SHIFT shl (retryCount - 1))
-    ClerkLog.d("Retrying initialization in ${delaySeconds}s (attempt $retryCount)")
+    val delaySeconds =
+      BACKOFF_BASE_DELAY_SECONDS * (EXPONENTIAL_BACKOFF_SHIFT shl (attempt.retryCount - 1))
+    ClerkLog.d("Retrying initialization in ${delaySeconds}s (attempt ${attempt.retryCount})")
 
     delay(delaySeconds.seconds)
 
+    if (attempt.expectedConfigurationVersion != configurationVersion) {
+      return
+    }
+
     // Retry the initialization
-    refreshClientAndEnvironment(options, retryCount)
+    queueClientAndEnvironmentRefresh(attempt)
   }
 
   /**
@@ -572,7 +618,7 @@ internal class ConfigurationManager {
 
     ClerkLog.d("Manual reinitialization requested")
     _initializationError.value = null
-    refreshClientAndEnvironment(storedOptions, retryCount = 0)
+    queueClientAndEnvironmentRefresh()
     return true
   }
 
@@ -593,14 +639,16 @@ internal class ConfigurationManager {
         ClerkLog.d("Connectivity restored - attempting automatic reinitialization")
         scope.launch {
           _initializationError.value = null
-          refreshClientAndEnvironment(storedOptions, retryCount = 0)
+          refreshClientAndEnvironment(currentRefreshAttempt(), RefreshMode.INITIALIZATION)
         }
       } else if (_isInitialized.value) {
         // Already initialized, but connectivity was restored - refresh data
         if (Clerk.debugMode) {
           ClerkLog.d("Connectivity restored - SDK already initialized, refreshing data")
         }
-        scope.launch { refreshClientAndEnvironment(storedOptions, retryCount = 0) }
+        scope.launch {
+          refreshClientAndEnvironment(currentRefreshAttempt(), RefreshMode.INITIALIZATION)
+        }
       }
     }
   }

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -251,6 +252,7 @@ internal class ConfigurationManager {
   @Synchronized
   fun reset() {
     configurationVersion += 1
+    scope.coroutineContext.cancelChildren()
     initializationJob?.cancel()
     refreshJob?.cancel()
     initializationJob = null
@@ -382,17 +384,19 @@ internal class ConfigurationManager {
     val failure = validateRefreshPreconditions(mode, attempt.expectedConfigurationVersion)
     if (failure != null) return failure
 
-    if (Clerk.debugMode) {
-      ClerkLog.d("Starting client and environment refresh (attempt ${attempt.retryCount + 1})")
-    }
-
-    // Clear error state on new attempt
-    if (attempt.retryCount == 0 && mode == RefreshMode.INITIALIZATION) {
-      _initializationError.value = null
-    }
-
     return refreshMutex.withLock {
+      val lockedFailure = validateRefreshPreconditions(mode, attempt.expectedConfigurationVersion)
+      if (lockedFailure != null) return@withLock lockedFailure
+
       try {
+        if (Clerk.debugMode) {
+          ClerkLog.d("Starting client and environment refresh (attempt ${attempt.retryCount + 1})")
+        }
+
+        if (attempt.retryCount == 0 && mode == RefreshMode.INITIALIZATION) {
+          _initializationError.value = null
+        }
+
         executeRefresh(attempt = attempt, mode = mode, skipClientId = skipClientId)
       } catch (e: Exception) {
         ClerkLog.e("Exception during client and environment refresh: ${e.message}")

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/lifecycle/AppLifecycleListener.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/lifecycle/AppLifecycleListener.kt
@@ -27,6 +27,9 @@ internal object AppLifecycleListener {
    */
   private var callback: () -> Unit = {}
 
+  @Volatile private var isListening = false
+  @Volatile private var listenerGeneration = 0
+
   /**
    * The lifecycle observer that monitors app foreground/background state changes.
    *
@@ -88,15 +91,48 @@ internal object AppLifecycleListener {
    */
   fun configure(callback: () -> Unit) {
     this.callback = callback
+    listenerGeneration += 1
+    val generation = listenerGeneration
+    if (isListening) {
+      return
+    }
 
     // Ensure observer is added on the main thread
     if (Looper.myLooper() == Looper.getMainLooper()) {
       // Already on main thread
       ProcessLifecycleOwner.get().lifecycle.addObserver(listener)
+      isListening = true
     } else {
       // Post to main thread
       Handler(Looper.getMainLooper()).post {
-        ProcessLifecycleOwner.get().lifecycle.addObserver(listener)
+        if (listenerGeneration == generation) {
+          ProcessLifecycleOwner.get().lifecycle.addObserver(listener)
+          isListening = true
+        }
+      }
+    }
+  }
+
+  /** Stops lifecycle monitoring and clears the foreground callback. */
+  fun stop() {
+    callback = {}
+    listener.wasBackgrounded = false
+    listenerGeneration += 1
+    val generation = listenerGeneration
+
+    if (!isListening) {
+      return
+    }
+
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      ProcessLifecycleOwner.get().lifecycle.removeObserver(listener)
+      isListening = false
+    } else {
+      Handler(Looper.getMainLooper()).post {
+        if (listenerGeneration == generation) {
+          ProcessLifecycleOwner.get().lifecycle.removeObserver(listener)
+          isListening = false
+        }
       }
     }
   }

--- a/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
@@ -91,6 +91,20 @@ internal object ClerkApi {
     _organization = retrofit.create(OrganizationApi::class.java)
   }
 
+  /** Clears all configured Retrofit services. */
+  fun reset() {
+    _client = null
+    _environment = null
+    _session = null
+    _signIn = null
+    _signUp = null
+    _user = null
+    _deviceAttestation = null
+    _organization = null
+    configuredBaseUrl = null
+    configuredUrlWithVersion = null
+  }
+
   /** Builds and configures the Retrofit instance. */
   private fun buildRetrofit(baseUrl: String): Retrofit {
     val urlWithVersion = "$baseUrl/v1/"

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/Environment.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/Environment.kt
@@ -1,6 +1,5 @@
 package com.clerk.api.network.model.environment
 
-import com.clerk.api.Clerk.environment
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
@@ -73,7 +72,7 @@ internal data class Environment(
 }
 
 internal fun Environment.enabledFirstFactorAttributes(): List<String> {
-  return environment.userSettings.attributes
+  return userSettings.attributes
     .filter { it.value.enabled && it.value.usedForFirstFactor }
     .keys
     .toList()

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
@@ -80,7 +80,7 @@ fun SignIn.alternativeSecondFactors(factor: Factor): List<Factor> {
  */
 val SignIn.startingFirstFactor: Factor?
   get() =
-    when (Clerk.environment.displayConfig?.preferredSignInStrategy) {
+    when (Clerk.environment?.displayConfig?.preferredSignInStrategy) {
       PreferredSignInStrategy.PASSWORD -> this.factorWhenPasswordIsPreferred
       else -> this.factorWhenOtpIsPreferred
     }

--- a/source/api/src/main/kotlin/com/clerk/api/sso/GoogleCredentialManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/GoogleCredentialManager.kt
@@ -36,7 +36,7 @@ class GoogleCredentialManagerImpl : GoogleCredentialManager {
     val activity = Clerk.credentialActivity() ?: throw CredentialFlowException.MissingActivity()
 
     val oneTapClientId =
-      requireNotNull(Clerk.environment.displayConfig.googleOneTapClientId) {
+      requireNotNull(Clerk.environment?.displayConfig?.googleOneTapClientId) {
         "Google One Tap Client ID is not set. Please set it in your Clerk dashboard."
       }
 
@@ -60,7 +60,7 @@ class GoogleCredentialManagerImpl : GoogleCredentialManager {
   }
 
   override fun getGoogleIdOption(): GetGoogleIdOption {
-    val oneTapClientId = requireNotNull(Clerk.environment.displayConfig.googleOneTapClientId)
+    val oneTapClientId = requireNotNull(Clerk.environment?.displayConfig?.googleOneTapClientId)
 
     return GetGoogleIdOption.Builder()
       .setFilterByAuthorizedAccounts(false)

--- a/source/api/src/main/kotlin/com/clerk/api/user/UserExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/user/UserExtensions.kt
@@ -16,7 +16,7 @@ import com.clerk.api.sso.OAuthProvider
  */
 val User.unconnectedProviders: List<OAuthProvider>
   get() {
-    val socialProviders = Clerk.environment.allSocialProviders
+    val socialProviders = Clerk.environment?.allSocialProviders.orEmpty()
     val verifiedExternalProviders = this.verifiedExternalAccounts.map { it.oauthProviderType }
     return socialProviders.filter { !verifiedExternalProviders.contains(it) }
   }

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkConfigurationSwitchTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkConfigurationSwitchTest.kt
@@ -1,0 +1,190 @@
+package com.clerk.api.sdk
+
+import android.content.Context
+import com.clerk.api.Clerk
+import com.clerk.api.ClerkConfigurationOptions
+import com.clerk.api.configuration.connectivity.NetworkConnectivityMonitor
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.client.Client
+import com.clerk.api.network.model.environment.AuthConfig
+import com.clerk.api.network.model.environment.DisplayConfig
+import com.clerk.api.network.model.environment.Environment
+import com.clerk.api.network.model.environment.UserSettings
+import com.clerk.api.network.model.token.TokenResource
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
+import com.clerk.api.session.SessionTokensCache
+import com.clerk.api.storage.StorageHelper
+import com.clerk.api.storage.StorageKey
+import com.clerk.api.user.User
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class ClerkConfigurationSwitchTest {
+  private lateinit var context: Context
+
+  @Before
+  fun setUp() {
+    context = RuntimeEnvironment.getApplication()
+    StorageHelper.initialize(context)
+    StorageHelper.reset(context)
+    Clerk.reset()
+    mockkObject(Client.Companion)
+    mockkObject(Environment.Companion)
+    coEvery { Client.get() } returns ClerkResult.success(Client())
+    coEvery { Client.getSkippingClientId() } returns ClerkResult.success(Client())
+    coEvery { Environment.get() } returns ClerkResult.success(testEnvironment("Ready"))
+  }
+
+  @After
+  fun tearDown() {
+    Clerk.reset()
+    unmockkAll()
+    StorageHelper.reset(context)
+    NetworkConnectivityMonitor.resetForTesting()
+  }
+
+  @Test
+  fun `reset clears local configuration and runtime auth state while preserving device id`() =
+    runTest {
+      Clerk.initialize(
+        context = context,
+        publishableKey = FIRST_KEY,
+        options = ClerkConfigurationOptions(enableDebugMode = true, proxyUrl = FIRST_PROXY),
+      )
+      val (client, user) = signedInClient()
+      Clerk.updateEnvironment(testEnvironment("Old Application"))
+      Clerk.updateClient(client)
+      StorageHelper.saveValue(StorageKey.DEVICE_ID, "device_id_123")
+      StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "device_token_123")
+      SessionTokensCache.setToken("sess_123", TokenResource(jwt = "jwt_123"))
+
+      assertEquals(user, Clerk.user)
+      assertEquals("Old Application", Clerk.applicationName)
+      assertEquals("device_token_123", StorageHelper.loadValue(StorageKey.DEVICE_TOKEN))
+
+      Clerk.reset()
+
+      assertNull(Clerk.session)
+      assertNull(Clerk.user)
+      assertNull(Clerk.applicationName)
+      assertNull(Clerk.publishableKey)
+      assertNull(Clerk.proxyUrl)
+      assertEquals("", Clerk.baseUrl)
+      assertNull(ClerkApi.configuredBaseUrl)
+      assertNull(StorageHelper.loadValue(StorageKey.DEVICE_TOKEN))
+      assertEquals("device_id_123", StorageHelper.loadValue(StorageKey.DEVICE_ID))
+      assertEquals(0, SessionTokensCache.size)
+      assertFalse(Clerk.debugMode)
+      assertFalse(Clerk.isInitialized.value)
+    }
+
+  @Test
+  fun `switchConfiguration resets and configures the new tenant synchronously`() {
+    Clerk.initialize(
+      context = context,
+      publishableKey = FIRST_KEY,
+      options = ClerkConfigurationOptions(enableDebugMode = true, proxyUrl = FIRST_PROXY),
+    )
+
+    Clerk.switchConfiguration(
+      context = context,
+      publishableKey = SECOND_KEY,
+      options = ClerkConfigurationOptions(proxyUrl = SECOND_PROXY),
+    )
+
+    assertEquals(SECOND_KEY, Clerk.publishableKey)
+    assertEquals(SECOND_PROXY, Clerk.proxyUrl)
+    assertEquals(SECOND_PROXY, Clerk.baseUrl)
+    assertEquals(SECOND_PROXY, ClerkApi.configuredBaseUrl)
+    assertEquals("$SECOND_PROXY/v1/", ClerkApi.configuredUrlWithVersion)
+    assertFalse(Clerk.debugMode)
+  }
+
+  @Test
+  fun `initialize after configuration is a no-op and does not partially mutate options`() {
+    Clerk.initialize(
+      context = context,
+      publishableKey = FIRST_KEY,
+      options = ClerkConfigurationOptions(enableDebugMode = true, proxyUrl = FIRST_PROXY),
+    )
+
+    Clerk.initialize(
+      context = context,
+      publishableKey = SECOND_KEY,
+      options = ClerkConfigurationOptions(enableDebugMode = false, proxyUrl = SECOND_PROXY),
+    )
+
+    assertEquals(FIRST_KEY, Clerk.publishableKey)
+    assertEquals(FIRST_PROXY, Clerk.proxyUrl)
+    assertEquals(FIRST_PROXY, Clerk.baseUrl)
+    assertEquals(FIRST_PROXY, ClerkApi.configuredBaseUrl)
+    assertEquals("$FIRST_PROXY/v1/", ClerkApi.configuredUrlWithVersion)
+    assertTrue(Clerk.debugMode)
+  }
+
+  private fun signedInClient(): Pair<Client, User> {
+    val user = mockk<User>(relaxed = true)
+    val session = mockk<Session>(relaxed = true)
+    every { session.id } returns "sess_123"
+    every { session.status } returns Session.SessionStatus.ACTIVE
+    every { session.user } returns user
+    return Client(
+      id = "client_123",
+      sessions = listOf(session),
+      lastActiveSessionId = "sess_123",
+    ) to user
+  }
+
+  private fun testEnvironment(applicationName: String): Environment {
+    return Environment(
+      authConfig = AuthConfig(singleSessionMode = false),
+      displayConfig =
+        DisplayConfig(
+          applicationName = applicationName,
+          branded = true,
+          logoImageUrl = "https://example.com/logo.png",
+          homeUrl = "/",
+          privacyPolicyUrl = null,
+          termsUrl = null,
+          googleOneTapClientId = null,
+        ),
+      userSettings =
+        UserSettings(
+          attributes = emptyMap(),
+          signUp =
+            UserSettings.SignUpUserSettings(
+              customActionRequired = false,
+              progressive = false,
+              mode = "public",
+              legalConsentEnabled = false,
+            ),
+          social = emptyMap(),
+          actions = UserSettings.Actions(),
+          passkeySettings = null,
+        ),
+    )
+  }
+
+  private companion object {
+    const val FIRST_KEY = "pk_test_first"
+    const val SECOND_KEY = "pk_test_second"
+    const val FIRST_PROXY = "https://first.example.com/__clerk"
+    const val SECOND_PROXY = "https://second.example.com/__clerk"
+  }
+}


### PR DESCRIPTION
## Summary
- Add a public reset/switch path so the SDK can move between Clerk configurations within the same process
- Clear and reinitialize cached API, lifecycle, attestation, and session state when the configuration changes
- Cover the switch flow with regression tests for reconfiguration and stale async work

## Testing
- `:source:api:compileDebugKotlin`
- `:source:api:testDebugUnitTest`
- `:source:api:spotlessCheck`
- Detekt passed on the touched API sources