### PR TITLE
Add multi-session account switching to Android auth UI

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -120,6 +120,17 @@ object Clerk {
 
   internal var applicationId: String? = null
 
+  private val _multiSessionModeIsEnabled = MutableStateFlow(false)
+
+  /**
+   * Reactive state indicating whether this Clerk instance allows multiple sessions on the same
+   * client.
+   *
+   * When enabled, a client can hold sessions for multiple accounts and switch the active session by
+   * updating [Client.lastActiveSessionId].
+   */
+  val multiSessionModeIsEnabledFlow: StateFlow<Boolean> = _multiSessionModeIsEnabled.asStateFlow()
+
   /** Internal environment configuration containing display settings and authentication options. */
   internal lateinit var environment: Environment
 
@@ -726,6 +737,7 @@ object Clerk {
    */
   internal fun updateEnvironment(environment: Environment) {
     this.environment = environment
+    _multiSessionModeIsEnabled.value = !environment.authConfig.singleSessionMode
   }
 
   internal fun credentialActivity(): Activity? = currentActivity?.get()

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -760,12 +760,14 @@ object Clerk {
   }
 
   private fun Client.withResolvedActiveSession(previousSession: Session?): Client {
+    val currentActiveSessionId =
+      lastActiveSessionId?.takeIf { activeSessionId -> sessions.any { it.id == activeSessionId } }
     val resolvedActiveSessionId =
-      lastActiveSessionId
+      currentActiveSessionId
         ?: previousSession?.id?.takeIf { previousSessionId ->
           sessions.any { it.id == previousSessionId }
         }
-        ?: sessions.singleOrNull()?.id
+        ?: if (lastActiveSessionId == null) sessions.singleOrNull()?.id else null
     return if (resolvedActiveSessionId == lastActiveSessionId || resolvedActiveSessionId == null) {
       this
     } else {

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -738,12 +738,26 @@ object Clerk {
    * @param client The updated client configuration.
    */
   internal fun updateClient(client: Client) {
-    this.client = client
+    this.client = client.withResolvedActiveSession(previousSession = _session.value)
     // Only update state if flows are initialized (not during static initialization)
     try {
       updateSessionAndUserState()
     } catch (e: Exception) {
       ClerkLog.e("${e.message}")
+    }
+  }
+
+  private fun Client.withResolvedActiveSession(previousSession: Session?): Client {
+    val resolvedActiveSessionId =
+      lastActiveSessionId
+        ?: previousSession?.id?.takeIf { previousSessionId ->
+          sessions.any { it.id == previousSessionId }
+        }
+        ?: sessions.singleOrNull()?.id
+    return if (resolvedActiveSessionId == lastActiveSessionId || resolvedActiveSessionId == null) {
+      this
+    } else {
+      copy(lastActiveSessionId = resolvedActiveSessionId)
     }
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.flow.asStateFlow
  * Provides access to authentication state, user information, and core functionality for managing
  * user sessions and sign-in flows.
  */
+@Suppress("TooManyFunctions")
 object Clerk {
 
   // region Configuration & Initialization
@@ -381,9 +382,29 @@ object Clerk {
   val mfaAuthenticatorAppIsEnabled: Boolean
     get() = if (::environment.isInitialized) environment.mfaAuthenticatorAppIsEnabled else false
 
+  /**
+   * Indicates whether this Clerk instance allows multiple sessions on the same client.
+   *
+   * When enabled, a client can hold sessions for multiple accounts and switch the active session by
+   * updating [Client.lastActiveSessionId].
+   */
+  val multiSessionModeIsEnabled: Boolean
+    get() = if (::environment.isInitialized) !environment.authConfig.singleSessionMode else false
+
   // endregion
 
   // region Session Management
+
+  /** Internal mutable state flow for all sessions on the current client. */
+  private val _sessions = MutableStateFlow<List<Session>>(emptyList())
+
+  /**
+   * Reactive state for all sessions available on the current client.
+   *
+   * In multi-session mode this may contain sessions for multiple user accounts. The current session
+   * is still determined by [Client.lastActiveSessionId] and exposed through [sessionFlow].
+   */
+  val sessionsFlow: StateFlow<List<Session>> = _sessions.asStateFlow()
 
   /** Internal mutable state flow for session changes. */
   private val _session = MutableStateFlow<Session?>(null)
@@ -611,22 +632,19 @@ object Clerk {
   /**
    * Provides the current foreground [Activity] to Clerk explicitly.
    *
-   * Useful for framework integrations — e.g. React Native bridges, plug-in
-   * SDKs, or any host that calls [initialize] with a non-Activity [Context]
-   * after the host Activity has already passed [Activity.onResume]. In that
-   * case the [Application.ActivityLifecycleCallbacks] registered by
-   * [initialize] miss the initial resume, leaving Clerk's tracked activity
-   * null — which makes the first Credential Manager call (Google sign-in,
-   * passkeys) fail with a `MissingActivity` error until the user backgrounds
-   * and foregrounds the app.
+   * Useful for framework integrations — e.g. React Native bridges, plug-in SDKs, or any host that
+   * calls [initialize] with a non-Activity [Context] after the host Activity has already passed
+   * [Activity.onResume]. In that case the [Application.ActivityLifecycleCallbacks] registered by
+   * [initialize] miss the initial resume, leaving Clerk's tracked activity null — which makes the
+   * first Credential Manager call (Google sign-in, passkeys) fail with a `MissingActivity` error
+   * until the user backgrounds and foregrounds the app.
    *
-   * Calling this with the current Activity immediately after [initialize]
-   * eliminates that gap. Subsequent activity changes are still observed via
-   * the registered lifecycle callbacks; this method only seeds the initial
-   * value.
+   * Calling this with the current Activity immediately after [initialize] eliminates that gap.
+   * Subsequent activity changes are still observed via the registered lifecycle callbacks; this
+   * method only seeds the initial value.
    *
-   * @param activity The current foreground Activity. Held as a [WeakReference]
-   *   so it can still be garbage-collected when destroyed.
+   * @param activity The current foreground Activity. Held as a [WeakReference] so it can still be
+   *   garbage-collected when destroyed.
    */
   fun attachActivity(activity: Activity) {
     currentActivity = WeakReference(activity)
@@ -635,10 +653,9 @@ object Clerk {
   /**
    * Walks a [Context]/[ContextWrapper] chain looking for an [Activity].
    *
-   * Returns the first Activity found, or null if the chain bottoms out at the
-   * Application context (or any other non-Activity context). Used by
-   * [initialize] so callers that pass an Activity (or a wrapper around one)
-   * automatically seed [currentActivity].
+   * Returns the first Activity found, or null if the chain bottoms out at the Application context
+   * (or any other non-Activity context). Used by [initialize] so callers that pass an Activity (or
+   * a wrapper around one) automatically seed [currentActivity].
    */
   private fun Context.findActivityOrNull(): Activity? {
     var ctx: Context? = this
@@ -741,10 +758,8 @@ object Clerk {
     val previousSession = _session.value
 
     // Find session by ID from all sessions (not just active sessions)
-    val currentSession =
-      if (::client.isInitialized) {
-        client.sessions.firstOrNull { it.id == client.lastActiveSessionId }
-      } else null
+    val currentSessions = if (::client.isInitialized) client.sessions else emptyList()
+    val currentSession = currentSessions.firstOrNull { it.id == client.lastActiveSessionId }
 
     if (currentSession?.status == Session.SessionStatus.PENDING) {
       ClerkLog.w(
@@ -754,6 +769,7 @@ object Clerk {
       )
     }
 
+    _sessions.value = currentSessions
     _session.value = currentSession
     _userFlow.value = currentSession?.user
 
@@ -779,6 +795,7 @@ object Clerk {
    */
   internal fun clearSessionAndUserState() {
     val previousSession = _session.value
+    _sessions.value = emptyList()
     _session.value = null
     _userFlow.value = null
 

--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -449,7 +449,7 @@ class Auth internal constructor() {
     provider: OAuthProvider
   ): ClerkResult<OAuthResult, ClerkErrorResponse> {
     val result =
-      SSOService.authenticateWithRedirect(
+      SSOService.authenticateSignUpWithRedirect(
         strategy = provider.providerData.strategy,
         redirectUrl = RedirectConfiguration.DEFAULT_REDIRECT_URL,
       )

--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -642,21 +642,30 @@ class Auth internal constructor() {
     activeSessionFallbackId: String?,
     fallbackClient: Client?,
   ): Client {
-    val fallbackSessions = fallbackClient?.sessions.orEmpty()
-    val canUseFallback =
-      activeSessionFallbackId != null &&
-        sessions.none { it.id == activeSessionFallbackId } &&
-        fallbackSessions.any { it.id == activeSessionFallbackId }
+    if (activeSessionFallbackId == null) return this
 
-    return if (!canUseFallback) {
-      this
-    } else {
-      val fallbackSessionId = requireNotNull(activeSessionFallbackId)
-      val missingFallbackSessions =
-        fallbackSessions.filterNot { fallbackSession ->
-          sessions.any { it.id == fallbackSession.id }
-        }
-      copy(sessions = sessions + missingFallbackSessions, lastActiveSessionId = fallbackSessionId)
+    val fallbackSessions = fallbackClient?.sessions.orEmpty()
+    val targetInFetchedSessions = sessions.any { it.id == activeSessionFallbackId }
+    val targetInFallbackSessions = fallbackSessions.any { it.id == activeSessionFallbackId }
+
+    return when {
+      // Fetched client is missing the target session entirely (e.g. cleared sessions list);
+      // splice it back in from the fallback and force it active.
+      !targetInFetchedSessions && targetInFallbackSessions -> {
+        val missingFallbackSessions =
+          fallbackSessions.filterNot { fallbackSession ->
+            sessions.any { it.id == fallbackSession.id }
+          }
+        copy(
+          sessions = sessions + missingFallbackSessions,
+          lastActiveSessionId = activeSessionFallbackId,
+        )
+      }
+      // Fetched client has the target session but `lastActiveSessionId` is stale
+      // (read-after-write lag); force the just-activated session back to active.
+      targetInFetchedSessions && lastActiveSessionId != activeSessionFallbackId ->
+        copy(lastActiveSessionId = activeSessionFallbackId)
+      else -> this
     }
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -460,8 +460,8 @@ class Auth internal constructor() {
   /**
    * Signs up with Google One Tap.
    *
-   * This native Google flow may resolve to either a sign-up or a sign-in, depending on whether the
-   * selected Google account already exists in Clerk.
+   * This native Google flow starts from sign-up and may resolve to either a sign-up or a sign-in,
+   * depending on whether the selected Google account already exists in Clerk.
    *
    * @return A [ClerkResult] containing the [OAuthResult] on success, or a [ClerkErrorResponse] on
    *   failure.
@@ -472,7 +472,7 @@ class Auth internal constructor() {
    * ```
    */
   suspend fun signUpWithGoogleOneTap(): ClerkResult<OAuthResult, ClerkErrorResponse> {
-    val result = SignIn.authenticateWithGoogleOneTap()
+    val result = SignUp.authenticateWithGoogleOneTap()
     result.onFailure { emitAuthError(it) }
     return result
   }

--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -621,11 +621,42 @@ class Auth internal constructor() {
     )
   }
 
-  private suspend fun refreshClientAfterSessionMutation() {
+  private suspend fun refreshClientAfterSessionMutation(
+    activeSessionFallbackId: String? = null,
+    fallbackClient: Client? = null,
+  ) {
     when (val clientResult = Client.get()) {
-      is ClerkResult.Success -> Clerk.updateClient(clientResult.value)
+      is ClerkResult.Success ->
+        Clerk.updateClient(
+          clientResult.value.withActiveSessionFallback(
+            activeSessionFallbackId = activeSessionFallbackId,
+            fallbackClient = fallbackClient,
+          )
+        )
       is ClerkResult.Failure ->
         ClerkLog.w("Client refresh after session mutation failed: ${clientResult.errorMessage}")
+    }
+  }
+
+  private fun Client.withActiveSessionFallback(
+    activeSessionFallbackId: String?,
+    fallbackClient: Client?,
+  ): Client {
+    val fallbackSessions = fallbackClient?.sessions.orEmpty()
+    val canUseFallback =
+      activeSessionFallbackId != null &&
+        sessions.none { it.id == activeSessionFallbackId } &&
+        fallbackSessions.any { it.id == activeSessionFallbackId }
+
+    return if (!canUseFallback) {
+      this
+    } else {
+      val fallbackSessionId = requireNotNull(activeSessionFallbackId)
+      val missingFallbackSessions =
+        fallbackSessions.filterNot { fallbackSession ->
+          sessions.any { it.id == fallbackSession.id }
+        }
+      copy(sessions = sessions + missingFallbackSessions, lastActiveSessionId = fallbackSessionId)
     }
   }
 
@@ -646,23 +677,59 @@ class Auth internal constructor() {
     sessionId: String,
     organizationId: String? = null,
   ): ClerkResult<Session, ClerkErrorResponse> {
+    val previousClient = if (Clerk.clientInitialized) Clerk.client else null
     val result = ClerkApi.client.setActive(sessionId, organizationId)
     when (result) {
       is ClerkResult.Success -> {
-        setActiveSessionLocally(sessionId)
-        refreshClientAfterSessionMutation()
+        setActiveSessionLocally(
+          sessionId,
+          activeSession = result.value,
+          sourceClient = previousClient,
+        )
+        refreshClientAfterSessionMutation(
+          activeSessionFallbackId = sessionId,
+          fallbackClient = if (Clerk.clientInitialized) Clerk.client else previousClient,
+        )
       }
       is ClerkResult.Failure -> emitAuthError(result)
     }
     return result
   }
 
-  private fun setActiveSessionLocally(sessionId: String) {
-    if (!Clerk.clientInitialized) return
-    if (Clerk.client.sessions.none { it.id == sessionId }) return
+  private fun setActiveSessionLocally(
+    sessionId: String,
+    activeSession: Session? = null,
+    sourceClient: Client? = null,
+  ) {
+    val client = sourceClient ?: if (Clerk.clientInitialized) Clerk.client else return
+    val sessions = client.sessions.withUpdatedSession(activeSession)
+    if (sessions.none { it.id == sessionId }) return
 
-    Clerk.updateClient(Clerk.client.copy(lastActiveSessionId = sessionId))
+    Clerk.updateClient(client.copy(sessions = sessions, lastActiveSessionId = sessionId))
   }
+
+  private fun List<Session>.withUpdatedSession(activeSession: Session?): List<Session> {
+    if (activeSession == null) return this
+
+    var replacedSession = false
+    val updatedSessions = map { existingSession ->
+      if (existingSession.id == activeSession.id) {
+        replacedSession = true
+        activeSession.withPreservedUserData(existingSession)
+      } else {
+        existingSession
+      }
+    }
+
+    return if (replacedSession) updatedSessions else updatedSessions + activeSession
+  }
+
+  private fun Session.withPreservedUserData(existingSession: Session): Session =
+    copy(
+      user = user ?: existingSession.user,
+      publicUserData = publicUserData ?: existingSession.publicUserData,
+      lastActiveToken = lastActiveToken ?: existingSession.lastActiveToken,
+    )
 
   /**
    * Gets a token for the current session.

--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -15,6 +15,7 @@ import com.clerk.api.auth.builders.SignUpWithIdTokenBuilder
 import com.clerk.api.auth.types.IdTokenProvider
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.errorMessage
@@ -125,6 +126,15 @@ class Auth internal constructor() {
    */
   val currentSignUp: SignUp?
     get() = if (Clerk.clientInitialized) Clerk.client.signUp else null
+
+  /**
+   * The sessions currently known on this client.
+   *
+   * In multi-session mode this can include sessions for multiple accounts. The current session is
+   * the one whose ID matches [Client.lastActiveSessionId].
+   */
+  val sessions: List<Session>
+    get() = if (Clerk.clientInitialized) Clerk.client.sessions else emptyList()
 
   // endregion
 
@@ -563,22 +573,27 @@ class Auth internal constructor() {
   // region Session Management
 
   /**
-   * Signs out the current session or a specific session.
+   * Signs out all sessions or removes a specific session from the current client.
    *
-   * @param sessionId Optional session ID to sign out. If null, signs out the current session.
+   * @param sessionId Optional session ID to sign out. If null, signs out all sessions on this
+   *   client.
    * @return A [ClerkResult] with Unit on success, or a [ClerkErrorResponse] on failure.
    *
    * ### Example usage:
    * ```kotlin
-   * clerk.auth.signOut()
+   * clerk.auth.signOut() // sign out all accounts
+   * clerk.auth.signOut(sessionId = Clerk.session?.id) // sign out the current account only
    * ```
    */
   suspend fun signOut(sessionId: String? = null): ClerkResult<Unit, ClerkErrorResponse> {
     val result =
       if (sessionId != null) {
-        // Sign out a specific session
         when (val result = ClerkApi.session.removeSession(sessionId)) {
-          is ClerkResult.Success -> ClerkResult.success(Unit)
+          is ClerkResult.Success -> {
+            removeSessionLocally(sessionId)
+            refreshClientAfterSessionMutation()
+            ClerkResult.success(Unit)
+          }
           is ClerkResult.Failure -> ClerkResult.apiFailure(result.error)
         }
       } else {
@@ -586,6 +601,32 @@ class Auth internal constructor() {
       }
     result.onFailure { emitAuthError(it) }
     return result
+  }
+
+  private fun removeSessionLocally(sessionId: String) {
+    if (!Clerk.clientInitialized) return
+
+    val client = Clerk.client
+    val remainingSessions = client.sessions.filterNot { it.id == sessionId }
+    val lastActiveSessionId =
+      if (client.lastActiveSessionId == sessionId) {
+        remainingSessions.firstOrNull { it.status == Session.SessionStatus.ACTIVE }?.id
+          ?: remainingSessions.firstOrNull()?.id
+      } else {
+        client.lastActiveSessionId
+      }
+
+    Clerk.updateClient(
+      client.copy(sessions = remainingSessions, lastActiveSessionId = lastActiveSessionId)
+    )
+  }
+
+  private suspend fun refreshClientAfterSessionMutation() {
+    when (val clientResult = Client.get()) {
+      is ClerkResult.Success -> Clerk.updateClient(clientResult.value)
+      is ClerkResult.Failure ->
+        ClerkLog.w("Client refresh after session mutation failed: ${clientResult.errorMessage}")
+    }
   }
 
   /**
@@ -606,8 +647,21 @@ class Auth internal constructor() {
     organizationId: String? = null,
   ): ClerkResult<Session, ClerkErrorResponse> {
     val result = ClerkApi.client.setActive(sessionId, organizationId)
-    result.onFailure { emitAuthError(it) }
+    when (result) {
+      is ClerkResult.Success -> {
+        setActiveSessionLocally(sessionId)
+        refreshClientAfterSessionMutation()
+      }
+      is ClerkResult.Failure -> emitAuthError(result)
+    }
     return result
+  }
+
+  private fun setActiveSessionLocally(sessionId: String) {
+    if (!Clerk.clientInitialized) return
+    if (Clerk.client.sessions.none { it.id == sessionId }) return
+
+    Clerk.updateClient(Clerk.client.copy(lastActiveSessionId = sessionId))
   }
 
   /**

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/SignUpApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/SignUpApi.kt
@@ -8,9 +8,11 @@ import com.clerk.api.signup.SignUp
 import retrofit2.http.Field
 import retrofit2.http.FieldMap
 import retrofit2.http.FormUrlEncoded
+import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 internal interface SignUpApi {
   /** @see [SignUp.create] */
@@ -18,6 +20,12 @@ internal interface SignUpApi {
   @POST(ApiPaths.Client.SignUp.BASE)
   suspend fun createSignUp(
     @FieldMap fields: Map<String, String>
+  ): ClerkResult<SignUp, ClerkErrorResponse>
+
+  @GET(ApiPaths.Client.SignUp.WITH_ID)
+  suspend fun fetchSignUp(
+    @Path(ApiParams.ID) id: String,
+    @Query("rotating_token_nonce") rotatingTokenNonce: String? = null,
   ): ClerkResult<SignUp, ClerkErrorResponse>
 
   /** @see [com.clerk.api.signup.update] */

--- a/source/api/src/main/kotlin/com/clerk/api/network/middleware/incoming/ClientSyncingMiddleware.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/middleware/incoming/ClientSyncingMiddleware.kt
@@ -41,7 +41,7 @@ internal class ClientSyncingMiddleware(private val json: Json) : Interceptor {
 
     // Only process JSON responses
     val body = response.body
-    if (response.isSuccessful && body != null && body.contentType()?.subtype == "json") {
+    if (response.isSuccessful && body.contentType()?.subtype == "json") {
       val responseBody = body.string()
       responseBody.let {
         try {
@@ -49,11 +49,18 @@ internal class ClientSyncingMiddleware(private val json: Json) : Interceptor {
           val jsonElement = json.parseToJsonElement(it)
           if (jsonElement is JsonObject && jsonElement.containsKey("client")) {
             val clientJson = jsonElement["client"]
-            if (clientJson != null && clientJson !is JsonNull) {
-              // Extract and set the client
-              val client = json.decodeFromJsonElement<Client>(clientJson)
-              ClerkLog.d("Client synced: ${client.id}")
-              Clerk.updateClient(client)
+            when (clientJson) {
+              is JsonNull -> {
+                ClerkLog.d("Client sync cleared by explicit null client")
+                Clerk.updateClient(Client())
+              }
+              null -> Unit
+              else -> {
+                // Extract and set the client
+                val client = json.decodeFromJsonElement<Client>(clientJson)
+                ClerkLog.d("Client synced: ${client.id}")
+                Clerk.updateClient(client)
+              }
             }
           }
 

--- a/source/api/src/main/kotlin/com/clerk/api/network/middleware/incoming/ClientSyncingMiddleware.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/middleware/incoming/ClientSyncingMiddleware.kt
@@ -51,8 +51,12 @@ internal class ClientSyncingMiddleware(private val json: Json) : Interceptor {
             val clientJson = jsonElement["client"]
             when (clientJson) {
               is JsonNull -> {
-                ClerkLog.d("Client sync cleared by explicit null client")
-                Clerk.updateClient(Client())
+                if (jsonElement.containsKey("response")) {
+                  ClerkLog.d("Client sync skipped null piggyback client")
+                } else {
+                  ClerkLog.d("Client sync cleared by explicit null client")
+                  Clerk.updateClient(Client())
+                }
               }
               null -> Unit
               else -> {

--- a/source/api/src/main/kotlin/com/clerk/api/signout/SignOutService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signout/SignOutService.kt
@@ -6,41 +6,38 @@ import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
-import com.clerk.api.session.delete
+import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.storage.StorageHelper
 import com.clerk.api.storage.StorageKey
 
 /**
- * Service responsible for signing out users by removing their active session.
+ * Service responsible for signing out users by removing every session on the current client.
  *
- * The SignOutService handles the complete sign-out process, including removing the session from the
- * Clerk API and cleaning up local session state. It performs network operations asynchronously and
- * provides proper error handling.
+ * The SignOutService handles the complete all-account sign-out process, including deleting client
+ * sessions from the Clerk API and cleaning up local client state. Single-session sign-out is
+ * handled by [com.clerk.api.auth.Auth.signOut] when a session ID is provided.
  */
 internal object SignOutService {
 
   /**
-   * Signs out the currently authenticated user by removing their active session.
+   * Signs out all accounts by deleting every session on the current client.
    *
-   * This method will attempt to remove the session from the Clerk API if a session ID exists,
-   * otherwise it will delete the local session. Local credentials are always cleared regardless of
-   * whether the server-side sign-out succeeds, ensuring users are never stuck in a logged-in state
-   * after attempting to sign out.
+   * Local credentials are always cleared regardless of whether the server-side sign-out succeeds,
+   * ensuring users are never stuck in a logged-in state after attempting to sign out.
    *
-   * @return A [com.clerk.network.serialization.ClerkResult] indicating the success or failure of
-   *   the sign-out operation. Returns
-   *   [com.clerk.network.serialization.ClerkResult.Companion.success] with [Unit] on successful
-   *   sign-out, or [com.clerk.network.serialization.ClerkResult.Companion.unknownFailure] with
-   *   error details on failure. Note: local credentials are cleared in both cases.
+   * @return A [ClerkResult] indicating the success or failure of the sign-out operation. Returns
+   *   [ClerkResult.Companion.success] with [Unit] on successful sign-out, or
+   *   [ClerkResult.Companion.unknownFailure] with error details on failure. Note: local credentials
+   *   are cleared in both cases.
    */
   suspend fun signOut(): ClerkResult<Unit, ClerkErrorResponse> {
     var serverError: Exception? = null
 
     try {
-      if (Clerk.session?.id != null) {
-        Clerk.session?.id?.let { sessionId -> ClerkApi.session.removeSession(sessionId) }
-      } else {
-        Clerk.session?.delete()
+      when (val result = ClerkApi.session.deleteSessions()) {
+        is ClerkResult.Success -> Clerk.updateClient(result.value)
+        is ClerkResult.Failure ->
+          serverError = result.throwable as? Exception ?: Exception(result.errorMessage)
       }
     } catch (e: Exception) {
       ClerkLog.w("Server sign-out failed: ${e.message}")
@@ -48,12 +45,18 @@ internal object SignOutService {
     } finally {
       // Always clear local credentials regardless of server response
       StorageHelper.deleteValue(StorageKey.DEVICE_TOKEN)
-      Clerk.clearSessionAndUserState()
+      Clerk.updateClient(Client())
 
       // Best-effort refresh of the in-memory client while skipping current client id.
       // This clears stale in-progress sign-in/sign-up state that can otherwise persist after
       // sign-out when the host remounts AuthView within the same process/activity lifecycle.
-      runCatching { Client.getSkippingClientId() }
+      runCatching {
+          when (val clientResult = Client.getSkippingClientId()) {
+            is ClerkResult.Success -> Clerk.updateClient(clientResult.value)
+            is ClerkResult.Failure ->
+              ClerkLog.w("Client refresh after sign-out failed: ${clientResult.errorMessage}")
+          }
+        }
         .onFailure { ClerkLog.w("Client refresh after sign-out failed: ${it.message}") }
     }
 

--- a/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
@@ -9,6 +9,7 @@ import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.sso.GoogleSignInService
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.OAuthResult
 import com.clerk.api.sso.RedirectConfiguration
@@ -473,6 +474,17 @@ data class SignUp(
      */
     suspend fun create(params: Map<String, String>): ClerkResult<SignUp, ClerkErrorResponse> {
       return ClerkApi.signUp.createSignUp(params)
+    }
+
+    /**
+     * Authenticates the user with a Google ID token from native Google One Tap, starting from a
+     * sign-up flow and transferring to sign-in when the external account already exists.
+     *
+     * @return A [ClerkResult] containing the [OAuthResult] on success, or a [ClerkErrorResponse] on
+     *   failure.
+     */
+    suspend fun authenticateWithGoogleOneTap(): ClerkResult<OAuthResult, ClerkErrorResponse> {
+      return GoogleSignInService().signUpWithGoogle()
     }
 
     /**

--- a/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
@@ -286,7 +286,8 @@ data class SignUp(
     @Serializable
     data class OAuth(
       @MapProperty("providerData?.strategy") @SerialName("strategy") val provider: OAuthProvider,
-      @SerialName("redirect_url") override val redirectUrl: String,
+      @SerialName("redirect_url")
+      override val redirectUrl: String = RedirectConfiguration.DEFAULT_REDIRECT_URL,
       override val identifier: String? = null,
       @SerialName("email_address") override val emailAddress: String? = null,
       @SerialName("legal_accepted") override val legalAccepted: Boolean? = null,
@@ -501,7 +502,7 @@ data class SignUp(
           is AuthenticateWithRedirectParams.EnterpriseSSO -> params.strategy
           is AuthenticateWithRedirectParams.OAuth -> params.provider.providerData.strategy
         }
-      return SSOService.authenticateWithRedirect(
+      return SSOService.authenticateSignUpWithRedirect(
         strategy = strategy,
         redirectUrl = params.redirectUrl,
         identifier = params.identifier,
@@ -550,6 +551,19 @@ suspend fun SignUp.update(
   updateParams: SignUp.SignUpUpdateParams
 ): ClerkResult<SignUp, ClerkErrorResponse> {
   return ClerkApi.signUp.updateSignUp(this.id, updateParams.toMap())
+}
+
+/**
+ * Retrieves the current state of the SignUp object from the server.
+ *
+ * @param rotatingTokenNonce Optional nonce for rotating token validation.
+ * @return A [ClerkResult] containing the refreshed [SignUp] object on success, or a
+ *   [ClerkErrorResponse] on failure.
+ */
+suspend fun SignUp.get(
+  rotatingTokenNonce: String? = null
+): ClerkResult<SignUp, ClerkErrorResponse> {
+  return ClerkApi.signUp.fetchSignUp(id = this.id, rotatingTokenNonce = rotatingTokenNonce)
 }
 
 /**

--- a/source/api/src/main/kotlin/com/clerk/api/sso/GoogleSignInService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/GoogleSignInService.kt
@@ -26,7 +26,6 @@ internal class GoogleSignInService(
   suspend fun signInWithGoogle(
     transferable: Boolean = true
   ): ClerkResult<OAuthResult, ClerkErrorResponse> {
-
     return try {
       val result = googleCredentialManager.getSignInWithGoogleCredential()
       handleSignInResult(result.credential, transferable)
@@ -35,6 +34,19 @@ internal class GoogleSignInService(
       classifyGetCredentialFailure(e, credentialTypes = listOf(SignIn.CredentialType.GOOGLE))
     } catch (e: CredentialFlowException) {
       ClerkLog.e("Google sign-in cannot start: ${e.message}")
+      ClerkResult.unknownFailure(e)
+    }
+  }
+
+  suspend fun signUpWithGoogle(): ClerkResult<OAuthResult, ClerkErrorResponse> {
+    return try {
+      val result = googleCredentialManager.getSignInWithGoogleCredential()
+      handleSignUpResult(result.credential)
+    } catch (e: GetCredentialException) {
+      ClerkLog.e("Error retrieving Google ID token: ${e.message}")
+      classifyGetCredentialFailure(e, credentialTypes = listOf(SignIn.CredentialType.GOOGLE))
+    } catch (e: CredentialFlowException) {
+      ClerkLog.e("Google sign-up cannot start: ${e.message}")
       ClerkResult.unknownFailure(e)
     }
   }
@@ -61,12 +73,30 @@ internal class GoogleSignInService(
             authResult.error?.errors?.firstOrNull()?.code == "external_account_not_found" &&
               transferable
           ) {
-            SignUp.create(SignUp.CreateParams.GoogleOneTap(token = idToken)).signUpToOAuthResult()
+            SignUp.create(SignUp.CreateParams.GoogleOneTap(token = idToken))
+              .signUpToOAuthResultWithTransfer()
           } else {
             authResult.signInToOAuthResult()
           }
         }
       }
+    } else {
+      ClerkResult.unknownFailure(
+        IllegalStateException("Unsupported credential type: ${credential.type}")
+      )
+    }
+  }
+
+  suspend fun handleSignUpResult(
+    credential: Credential
+  ): ClerkResult<OAuthResult, ClerkErrorResponse> {
+    return if (
+      credential is CustomCredential &&
+        credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
+    ) {
+      val idToken = googleCredentialManager.getIdTokenFromCredential(credential.data)
+      SignUp.create(SignUp.CreateParams.GoogleOneTap(token = idToken))
+        .signUpToOAuthResultWithTransfer()
     } else {
       ClerkResult.unknownFailure(
         IllegalStateException("Unsupported credential type: ${credential.type}")

--- a/source/api/src/main/kotlin/com/clerk/api/sso/SSOExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/SSOExtensions.kt
@@ -1,6 +1,7 @@
 package com.clerk.api.sso
 
 import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.shortErrorMessageOrNull
 import com.clerk.api.signin.SignIn
@@ -55,3 +56,27 @@ internal fun ClerkResult<SignUp, ClerkErrorResponse>.signUpToOAuthResult():
     }
   }
 }
+
+/**
+ * Converts a [SignUp] to OAuth output, following the reverse transfer flow used by native ID-token
+ * providers when the selected external account already belongs to an existing Clerk user.
+ */
+internal suspend fun ClerkResult<SignUp, ClerkErrorResponse>.signUpToOAuthResultWithTransfer():
+  ClerkResult<OAuthResult, ClerkErrorResponse> {
+  return when (this) {
+    is ClerkResult.Success -> this.value.toOAuthResultWithTransfer()
+    is ClerkResult.Failure -> this.signUpToOAuthResult()
+  }
+}
+
+private suspend fun SignUp.toOAuthResultWithTransfer():
+  ClerkResult<OAuthResult, ClerkErrorResponse> {
+  return if (needsTransferToSignIn) {
+    SignIn.create(SignIn.CreateParams.Strategy.Transfer()).signInToOAuthResult()
+  } else {
+    ClerkResult.success(OAuthResult(signUp = this))
+  }
+}
+
+private val SignUp.needsTransferToSignIn: Boolean
+  get() = verifications["external_account"]?.status == Verification.Status.TRANSFERABLE

--- a/source/api/src/main/kotlin/com/clerk/api/sso/SSOService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/SSOService.kt
@@ -5,14 +5,16 @@ import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.net.Uri
 import androidx.core.net.toUri
 import com.clerk.api.Clerk
+import com.clerk.api.Constants.Strategy.ENTERPRISE_SSO
 import com.clerk.api.externalaccount.ExternalAccount
 import com.clerk.api.externalaccount.ExternalAccountService
 import com.clerk.api.log.ClerkLog
-import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.errorMessage
+import com.clerk.api.signin.SignIn
 import com.clerk.api.signin.get
+import com.clerk.api.signin.prepareFirstFactor
 import com.clerk.api.signup.SignUp
 import com.clerk.api.signup.get
 import com.clerk.api.user.User.CreateExternalAccountParams
@@ -96,33 +98,66 @@ internal object SSOService {
       )
     )
     clearCurrentAuth()
+    val resolvedStrategy =
+      strategy
+        ?: return ClerkResult.unknownFailure(
+          Exception("Strategy cannot be null for redirect authentication")
+        )
 
     val initialResult =
-      ClerkApi.signIn.authenticateWithRedirect(
-        strategy = strategy,
-        redirectUrl = redirectUrl,
-        identifier = identifier,
-        emailAddress = emailAddress,
-        legalAccepted = legalAccepted,
+      SignIn.create(
+        buildMap {
+          put("strategy", resolvedStrategy)
+          put("redirect_url", redirectUrl)
+          put("locale", Clerk.locale.value.orEmpty())
+          identifier?.let { put("identifier", it) }
+          emailAddress?.let { put("email_address", it) }
+          legalAccepted?.let { put("legal_accepted", it.toString()) }
+        }
       )
 
     return when (initialResult) {
       is ClerkResult.Failure -> {
         val message = initialResult.errorMessage
         ClerkLog.e("Failed to authenticate with redirect: $message")
-        ClerkResult.apiFailure(initialResult.error)
+        initialResult.signInToOAuthResult()
       }
       is ClerkResult.Success -> {
-        ClerkLog.d("Successfully authenticated with redirect: $initialResult")
-        val externalUrl =
-          requireNotNull(
-            initialResult.value.firstFactorVerification?.externalVerificationRedirectUrl
-          ) {
-            "External URL cannot be null"
+        ClerkLog.d("Successfully created sign-in for redirect: $initialResult")
+        when (
+          val prepareResult =
+            initialResult.value.prepareFirstFactor(
+              firstFactorParams(strategy = resolvedStrategy, redirectUrl = redirectUrl)
+            )
+        ) {
+          is ClerkResult.Failure -> {
+            val message = prepareResult.errorMessage
+            ClerkLog.e("Failed to prepare redirect first factor: $message")
+            prepareResult.signInToOAuthResult()
           }
+          is ClerkResult.Success -> {
+            val externalUrl =
+              requireNotNull(
+                prepareResult.value.firstFactorVerification?.externalVerificationRedirectUrl
+              ) {
+                "External URL cannot be null"
+              }
 
-        authenticateWithPreparedRedirect(externalUrl, transferable)
+            authenticateWithPreparedRedirect(externalUrl, transferable)
+          }
+        }
       }
+    }
+  }
+
+  private fun firstFactorParams(
+    strategy: String,
+    redirectUrl: String,
+  ): SignIn.PrepareFirstFactorParams {
+    return if (strategy == ENTERPRISE_SSO) {
+      SignIn.PrepareFirstFactorParams.EnterpriseSSO(redirectUrl = redirectUrl)
+    } else {
+      SignIn.PrepareFirstFactorParams.OAuth(strategy = strategy, redirectUrl = redirectUrl)
     }
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/sso/SSOService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/SSOService.kt
@@ -14,7 +14,7 @@ import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.signin.get
 import com.clerk.api.signup.SignUp
-import com.clerk.api.sso.SSOService.authenticateWithRedirect
+import com.clerk.api.signup.get
 import com.clerk.api.user.User.CreateExternalAccountParams
 import kotlinx.coroutines.CompletableDeferred
 
@@ -54,6 +54,10 @@ internal object SSOService {
    * error.
    */
   private var currentTransferable: Boolean = true
+
+  private var currentRedirectFlow: RedirectFlow = RedirectFlow.SIGN_IN
+
+  private var currentSignUp: SignUp? = null
 
   /**
    * Initiates an OAuth authentication flow with redirect to an external provider.
@@ -122,6 +126,57 @@ internal object SSOService {
     }
   }
 
+  suspend fun authenticateSignUpWithRedirect(
+    strategy: String? = null,
+    redirectUrl: String = RedirectConfiguration.DEFAULT_REDIRECT_URL,
+    identifier: String? = null,
+    emailAddress: String? = null,
+    legalAccepted: Boolean? = null,
+  ): ClerkResult<OAuthResult, ClerkErrorResponse> {
+    currentPendingAuth?.complete(
+      ClerkResult.unknownFailure(
+        Exception("New authentication started, cancelling previous attempt")
+      )
+    )
+    clearCurrentAuth()
+
+    val initialResult =
+      SignUp.create(
+        buildMap {
+          strategy?.let { put("strategy", it) }
+          put("redirect_url", redirectUrl)
+          put("locale", Clerk.locale.value.orEmpty())
+          identifier?.let { put("identifier", it) }
+          emailAddress?.let { put("email_address", it) }
+          legalAccepted?.let { put("legal_accepted", it.toString()) }
+        }
+      )
+
+    return when (initialResult) {
+      is ClerkResult.Failure -> {
+        val message = initialResult.errorMessage
+        ClerkLog.e("Failed to authenticate sign-up with redirect: $message")
+        initialResult.signUpToOAuthResult()
+      }
+      is ClerkResult.Success -> {
+        val signUp = initialResult.value
+        val externalUrl =
+          requireNotNull(
+            signUp.verifications["external_account"]?.externalVerificationRedirectUrl
+          ) {
+            "External URL cannot be null"
+          }
+
+        authenticateWithPreparedRedirect(
+          externalVerificationRedirectUrl = externalUrl,
+          transferable = true,
+          redirectFlow = RedirectFlow.SIGN_UP,
+          signUp = signUp,
+        )
+      }
+    }
+  }
+
   /**
    * Continues an already prepared redirect flow.
    *
@@ -132,6 +187,8 @@ internal object SSOService {
   suspend fun authenticateWithPreparedRedirect(
     externalVerificationRedirectUrl: String,
     transferable: Boolean = true,
+    redirectFlow: RedirectFlow = RedirectFlow.SIGN_IN,
+    signUp: SignUp? = null,
   ): ClerkResult<OAuthResult, ClerkErrorResponse> {
     currentPendingAuth?.complete(
       ClerkResult.unknownFailure(
@@ -144,6 +201,8 @@ internal object SSOService {
 
     currentPendingAuth = completableDeferred
     currentTransferable = transferable
+    currentRedirectFlow = redirectFlow
+    currentSignUp = signUp
 
     val intent =
       Intent(Clerk.applicationContext?.get(), SSOReceiverActivity::class.java).apply {
@@ -184,16 +243,27 @@ internal object SSOService {
 
       val nonce = uri.getQueryParameter("rotating_token_nonce")
 
-      if (nonce != null) {
-        handleSignIn(nonce)
-      } else if (currentTransferable) {
-        handleSignUpTransfer()
-      } else {
-        ClerkLog.d("Sign-up transfer blocked: transferable is false")
-        currentPendingAuth?.complete(
-          ClerkResult.unknownFailure(Exception("external_account_not_found"))
-        )
-        clearCurrentAuth()
+      when (currentRedirectFlow) {
+        RedirectFlow.SIGN_IN -> {
+          if (nonce != null) {
+            handleSignIn(nonce)
+          } else if (currentTransferable) {
+            handleSignUpTransfer()
+          } else {
+            ClerkLog.d("Sign-up transfer blocked: transferable is false")
+            currentPendingAuth?.complete(
+              ClerkResult.unknownFailure(Exception("external_account_not_found"))
+            )
+            clearCurrentAuth()
+          }
+        }
+        RedirectFlow.SIGN_UP -> {
+          if (nonce != null) {
+            handleSignUp(nonce)
+          } else {
+            handleSignInTransfer()
+          }
+        }
       }
     } catch (e: Exception) {
       ClerkLog.e("Error completing authentication with redirect: ${e.message}")
@@ -265,6 +335,21 @@ internal object SSOService {
     clearCurrentAuth()
   }
 
+  private suspend fun handleSignUp(nonce: String) {
+    val signUpResult = requireNotNull(currentSignUp ?: Clerk.auth.currentSignUp).get(nonce)
+    currentPendingAuth?.complete(signUpResult.signUpToOAuthResult())
+
+    clearCurrentAuth()
+  }
+
+  private suspend fun handleSignInTransfer() {
+    ClerkLog.d("Handling sign-in transfer")
+    val signUpResult = requireNotNull(currentSignUp ?: Clerk.auth.currentSignUp).get()
+    currentPendingAuth?.complete(signUpResult.signUpToOAuthResultWithTransfer())
+
+    clearCurrentAuth()
+  }
+
   /**
    * Clears the current authentication state.
    *
@@ -275,6 +360,8 @@ internal object SSOService {
   private fun clearCurrentAuth() {
     currentPendingAuth = null
     currentTransferable = true
+    currentRedirectFlow = RedirectFlow.SIGN_IN
+    currentSignUp = null
   }
 
   /**
@@ -313,5 +400,10 @@ internal object SSOService {
    */
   fun hasPendingExternalAccountConnection(): Boolean {
     return ExternalAccountService.hasPendingExternalAccountConnection()
+  }
+
+  internal enum class RedirectFlow {
+    SIGN_IN,
+    SIGN_UP,
   }
 }

--- a/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
+++ b/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
@@ -9,7 +9,6 @@ import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
-import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
 import com.clerk.api.sso.OAuthResult
 import io.mockk.coEvery
@@ -45,22 +44,22 @@ class AuthTest {
   }
 
   @Test
-  fun `signUpWithGoogleOneTap delegates to transferable Google One Tap flow`() = runTest {
-    mockkObject(SignIn.Companion)
+  fun `signUpWithGoogleOneTap delegates to Google sign-up flow`() = runTest {
+    mockkObject(SignUp.Companion)
     val signUp = mockk<SignUp>(relaxed = true)
     val oauthResult = OAuthResult(signUp = signUp)
-    coEvery { SignIn.authenticateWithGoogleOneTap(true) } returns ClerkResult.success(oauthResult)
+    coEvery { SignUp.authenticateWithGoogleOneTap() } returns ClerkResult.success(oauthResult)
 
     val result = Auth().signUpWithGoogleOneTap()
 
     assertTrue(result is ClerkResult.Success)
     assertSame(oauthResult, (result as ClerkResult.Success).value)
-    coVerify(exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
+    coVerify(exactly = 1) { SignUp.authenticateWithGoogleOneTap() }
   }
 
   @Test
   fun `signUpWithGoogleOneTap emits auth error event on failure`() = runTest {
-    mockkObject(SignIn.Companion)
+    mockkObject(SignUp.Companion)
     val error =
       ClerkErrorResponse(
         errors =
@@ -73,7 +72,7 @@ class AuthTest {
           ),
         clerkTraceId = "trace_123",
       )
-    coEvery { SignIn.authenticateWithGoogleOneTap(true) } returns ClerkResult.apiFailure(error)
+    coEvery { SignUp.authenticateWithGoogleOneTap() } returns ClerkResult.apiFailure(error)
 
     val auth = Auth()
     val events = mutableListOf<AuthEvent>()
@@ -91,7 +90,7 @@ class AuthTest {
       "Account already exists. Use sign in instead.",
       (events.single() as AuthEvent.Error).message,
     )
-    coVerify(exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
+    coVerify(exactly = 1) { SignUp.authenticateWithGoogleOneTap() }
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
+++ b/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
@@ -1,13 +1,20 @@
 package com.clerk.api.auth
 
+import com.clerk.api.Clerk
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.api.ClientApi
+import com.clerk.api.network.api.SessionApi
+import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
 import com.clerk.api.sso.OAuthResult
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
@@ -21,13 +28,20 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 class AuthTest {
 
+  @Before
+  fun setup() {
+    Clerk.updateClient(Client())
+  }
+
   @After
   fun tearDown() {
     unmockkAll()
+    Clerk.updateClient(Client())
   }
 
   @Test
@@ -79,4 +93,85 @@ class AuthTest {
     )
     coVerify(exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
   }
+
+  @Test
+  fun `sessions exposes all sessions on the current client`() {
+    val firstSession = testSession("sess_1")
+    val secondSession = testSession("sess_2")
+    Clerk.updateClient(
+      Client(
+        id = "client_123",
+        sessions = listOf(firstSession, secondSession),
+        lastActiveSessionId = firstSession.id,
+      )
+    )
+
+    assertEquals(listOf(firstSession, secondSession), Auth().sessions)
+  }
+
+  @Test
+  fun `signOut with session ID removes only that session locally`() = runTest {
+    val firstSession = testSession("sess_1")
+    val secondSession = testSession("sess_2")
+    val sessionApi = mockk<SessionApi>()
+    val clientApi = mockk<ClientApi>()
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    every { ClerkApi.client } returns clientApi
+    coEvery { sessionApi.removeSession(firstSession.id) } returns ClerkResult.success(firstSession)
+    coEvery { clientApi.get() } returns
+      ClerkResult.apiFailure(ClerkErrorResponse(errors = emptyList()))
+    Clerk.updateClient(
+      Client(
+        id = "client_123",
+        sessions = listOf(firstSession, secondSession),
+        lastActiveSessionId = firstSession.id,
+      )
+    )
+
+    val result = Auth().signOut(sessionId = firstSession.id)
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(listOf(secondSession), Clerk.client.sessions)
+    assertEquals(secondSession.id, Clerk.client.lastActiveSessionId)
+    assertEquals(secondSession, Clerk.sessionFlow.value)
+    coVerify(exactly = 1) { sessionApi.removeSession(firstSession.id) }
+  }
+
+  @Test
+  fun `setActive updates the active session locally`() = runTest {
+    val firstSession = testSession("sess_1")
+    val secondSession = testSession("sess_2")
+    val clientApi = mockk<ClientApi>()
+    mockkObject(ClerkApi)
+    every { ClerkApi.client } returns clientApi
+    coEvery { clientApi.setActive(secondSession.id, null) } returns
+      ClerkResult.success(secondSession)
+    coEvery { clientApi.get() } returns
+      ClerkResult.apiFailure(ClerkErrorResponse(errors = emptyList()))
+    Clerk.updateClient(
+      Client(
+        id = "client_123",
+        sessions = listOf(firstSession, secondSession),
+        lastActiveSessionId = firstSession.id,
+      )
+    )
+
+    val result = Auth().setActive(sessionId = secondSession.id)
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(secondSession.id, Clerk.client.lastActiveSessionId)
+    assertEquals(secondSession, Clerk.sessionFlow.value)
+    coVerify(exactly = 1) { clientApi.setActive(secondSession.id, null) }
+  }
+
+  private fun testSession(id: String): Session =
+    Session(
+      id = id,
+      status = Session.SessionStatus.ACTIVE,
+      expireAt = 10_000,
+      lastActiveAt = 1_000,
+      createdAt = 1_000,
+      updatedAt = 1_000,
+    )
 }

--- a/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
+++ b/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
@@ -10,7 +10,9 @@ import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
 import com.clerk.api.signup.SignUp
+import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.OAuthResult
+import com.clerk.api.sso.SSOService
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -55,6 +57,36 @@ class AuthTest {
     assertTrue(result is ClerkResult.Success)
     assertSame(oauthResult, (result as ClerkResult.Success).value)
     coVerify(exactly = 1) { SignUp.authenticateWithGoogleOneTap() }
+  }
+
+  @Test
+  fun `signUpWithOAuth delegates to sign-up redirect flow`() = runTest {
+    mockkObject(SSOService)
+    val signUp = mockk<SignUp>(relaxed = true)
+    val oauthResult = OAuthResult(signUp = signUp)
+    coEvery {
+      SSOService.authenticateSignUpWithRedirect(
+        strategy = "oauth_google",
+        redirectUrl = any(),
+        identifier = null,
+        emailAddress = null,
+        legalAccepted = null,
+      )
+    } returns ClerkResult.success(oauthResult)
+
+    val result = Auth().signUpWithOAuth(OAuthProvider.GOOGLE)
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(oauthResult, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) {
+      SSOService.authenticateSignUpWithRedirect(
+        strategy = "oauth_google",
+        redirectUrl = any(),
+        identifier = null,
+        emailAddress = null,
+        legalAccepted = null,
+      )
+    }
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
+++ b/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
@@ -13,6 +13,7 @@ import com.clerk.api.signup.SignUp
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.OAuthResult
 import com.clerk.api.sso.SSOService
+import com.clerk.api.user.User
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -194,6 +195,66 @@ class AuthTest {
     assertEquals(secondSession.id, Clerk.client.lastActiveSessionId)
     assertEquals(secondSession, Clerk.sessionFlow.value)
     coVerify(exactly = 1) { clientApi.setActive(secondSession.id, null) }
+  }
+
+  @Test
+  fun `setActive restores active session when response client sync clears local sessions`() =
+    runTest {
+      val firstSession = testSession("sess_1")
+      val secondUser = mockk<User>(relaxed = true)
+      val secondSession = testSession("sess_2").copy(user = secondUser)
+      val dehydratedSecondSession = testSession("sess_2")
+      val clientApi = mockk<ClientApi>()
+      mockkObject(ClerkApi)
+      every { ClerkApi.client } returns clientApi
+      coEvery { clientApi.setActive(secondSession.id, null) } coAnswers
+        {
+          Clerk.updateClient(Client(id = "client_123"))
+          ClerkResult.success(dehydratedSecondSession)
+        }
+      coEvery { clientApi.get() } returns
+        ClerkResult.apiFailure(ClerkErrorResponse(errors = emptyList()))
+      Clerk.updateClient(
+        Client(
+          id = "client_123",
+          sessions = listOf(firstSession, secondSession),
+          lastActiveSessionId = firstSession.id,
+        )
+      )
+
+      val result = Auth().setActive(sessionId = secondSession.id)
+
+      assertTrue(result is ClerkResult.Success)
+      assertEquals(listOf(firstSession, secondSession), Clerk.client.sessions)
+      assertEquals(secondSession.id, Clerk.client.lastActiveSessionId)
+      assertEquals(secondSession, Clerk.sessionFlow.value)
+      assertEquals(secondUser, Clerk.userFlow.value)
+    }
+
+  @Test
+  fun `setActive keeps active session when follow-up client refresh omits it`() = runTest {
+    val firstSession = testSession("sess_1")
+    val secondSession = testSession("sess_2")
+    val clientApi = mockk<ClientApi>()
+    mockkObject(ClerkApi)
+    every { ClerkApi.client } returns clientApi
+    coEvery { clientApi.setActive(secondSession.id, null) } returns
+      ClerkResult.success(secondSession)
+    coEvery { clientApi.get() } returns ClerkResult.success(Client(id = "client_123"))
+    Clerk.updateClient(
+      Client(
+        id = "client_123",
+        sessions = listOf(firstSession, secondSession),
+        lastActiveSessionId = firstSession.id,
+      )
+    )
+
+    val result = Auth().setActive(sessionId = secondSession.id)
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(listOf(firstSession, secondSession), Clerk.client.sessions)
+    assertEquals(secondSession.id, Clerk.client.lastActiveSessionId)
+    assertEquals(secondSession, Clerk.sessionFlow.value)
   }
 
   private fun testSession(id: String): Session =

--- a/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
+++ b/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
@@ -257,6 +257,42 @@ class AuthTest {
     assertEquals(secondSession, Clerk.sessionFlow.value)
   }
 
+  @Test
+  fun `setActive keeps active session when follow-up refresh returns stale lastActiveSessionId`() =
+    runTest {
+      val firstSession = testSession("sess_1")
+      val secondSession = testSession("sess_2")
+      val clientApi = mockk<ClientApi>()
+      mockkObject(ClerkApi)
+      every { ClerkApi.client } returns clientApi
+      coEvery { clientApi.setActive(secondSession.id, null) } returns
+        ClerkResult.success(secondSession)
+      // Read replica returns a fully-hydrated client but with the previous
+      // lastActiveSessionId — read-after-write lag.
+      coEvery { clientApi.get() } returns
+        ClerkResult.success(
+          Client(
+            id = "client_123",
+            sessions = listOf(firstSession, secondSession),
+            lastActiveSessionId = firstSession.id,
+          )
+        )
+      Clerk.updateClient(
+        Client(
+          id = "client_123",
+          sessions = listOf(firstSession, secondSession),
+          lastActiveSessionId = firstSession.id,
+        )
+      )
+
+      val result = Auth().setActive(sessionId = secondSession.id)
+
+      assertTrue(result is ClerkResult.Success)
+      assertEquals(listOf(firstSession, secondSession), Clerk.client.sessions)
+      assertEquals(secondSession.id, Clerk.client.lastActiveSessionId)
+      assertEquals(secondSession, Clerk.sessionFlow.value)
+    }
+
   private fun testSession(id: String): Session =
     Session(
       id = id,

--- a/source/api/src/test/java/com/clerk/api/network/middleware/incoming/ClientSyncingMiddlewareTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/middleware/incoming/ClientSyncingMiddlewareTest.kt
@@ -136,6 +136,50 @@ class ClientSyncingMiddlewareTest {
     assertEquals(emptyList<Session>(), Clerk.sessionsFlow.value)
   }
 
+  @Test
+  fun `intercept does not clear Clerk client when null client piggyback accompanies response`() {
+    val middleware = ClientSyncingMiddleware(json = ClerkApi.json)
+    val session = testSession("sess_123")
+    val client =
+      Client(id = "client_123", sessions = listOf(session), lastActiveSessionId = session.id)
+    Clerk.updateClient(client)
+
+    val request = Request.Builder().url("https://api.clerk.com/v1/client").build()
+
+    val responseBody =
+      """
+      {
+        "response": {
+          "object": "client",
+          "id": "client_123",
+          "sessions": [],
+          "last_active_session_id": null
+        },
+        "client": null
+      }
+      """
+        .trimIndent()
+        .toResponseBody("application/json".toMediaType())
+
+    val response =
+      Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .body(responseBody)
+        .build()
+
+    val chain = mockk<Interceptor.Chain>()
+    every { chain.request() } returns request
+    every { chain.proceed(request) } returns response
+
+    middleware.intercept(chain)
+
+    assertEquals(client, Clerk.client)
+    assertEquals(listOf(session), Clerk.sessionsFlow.value)
+  }
+
   private fun testSession(id: String): Session =
     Session(
       id = id,

--- a/source/api/src/test/java/com/clerk/api/network/middleware/incoming/ClientSyncingMiddlewareTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/middleware/incoming/ClientSyncingMiddlewareTest.kt
@@ -3,6 +3,8 @@ package com.clerk.api.network.middleware.incoming
 import com.clerk.api.Clerk
 import com.clerk.api.auth.AuthEvent
 import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.client.Client
+import com.clerk.api.session.Session
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -32,6 +34,7 @@ class ClientSyncingMiddlewareTest {
   @After
   fun tearDown() {
     unmockkAll()
+    Clerk.updateClient(Client())
     Clerk.clearSessionAndUserState()
   }
 
@@ -94,4 +97,52 @@ class ClientSyncingMiddlewareTest {
     assertEquals(1, completedEvents.size)
     assertEquals("su_123", completedEvents.single().signUp.id)
   }
+
+  @Test
+  fun `intercept clears Clerk client when response client is explicit null`() {
+    val middleware = ClientSyncingMiddleware(json = ClerkApi.json)
+    val session = testSession("sess_123")
+    Clerk.updateClient(
+      Client(id = "client_123", sessions = listOf(session), lastActiveSessionId = session.id)
+    )
+
+    val request = Request.Builder().url("https://api.clerk.com/v1/client/sessions").build()
+
+    val responseBody =
+      """
+      {
+        "client": null
+      }
+      """
+        .trimIndent()
+        .toResponseBody("application/json".toMediaType())
+
+    val response =
+      Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .body(responseBody)
+        .build()
+
+    val chain = mockk<Interceptor.Chain>()
+    every { chain.request() } returns request
+    every { chain.proceed(request) } returns response
+
+    middleware.intercept(chain)
+
+    assertEquals(Client(), Clerk.client)
+    assertEquals(emptyList<Session>(), Clerk.sessionsFlow.value)
+  }
+
+  private fun testSession(id: String): Session =
+    Session(
+      id = id,
+      status = Session.SessionStatus.ACTIVE,
+      expireAt = 10_000,
+      lastActiveAt = 1_000,
+      createdAt = 1_000,
+      updatedAt = 1_000,
+    )
 }

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -107,9 +107,6 @@ class ClerkTest {
 
   private fun resetClerkState() {
     try {
-      // Reset lateinit properties using reflection
-      val clerkClass = Clerk::class.java
-
       // Reset client if it's initialized
       try {
         // We can't unset a lateinit property, but we can set it to a mock that behaves as
@@ -128,8 +125,6 @@ class ClerkTest {
 
       // Reset environment if it's initialized
       try {
-        val environmentField = clerkClass.getDeclaredField("environment")
-        environmentField.isAccessible = true
         // We can't unset a lateinit property, so we set it to a mock that behaves as uninitialized
         val uninitializedEnvironment = mockk<Environment>()
         val uninitializedDisplayConfig = mockk<DisplayConfig>()
@@ -152,7 +147,7 @@ class ClerkTest {
         every { uninitializedEnvironment.emailIsImmutable } returns false
         every { uninitializedEnvironment.phoneNumberIsImmutable } returns false
         every { uninitializedEnvironment.usernameIsImmutable } returns false
-        environmentField.set(Clerk, uninitializedEnvironment)
+        Clerk.updateEnvironment(uninitializedEnvironment)
       } catch (_: Exception) {
         // Environment not initialized, that's fine
       }
@@ -171,11 +166,11 @@ class ClerkTest {
 
   private fun initializeClerkWithClient(client: Client) {
     Clerk.updateClient(client)
-    Clerk.environment = mockEnvironment
+    Clerk.updateEnvironment(mockEnvironment)
   }
 
   private fun initializeClerkWithEnvironment() {
-    Clerk.environment = mockEnvironment
+    Clerk.updateEnvironment(mockEnvironment)
   }
 
   private fun simulateUninitializedClient() {
@@ -205,7 +200,7 @@ class ClerkTest {
     every { uninitializedEnvironment.emailIsImmutable } returns false
     every { uninitializedEnvironment.phoneNumberIsImmutable } returns false
     every { uninitializedEnvironment.usernameIsImmutable } returns false
-    Clerk.environment = uninitializedEnvironment
+    Clerk.updateEnvironment(uninitializedEnvironment)
   }
 
   @Test
@@ -338,12 +333,15 @@ class ClerkTest {
 
     // Then
     assertTrue(Clerk.multiSessionModeIsEnabled)
+    assertTrue(Clerk.multiSessionModeIsEnabledFlow.value)
 
     // When
     every { mockEnvironment.authConfig } returns AuthConfig(singleSessionMode = true)
+    Clerk.updateEnvironment(mockEnvironment)
 
     // Then
     assertFalse(Clerk.multiSessionModeIsEnabled)
+    assertFalse(Clerk.multiSessionModeIsEnabledFlow.value)
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -308,6 +308,28 @@ class ClerkTest {
     }
 
   @Test
+  fun `updateClient preserves previous active session when refreshed client references missing active id`() =
+    runTest {
+      // Given
+      val activeSessionId = "session_1"
+      every { mockSession.id } returns activeSessionId
+      every { mockSession.status } returns Session.SessionStatus.ACTIVE
+      every { mockSession.user } returns mockUser
+      initializeClerkWithClient(
+        Client(sessions = listOf(mockSession), lastActiveSessionId = activeSessionId)
+      )
+
+      // When - set-active refreshes can briefly include an active id that is not hydrated in the
+      // sessions list.
+      Clerk.updateClient(Client(sessions = listOf(mockSession), lastActiveSessionId = "session_2"))
+
+      // Then
+      assertEquals(activeSessionId, Clerk.client.lastActiveSessionId)
+      assertEquals(mockSession, Clerk.sessionFlow.value)
+      assertEquals(mockUser, Clerk.userFlow.value)
+    }
+
+  @Test
   fun `updateClient activates sole session when refreshed client omits active id`() = runTest {
     // Given
     val activeSessionId = "session_1"

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -221,18 +221,23 @@ class ClerkTest {
   }
 
   @Test
-  fun `session returns null when client has no last active session ID`() = runTest {
-    // Given
-    every { mockClient.lastActiveSessionId } returns null
-    every { mockClient.sessions } returns listOf(mockSession)
-    initializeClerkWithClient(mockClient)
+  fun `session returns null when client has multiple sessions and no last active session ID`() =
+    runTest {
+      // Given
+      val firstSession = mockk<Session>(relaxed = true)
+      val secondSession = mockk<Session>(relaxed = true)
+      every { firstSession.id } returns "session_1"
+      every { secondSession.id } returns "session_2"
+      every { mockClient.lastActiveSessionId } returns null
+      every { mockClient.sessions } returns listOf(firstSession, secondSession)
+      initializeClerkWithClient(mockClient)
 
-    // When
-    val session = Clerk.session
+      // When
+      val session = Clerk.session
 
-    // Then
-    assertNull(session)
-  }
+      // Then
+      assertNull(session)
+    }
 
   @Test
   fun `session returns null when no sessions match active session ID`() = runTest {
@@ -283,6 +288,46 @@ class ClerkTest {
 
     // Then
     assertEquals(listOf(firstSession, secondSession), Clerk.sessionsFlow.value)
+  }
+
+  @Test
+  fun `updateClient preserves previous active session when refreshed client omits active id`() =
+    runTest {
+      // Given
+      val activeSessionId = "session_1"
+      every { mockSession.id } returns activeSessionId
+      every { mockSession.status } returns Session.SessionStatus.ACTIVE
+      every { mockSession.user } returns mockUser
+      initializeClerkWithClient(
+        Client(sessions = listOf(mockSession), lastActiveSessionId = activeSessionId)
+      )
+
+      // When - in-progress add-account responses can omit lastActiveSessionId while retaining
+      // existing sessions.
+      Clerk.updateClient(Client(sessions = listOf(mockSession), lastActiveSessionId = null))
+
+      // Then
+      assertEquals(activeSessionId, Clerk.client.lastActiveSessionId)
+      assertEquals(mockSession, Clerk.sessionFlow.value)
+      assertEquals(mockUser, Clerk.userFlow.value)
+    }
+
+  @Test
+  fun `updateClient activates sole session when refreshed client omits active id`() = runTest {
+    // Given
+    val activeSessionId = "session_1"
+    every { mockSession.id } returns activeSessionId
+    every { mockSession.status } returns Session.SessionStatus.ACTIVE
+    every { mockSession.user } returns mockUser
+    simulateUninitializedClient()
+
+    // When - initial Google auth can return one session before lastActiveSessionId is populated.
+    Clerk.updateClient(Client(sessions = listOf(mockSession), lastActiveSessionId = null))
+
+    // Then
+    assertEquals(activeSessionId, Clerk.client.lastActiveSessionId)
+    assertEquals(mockSession, Clerk.sessionFlow.value)
+    assertEquals(mockUser, Clerk.userFlow.value)
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.clerk.api.Clerk
 import com.clerk.api.auth.AuthEvent
 import com.clerk.api.network.model.client.Client
+import com.clerk.api.network.model.environment.AuthConfig
 import com.clerk.api.network.model.environment.DisplayConfig
 import com.clerk.api.network.model.environment.Environment
 import com.clerk.api.network.model.environment.UserSettings
@@ -76,6 +77,7 @@ class ClerkTest {
     every { mockClient.updatedAt } returns null
 
     // Set up environment mock with display config and user settings
+    every { mockEnvironment.authConfig } returns AuthConfig(singleSessionMode = false)
     every { mockEnvironment.displayConfig } returns mockDisplayConfig
     every { mockEnvironment.userSettings } returns mockUserSettings
     every { mockDisplayConfig.logoImageUrl } returns "https://example.com/logo.png"
@@ -132,6 +134,7 @@ class ClerkTest {
         val uninitializedEnvironment = mockk<Environment>()
         val uninitializedDisplayConfig = mockk<DisplayConfig>()
         val uninitializedUserSettings = mockk<UserSettings>()
+        every { uninitializedEnvironment.authConfig } returns AuthConfig(singleSessionMode = true)
         every { uninitializedEnvironment.displayConfig } returns uninitializedDisplayConfig
         every { uninitializedEnvironment.userSettings } returns uninitializedUserSettings
         every { uninitializedDisplayConfig.logoImageUrl } returns ""
@@ -190,6 +193,7 @@ class ClerkTest {
     val uninitializedEnvironment = mockk<Environment>(relaxed = true)
     val uninitializedDisplayConfig = mockk<DisplayConfig>(relaxed = true)
     val uninitializedUserSettings = mockk<UserSettings>(relaxed = true)
+    every { uninitializedEnvironment.authConfig } returns AuthConfig(singleSessionMode = true)
     every { uninitializedEnvironment.displayConfig } returns uninitializedDisplayConfig
     every { uninitializedEnvironment.userSettings } returns uninitializedUserSettings
     every { uninitializedDisplayConfig.logoImageUrl } returns ""
@@ -264,6 +268,37 @@ class ClerkTest {
 
     // Then
     assertEquals(mockSession, session)
+  }
+
+  @Test
+  fun `sessionsFlow exposes all sessions from current client`() = runTest {
+    // Given
+    val firstSession = mockk<Session>(relaxed = true)
+    val secondSession = mockk<Session>(relaxed = true)
+    every { firstSession.id } returns "session_1"
+    every { secondSession.id } returns "session_2"
+    every { mockClient.sessions } returns listOf(firstSession, secondSession)
+    every { mockClient.lastActiveSessionId } returns "session_1"
+    initializeClerkWithClient(mockClient)
+
+    // Then
+    assertEquals(listOf(firstSession, secondSession), Clerk.sessionsFlow.value)
+  }
+
+  @Test
+  fun `multiSessionModeIsEnabled mirrors inverse of single session environment flag`() = runTest {
+    // Given
+    every { mockEnvironment.authConfig } returns AuthConfig(singleSessionMode = false)
+    initializeClerkWithEnvironment()
+
+    // Then
+    assertTrue(Clerk.multiSessionModeIsEnabled)
+
+    // When
+    every { mockEnvironment.authConfig } returns AuthConfig(singleSessionMode = true)
+
+    // Then
+    assertFalse(Clerk.multiSessionModeIsEnabled)
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/signout/SignOutServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signout/SignOutServiceTest.kt
@@ -118,8 +118,8 @@ class SignOutServiceTest {
     StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "test_device_token")
 
     // Mock successful server sign-out
-    coEvery { mockSessionApi.removeSession(any()) } returns ClerkResult.success(mockSession)
-    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(mockClient)
+    coEvery { mockSessionApi.deleteSessions() } returns ClerkResult.success(Client())
+    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(Client())
 
     // Verify device token exists before sign-out
     assertTrue(StorageHelper.loadValue(StorageKey.DEVICE_TOKEN) != null)
@@ -142,8 +142,8 @@ class SignOutServiceTest {
     StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "test_device_token")
 
     // Mock server sign-out failure (network error)
-    coEvery { mockSessionApi.removeSession(any()) } throws Exception("Network error")
-    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(mockClient)
+    coEvery { mockSessionApi.deleteSessions() } throws Exception("Network error")
+    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(Client())
 
     // Verify device token exists before sign-out
     assertTrue(StorageHelper.loadValue(StorageKey.DEVICE_TOKEN) != null)
@@ -168,8 +168,8 @@ class SignOutServiceTest {
     setupActiveSession()
 
     // Mock successful server sign-out
-    coEvery { mockSessionApi.removeSession(any()) } returns ClerkResult.success(mockSession)
-    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(mockClient)
+    coEvery { mockSessionApi.deleteSessions() } returns ClerkResult.success(Client())
+    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(Client())
 
     // Verify session exists before sign-out
     assertTrue("Session should exist before sign-out", Clerk.session != null)
@@ -191,8 +191,8 @@ class SignOutServiceTest {
     setupActiveSession()
 
     // Mock server sign-out failure
-    coEvery { mockSessionApi.removeSession(any()) } throws Exception("Server error")
-    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(mockClient)
+    coEvery { mockSessionApi.deleteSessions() } throws Exception("Server error")
+    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(Client())
 
     // Verify session exists before sign-out
     assertTrue("Session should exist before sign-out", Clerk.session != null)
@@ -221,7 +221,8 @@ class SignOutServiceTest {
     Clerk.updateClient(emptyClient)
     Clerk.environment = mockEnvironment
 
-    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(emptyClient)
+    coEvery { mockSessionApi.deleteSessions() } returns ClerkResult.success(Client())
+    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(Client())
 
     // When
     val result = SignOutService.signOut()
@@ -238,8 +239,8 @@ class SignOutServiceTest {
     StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "test_device_token")
 
     // Mock successful server sign-out
-    coEvery { mockSessionApi.removeSession(any()) } returns ClerkResult.success(mockSession)
-    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(mockClient)
+    coEvery { mockSessionApi.deleteSessions() } returns ClerkResult.success(Client())
+    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(Client())
 
     // When
     SignOutService.signOut()
@@ -255,8 +256,8 @@ class SignOutServiceTest {
   @Test
   fun `signOut refreshes client after local sign-out cleanup`() = runTest {
     setupActiveSession()
-    coEvery { mockSessionApi.removeSession(any()) } returns ClerkResult.success(mockSession)
-    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(mockClient)
+    coEvery { mockSessionApi.deleteSessions() } returns ClerkResult.success(Client())
+    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(Client())
 
     val result = SignOutService.signOut()
 
@@ -267,7 +268,7 @@ class SignOutServiceTest {
   @Test
   fun `signOut tolerates client refresh failure`() = runTest {
     setupActiveSession()
-    coEvery { mockSessionApi.removeSession(any()) } returns ClerkResult.success(mockSession)
+    coEvery { mockSessionApi.deleteSessions() } returns ClerkResult.success(Client())
     coEvery { mockClientApi.getSkippingClientId(any()) } throws Exception("Refresh failed")
 
     val result = SignOutService.signOut()

--- a/source/api/src/test/java/com/clerk/api/signup/SignUpAuthenticateWithRedirectTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signup/SignUpAuthenticateWithRedirectTest.kt
@@ -1,0 +1,61 @@
+package com.clerk.api.signup
+
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.sso.OAuthProvider
+import com.clerk.api.sso.OAuthResult
+import com.clerk.api.sso.SSOService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SignUpAuthenticateWithRedirectTest {
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `authenticateWithRedirect uses sign-up redirect flow for OAuth provider`() = runTest {
+    mockkObject(SSOService)
+    val redirectUrl = "clerk://example.callback"
+    val signUp = mockk<SignUp>(relaxed = true)
+    val oauthResult = OAuthResult(signUp = signUp)
+    coEvery {
+      SSOService.authenticateSignUpWithRedirect(
+        strategy = "oauth_google",
+        redirectUrl = redirectUrl,
+        identifier = null,
+        emailAddress = null,
+        legalAccepted = null,
+      )
+    } returns ClerkResult.success(oauthResult)
+
+    val result =
+      SignUp.authenticateWithRedirect(
+        SignUp.AuthenticateWithRedirectParams.OAuth(
+          provider = OAuthProvider.GOOGLE,
+          redirectUrl = redirectUrl,
+        )
+      )
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(oauthResult, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) {
+      SSOService.authenticateSignUpWithRedirect(
+        strategy = "oauth_google",
+        redirectUrl = redirectUrl,
+        identifier = null,
+        emailAddress = null,
+        legalAccepted = null,
+      )
+    }
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/sso/GoogleSignInServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/GoogleSignInServiceTest.kt
@@ -13,11 +13,13 @@ import com.clerk.api.network.model.environment.DisplayConfig
 import com.clerk.api.network.model.environment.Environment
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
+import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -55,6 +57,7 @@ class GoogleSignInServiceTest {
     mockSignUp = mockk(relaxed = true)
     mockEnvironment = mockk(relaxed = true)
     mockDisplayConfig = mockk(relaxed = true)
+    every { mockSignUp.verifications } returns emptyMap()
 
     // Mock Clerk object and its environment
     mockkObject(Clerk)
@@ -68,6 +71,7 @@ class GoogleSignInServiceTest {
 
     // Mock SignUp.create
     mockkObject(SignUp.Companion)
+    mockkObject(SignIn.Companion)
 
     // Create service instance with mocked credential manager
     googleSignInService = GoogleSignInService(mockGoogleCredentialManager)
@@ -142,6 +146,52 @@ class GoogleSignInServiceTest {
     assertEquals(mockSignUp, oauthResult.signUp)
     assertEquals(ResultType.SIGN_UP, oauthResult.resultType)
   }
+
+  @Test
+  fun `signInWithGoogle transfers created sign-up back to sign-in when external account exists`() =
+    runTest {
+      // Given
+      val idToken = "test_id_token"
+      val error =
+        Error(
+          code = "external_account_not_found",
+          message = "Account not found",
+          longMessage = "External account not found for this user",
+        )
+      val errorResponse = ClerkErrorResponse(errors = listOf(error), clerkTraceId = "test_trace_id")
+      val transferableSignUp =
+        testSignUp(
+          verifications =
+            mapOf("external_account" to Verification(status = Verification.Status.TRANSFERABLE))
+        )
+
+      every { mockGetCredentialResponse.credential } returns mockCustomCredential
+      every { mockCustomCredential.type } returns
+        GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
+      every { mockCustomCredential.data } returns mockBundle
+
+      coEvery { mockGoogleCredentialManager.getSignInWithGoogleCredential() } returns
+        mockGetCredentialResponse
+      every { mockGoogleCredentialManager.getIdTokenFromCredential(mockBundle) } returns idToken
+
+      coEvery { ClerkApi.signIn.authenticateWithGoogle(token = idToken) } returns
+        ClerkResult.apiFailure(errorResponse)
+      coEvery { SignUp.create(any<SignUp.CreateParams.GoogleOneTap>()) } returns
+        ClerkResult.success(transferableSignUp)
+      coEvery { SignIn.create(any<SignIn.CreateParams.Strategy.Transfer>()) } returns
+        ClerkResult.success(mockSignIn)
+
+      // When
+      val result = googleSignInService.signInWithGoogle()
+
+      // Then
+      assertTrue(result is ClerkResult.Success)
+      val oauthResult = (result as ClerkResult.Success).value
+      assertEquals(mockSignIn, oauthResult.signIn)
+      assertEquals(null, oauthResult.signUp)
+      assertEquals(ResultType.SIGN_IN, oauthResult.resultType)
+      coVerify(exactly = 1) { SignIn.create(any<SignIn.CreateParams.Strategy.Transfer>()) }
+    }
 
   @Test
   fun `signInWithGoogle returns error when authentication fails with other error`() = runTest {
@@ -267,5 +317,53 @@ class GoogleSignInServiceTest {
 
     // Then
     assertEquals(idToken, createParamsSlot.captured.token)
+  }
+
+  @Test
+  fun `signUpWithGoogle transfers existing external account to sign-in`() = runTest {
+    // Given
+    val idToken = "test_id_token"
+    val transferableSignUp =
+      testSignUp(
+        verifications =
+          mapOf("external_account" to Verification(status = Verification.Status.TRANSFERABLE))
+      )
+
+    every { mockGetCredentialResponse.credential } returns mockCustomCredential
+    every { mockCustomCredential.type } returns
+      GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
+    every { mockCustomCredential.data } returns mockBundle
+
+    coEvery { mockGoogleCredentialManager.getSignInWithGoogleCredential() } returns
+      mockGetCredentialResponse
+    every { mockGoogleCredentialManager.getIdTokenFromCredential(mockBundle) } returns idToken
+
+    coEvery { SignUp.create(any<SignUp.CreateParams.GoogleOneTap>()) } returns
+      ClerkResult.success(transferableSignUp)
+    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy.Transfer>()) } returns
+      ClerkResult.success(mockSignIn)
+
+    // When
+    val result = googleSignInService.signUpWithGoogle()
+
+    // Then
+    assertTrue(result is ClerkResult.Success)
+    val oauthResult = (result as ClerkResult.Success).value
+    assertEquals(mockSignIn, oauthResult.signIn)
+    assertEquals(null, oauthResult.signUp)
+    assertEquals(ResultType.SIGN_IN, oauthResult.resultType)
+    coVerify(exactly = 1) { SignIn.create(any<SignIn.CreateParams.Strategy.Transfer>()) }
+  }
+
+  private fun testSignUp(verifications: Map<String, Verification?> = emptyMap()): SignUp {
+    return SignUp(
+      id = "sign_up_123",
+      requiredFields = emptyList(),
+      optionalFields = emptyList(),
+      missingFields = emptyList(),
+      unverifiedFields = emptyList(),
+      verifications = verifications,
+      passwordEnabled = false,
+    )
   }
 }

--- a/source/api/src/test/java/com/clerk/api/sso/SSOServiceAuthenticateWithRedirectTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/SSOServiceAuthenticateWithRedirectTest.kt
@@ -1,0 +1,86 @@
+package com.clerk.api.sso
+
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.api.SignInApi
+import com.clerk.api.network.model.verification.Verification
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SSOServiceAuthenticateWithRedirectTest {
+
+  @After
+  fun tearDown() {
+    SSOService.cancelPendingAuthentication()
+    unmockkAll()
+  }
+
+  @Test
+  fun `authenticateWithRedirect creates sign in then prepares OAuth first factor`() = runTest {
+    mockkObject(ClerkApi)
+    mockkObject(SSOService)
+    val signInApi = mockk<SignInApi>()
+    val redirectUrl = "clerk://example.callback"
+    val externalVerificationRedirectUrl = "https://oauth.example.com/start"
+    val createdSignIn = SignIn(id = "sign_in_123")
+    val preparedSignIn =
+      SignIn(
+        id = createdSignIn.id,
+        firstFactorVerification =
+          Verification(externalVerificationRedirectUrl = externalVerificationRedirectUrl),
+      )
+    val oauthResult = OAuthResult(signIn = preparedSignIn)
+    val createParams = slot<Map<String, String>>()
+    val prepareParams = slot<Map<String, String>>()
+
+    every { ClerkApi.signIn } returns signInApi
+    coEvery { signInApi.createSignIn(capture(createParams)) } returns
+      ClerkResult.success(createdSignIn)
+    coEvery { signInApi.prepareSignInFirstFactor(createdSignIn.id, capture(prepareParams)) } returns
+      ClerkResult.success(preparedSignIn)
+    coEvery {
+      SSOService.authenticateWithRedirect(any(), any(), any(), any(), any(), any())
+    } coAnswers { callOriginal() }
+    coEvery {
+      SSOService.authenticateWithPreparedRedirect(
+        externalVerificationRedirectUrl = externalVerificationRedirectUrl,
+        transferable = true,
+      )
+    } returns ClerkResult.success(oauthResult)
+
+    val result =
+      SSOService.authenticateWithRedirect(
+        strategy = "oauth_google",
+        redirectUrl = redirectUrl,
+        transferable = true,
+      )
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(oauthResult, (result as ClerkResult.Success).value)
+    assertEquals("oauth_google", createParams.captured["strategy"])
+    assertEquals(redirectUrl, createParams.captured["redirect_url"])
+    assertTrue(createParams.captured.containsKey("locale"))
+    assertEquals("oauth_google", prepareParams.captured["strategy"])
+    assertEquals(redirectUrl, prepareParams.captured["redirect_url"])
+    coVerify(exactly = 1) { signInApi.createSignIn(any()) }
+    coVerify(exactly = 1) { signInApi.prepareSignInFirstFactor(createdSignIn.id, any()) }
+    coVerify(exactly = 1) {
+      SSOService.authenticateWithPreparedRedirect(
+        externalVerificationRedirectUrl = externalVerificationRedirectUrl,
+        transferable = true,
+      )
+    }
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -47,11 +47,13 @@ fun AuthStartView(
   modifier: Modifier = Modifier,
   clerkTheme: ClerkTheme? = null,
   preferGoogleOneTap: Boolean = true,
+  startSocialOAuthAsSignUp: Boolean = false,
   onAuthComplete: () -> Unit,
 ) {
   AuthStartViewImpl(
     modifier = modifier,
     preferGoogleOneTap = preferGoogleOneTap,
+    startSocialOAuthAsSignUp = startSocialOAuthAsSignUp,
     onAuthComplete = onAuthComplete,
     clerkTheme = clerkTheme,
   )
@@ -65,6 +67,7 @@ internal fun AuthStartViewImpl(
   authViewHelper: AuthStartViewHelper = AuthStartViewHelper(),
   clerkTheme: ClerkTheme? = null,
   preferGoogleOneTap: Boolean = true,
+  startSocialOAuthAsSignUp: Boolean = false,
   authStartViewModel: AuthStartViewModel = viewModel(),
 ) {
   val authState = LocalAuthState.current
@@ -212,6 +215,7 @@ internal fun AuthStartViewImpl(
                     provider = it,
                     transferable = authState.mode.transferable,
                     preferGoogleOneTap = preferGoogleOneTap,
+                    startOAuthWithSignUp = startSocialOAuthAsSignUp,
                   )
                 },
                 forceIconOnly = false,
@@ -227,6 +231,7 @@ internal fun AuthStartViewImpl(
                   provider = it,
                   transferable = authState.mode.transferable,
                   preferGoogleOneTap = preferGoogleOneTap,
+                  startOAuthWithSignUp = startSocialOAuthAsSignUp,
                 )
               },
             )

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -46,9 +46,15 @@ import kotlinx.collections.immutable.toImmutableList
 fun AuthStartView(
   modifier: Modifier = Modifier,
   clerkTheme: ClerkTheme? = null,
+  preferGoogleOneTap: Boolean = true,
   onAuthComplete: () -> Unit,
 ) {
-  AuthStartViewImpl(modifier = modifier, onAuthComplete = onAuthComplete, clerkTheme = clerkTheme)
+  AuthStartViewImpl(
+    modifier = modifier,
+    preferGoogleOneTap = preferGoogleOneTap,
+    onAuthComplete = onAuthComplete,
+    clerkTheme = clerkTheme,
+  )
 }
 
 @Composable
@@ -58,6 +64,7 @@ internal fun AuthStartViewImpl(
   modifier: Modifier = Modifier,
   authViewHelper: AuthStartViewHelper = AuthStartViewHelper(),
   clerkTheme: ClerkTheme? = null,
+  preferGoogleOneTap: Boolean = true,
   authStartViewModel: AuthStartViewModel = viewModel(),
 ) {
   val authState = LocalAuthState.current
@@ -201,7 +208,11 @@ internal fun AuthStartViewImpl(
                 provider = lastUsedSocialProvider,
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {
-                  authStartViewModel.authenticateWithSocialProvider(it, authState.mode.transferable)
+                  authStartViewModel.authenticateWithSocialProvider(
+                    provider = it,
+                    transferable = authState.mode.transferable,
+                    preferGoogleOneTap = preferGoogleOneTap,
+                  )
                 },
                 forceIconOnly = false,
               )
@@ -212,7 +223,11 @@ internal fun AuthStartViewImpl(
             ClerkSocialRow(
               providers = socialProvidersMinusLastUsed.toImmutableList(),
               onClick = {
-                authStartViewModel.authenticateWithSocialProvider(it, authState.mode.transferable)
+                authStartViewModel.authenticateWithSocialProvider(
+                  provider = it,
+                  transferable = authState.mode.transferable,
+                  preferGoogleOneTap = preferGoogleOneTap,
+                )
               },
             )
           }

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -153,17 +153,19 @@ internal class AuthStartViewModel : ViewModel() {
    * @param provider The [OAuthProvider] to authenticate with (e.g., Google, Facebook).
    * @param transferable Whether the flow can transfer between sign-in and sign-up.
    * @param preferGoogleOneTap Whether Google should prefer native One Tap over browser OAuth.
+   * @param startOAuthWithSignUp Whether browser OAuth should create a sign-up attempt first.
    */
   internal fun authenticateWithSocialProvider(
     provider: OAuthProvider,
     transferable: Boolean = true,
     preferGoogleOneTap: Boolean = true,
+    startOAuthWithSignUp: Boolean = false,
   ) {
     _state.value = AuthState.OAuthState.Loading
     if (preferGoogleOneTap && provider == OAuthProvider.GOOGLE && Clerk.isGoogleOneTapEnabled) {
       handleGoogleOneTap(transferable)
     } else {
-      authenticateWithOAuthProvider(provider, transferable)
+      authenticateWithOAuthProvider(provider, transferable, startOAuthWithSignUp)
     }
   }
 
@@ -200,12 +202,25 @@ internal class AuthStartViewModel : ViewModel() {
     }
   }
 
-  private fun authenticateWithOAuthProvider(provider: OAuthProvider, transferable: Boolean) {
+  private fun authenticateWithOAuthProvider(
+    provider: OAuthProvider,
+    transferable: Boolean,
+    startOAuthWithSignUp: Boolean,
+  ) {
     viewModelScope.launch {
-      SignIn.authenticateWithRedirect(
-          SignIn.AuthenticateWithRedirectParams.OAuth(provider = provider),
-          transferable = transferable,
-        )
+      val result =
+        if (startOAuthWithSignUp) {
+          SignUp.authenticateWithRedirect(
+            SignUp.AuthenticateWithRedirectParams.OAuth(provider = provider)
+          )
+        } else {
+          SignIn.authenticateWithRedirect(
+            SignIn.AuthenticateWithRedirectParams.OAuth(provider = provider),
+            transferable = transferable,
+          )
+        }
+
+      result
         .onSuccess {
           _state.value =
             when (it.resultType) {

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -146,18 +146,21 @@ internal class AuthStartViewModel : ViewModel() {
   /**
    * Initiates authentication using a specified social (OAuth) provider.
    *
-   * If Google One Tap is enabled and the provider is Google, it attempts Google One Tap
-   * authentication. Otherwise, it proceeds with the standard OAuth redirect flow for the given
-   * provider.
+   * If [preferGoogleOneTap] is true, Google One Tap is enabled, and the provider is Google, it
+   * attempts Google One Tap authentication. Otherwise, it proceeds with the standard OAuth redirect
+   * flow for the given provider.
    *
    * @param provider The [OAuthProvider] to authenticate with (e.g., Google, Facebook).
+   * @param transferable Whether the flow can transfer between sign-in and sign-up.
+   * @param preferGoogleOneTap Whether Google should prefer native One Tap over browser OAuth.
    */
   internal fun authenticateWithSocialProvider(
     provider: OAuthProvider,
     transferable: Boolean = true,
+    preferGoogleOneTap: Boolean = true,
   ) {
     _state.value = AuthState.OAuthState.Loading
-    if (provider == OAuthProvider.GOOGLE && Clerk.isGoogleOneTapEnabled) {
+    if (preferGoogleOneTap && provider == OAuthProvider.GOOGLE && Clerk.isGoogleOneTapEnabled) {
       handleGoogleOneTap(transferable)
     } else {
       authenticateWithOAuthProvider(provider, transferable)

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -54,6 +54,8 @@ import kotlinx.serialization.Serializable
  *   routed to the phone number field automatically.
  * @param persistIdentifiers When `false`, stored auth-start identifiers are cleared and future
  *   edits are kept in memory only for the lifetime of the current view.
+ * @param preferGoogleOneTap When `true`, Google social auth uses native Google One Tap if
+ *   configured. When `false`, Google social auth always uses browser OAuth.
  */
 @Composable
 fun AuthView(
@@ -61,6 +63,7 @@ fun AuthView(
   clerkTheme: ClerkTheme? = null,
   initialIdentifier: String? = null,
   persistIdentifiers: Boolean = true,
+  preferGoogleOneTap: Boolean = true,
   onAuthComplete: () -> Unit = {},
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
@@ -79,6 +82,7 @@ fun AuthView(
       AuthNavDisplay(
         modifier = fullScreenModifier,
         backStack = backStack,
+        preferGoogleOneTap = preferGoogleOneTap,
         onAuthComplete = onAuthComplete,
       )
     }
@@ -108,6 +112,7 @@ private fun ObservePendingSessionTaskRouting(backStack: NavBackStack<NavKey>) {
 private fun AuthNavDisplay(
   backStack: NavBackStack<NavKey>,
   modifier: Modifier = Modifier,
+  preferGoogleOneTap: Boolean,
   onAuthComplete: () -> Unit,
 ) {
   NavDisplay(
@@ -132,76 +137,86 @@ private fun AuthNavDisplay(
         backStack.removeLastOrNull()
       }
     },
-    entryProvider = authEntryProvider(backStack = backStack, onAuthComplete = onAuthComplete),
+    entryProvider =
+      authEntryProvider(
+        backStack = backStack,
+        preferGoogleOneTap = preferGoogleOneTap,
+        onAuthComplete = onAuthComplete,
+      ),
   )
 }
 
 @Suppress("LongMethod")
-private fun authEntryProvider(backStack: NavBackStack<NavKey>, onAuthComplete: () -> Unit) =
-  entryProvider {
-    entry<AuthDestination.AuthStart> { AuthStartView(onAuthComplete = onAuthComplete) }
-    entry<AuthDestination.SignInFactorOne> {
-      SignInFactorOneView(factor = it.factor, onAuthComplete = onAuthComplete)
-    }
-    entry<AuthDestination.SignInFactorOneUseAnotherMethod> {
-      SignInFactorAlternativeMethodsView(
-        currentFactor = it.currentFactor,
-        onAuthComplete = onAuthComplete,
-      )
-    }
-    entry<AuthDestination.SignInFactorTwo> {
-      SignInFactorTwoView(factor = it.factor, onAuthComplete = onAuthComplete)
-    }
-    entry<AuthDestination.SessionTaskMfa> { SessionTaskMfaView(onAuthComplete = onAuthComplete) }
-    entry<AuthDestination.SessionTaskResetPassword> {
-      SessionTaskResetPasswordView(onAuthComplete = onAuthComplete)
-    }
-    entry<AuthDestination.SessionTaskChooseOrganization> {
-      val authState = LocalAuthState.current
-      SessionTaskChooseOrganizationView(
-        onAuthComplete = onAuthComplete,
-        onCreateOrganization = {
-          authState.navigateTo(AuthDestination.SessionTaskCreateOrganization(it))
-        },
-      )
-    }
-    entry<AuthDestination.SessionTaskCreateOrganization> {
-      SessionTaskCreateOrganizationView(
-        creationDefaults = it.creationDefaults,
-        showBackButton = true,
-        onAuthComplete = onAuthComplete,
-      )
-    }
-    entry<AuthDestination.SignInFactorTwoUseAnotherMethod> {
-      SignInFactorAlternativeMethodsView(
-        currentFactor = it.currentFactor,
-        isSecondFactor = true,
-        onAuthComplete = onAuthComplete,
-      )
-    }
-    entry<AuthDestination.SignInForgotPassword> {
-      SignInFactorOneForgotPasswordView(
-        onClickFactor = { backStack.removeLastOrNull() },
-        onAuthComplete = onAuthComplete,
-      )
-    }
-    entry<AuthDestination.SignInSetNewPassword> {
-      SignInSetNewPasswordView(onAuthComplete = onAuthComplete)
-    }
-    entry<AuthDestination.SignInGetHelp> { SignInGetHelpView() }
-    entry<AuthDestination.SignInClientTrust> {
-      SignInClientTrustView(factor = it.factor, onAuthComplete = onAuthComplete)
-    }
-    entry<AuthDestination.SignUpCollectField> {
-      SignUpCollectFieldView(field = it.field, onAuthComplete = onAuthComplete)
-    }
-    entry<AuthDestination.SignUpCode> {
-      SignUpCodeView(field = it.field, onAuthComplete = onAuthComplete)
-    }
-    entry<AuthDestination.SignUpCompleteProfile> {
-      SignUpCompleteProfileView(onAuthComplete = onAuthComplete)
-    }
+private fun authEntryProvider(
+  backStack: NavBackStack<NavKey>,
+  preferGoogleOneTap: Boolean,
+  onAuthComplete: () -> Unit,
+) = entryProvider {
+  entry<AuthDestination.AuthStart> {
+    AuthStartView(preferGoogleOneTap = preferGoogleOneTap, onAuthComplete = onAuthComplete)
   }
+  entry<AuthDestination.SignInFactorOne> {
+    SignInFactorOneView(factor = it.factor, onAuthComplete = onAuthComplete)
+  }
+  entry<AuthDestination.SignInFactorOneUseAnotherMethod> {
+    SignInFactorAlternativeMethodsView(
+      currentFactor = it.currentFactor,
+      onAuthComplete = onAuthComplete,
+    )
+  }
+  entry<AuthDestination.SignInFactorTwo> {
+    SignInFactorTwoView(factor = it.factor, onAuthComplete = onAuthComplete)
+  }
+  entry<AuthDestination.SessionTaskMfa> { SessionTaskMfaView(onAuthComplete = onAuthComplete) }
+  entry<AuthDestination.SessionTaskResetPassword> {
+    SessionTaskResetPasswordView(onAuthComplete = onAuthComplete)
+  }
+  entry<AuthDestination.SessionTaskChooseOrganization> {
+    val authState = LocalAuthState.current
+    SessionTaskChooseOrganizationView(
+      onAuthComplete = onAuthComplete,
+      onCreateOrganization = {
+        authState.navigateTo(AuthDestination.SessionTaskCreateOrganization(it))
+      },
+    )
+  }
+  entry<AuthDestination.SessionTaskCreateOrganization> {
+    SessionTaskCreateOrganizationView(
+      creationDefaults = it.creationDefaults,
+      showBackButton = true,
+      onAuthComplete = onAuthComplete,
+    )
+  }
+  entry<AuthDestination.SignInFactorTwoUseAnotherMethod> {
+    SignInFactorAlternativeMethodsView(
+      currentFactor = it.currentFactor,
+      isSecondFactor = true,
+      onAuthComplete = onAuthComplete,
+    )
+  }
+  entry<AuthDestination.SignInForgotPassword> {
+    SignInFactorOneForgotPasswordView(
+      onClickFactor = { backStack.removeLastOrNull() },
+      onAuthComplete = onAuthComplete,
+    )
+  }
+  entry<AuthDestination.SignInSetNewPassword> {
+    SignInSetNewPasswordView(onAuthComplete = onAuthComplete)
+  }
+  entry<AuthDestination.SignInGetHelp> { SignInGetHelpView() }
+  entry<AuthDestination.SignInClientTrust> {
+    SignInClientTrustView(factor = it.factor, onAuthComplete = onAuthComplete)
+  }
+  entry<AuthDestination.SignUpCollectField> {
+    SignUpCollectFieldView(field = it.field, onAuthComplete = onAuthComplete)
+  }
+  entry<AuthDestination.SignUpCode> {
+    SignUpCodeView(field = it.field, onAuthComplete = onAuthComplete)
+  }
+  entry<AuthDestination.SignUpCompleteProfile> {
+    SignUpCompleteProfileView(onAuthComplete = onAuthComplete)
+  }
+}
 
 internal fun shouldRouteToSessionTaskMfa(requiresForcedMfa: Boolean, top: NavKey?): Boolean {
   return requiresForcedMfa && top != AuthDestination.SessionTaskMfa

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -56,6 +56,8 @@ import kotlinx.serialization.Serializable
  *   edits are kept in memory only for the lifetime of the current view.
  * @param preferGoogleOneTap When `true`, Google social auth uses native Google One Tap if
  *   configured. When `false`, Google social auth always uses browser OAuth.
+ * @param startSocialOAuthAsSignUp When `true`, browser OAuth social auth starts from a sign-up
+ *   attempt and transfers back to sign-in if the selected account already exists.
  */
 @Composable
 fun AuthView(
@@ -64,6 +66,7 @@ fun AuthView(
   initialIdentifier: String? = null,
   persistIdentifiers: Boolean = true,
   preferGoogleOneTap: Boolean = true,
+  startSocialOAuthAsSignUp: Boolean = false,
   onAuthComplete: () -> Unit = {},
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
@@ -83,6 +86,7 @@ fun AuthView(
         modifier = fullScreenModifier,
         backStack = backStack,
         preferGoogleOneTap = preferGoogleOneTap,
+        startSocialOAuthAsSignUp = startSocialOAuthAsSignUp,
         onAuthComplete = onAuthComplete,
       )
     }
@@ -113,6 +117,7 @@ private fun AuthNavDisplay(
   backStack: NavBackStack<NavKey>,
   modifier: Modifier = Modifier,
   preferGoogleOneTap: Boolean,
+  startSocialOAuthAsSignUp: Boolean,
   onAuthComplete: () -> Unit,
 ) {
   NavDisplay(
@@ -141,6 +146,7 @@ private fun AuthNavDisplay(
       authEntryProvider(
         backStack = backStack,
         preferGoogleOneTap = preferGoogleOneTap,
+        startSocialOAuthAsSignUp = startSocialOAuthAsSignUp,
         onAuthComplete = onAuthComplete,
       ),
   )
@@ -150,10 +156,15 @@ private fun AuthNavDisplay(
 private fun authEntryProvider(
   backStack: NavBackStack<NavKey>,
   preferGoogleOneTap: Boolean,
+  startSocialOAuthAsSignUp: Boolean,
   onAuthComplete: () -> Unit,
 ) = entryProvider {
   entry<AuthDestination.AuthStart> {
-    AuthStartView(preferGoogleOneTap = preferGoogleOneTap, onAuthComplete = onAuthComplete)
+    AuthStartView(
+      preferGoogleOneTap = preferGoogleOneTap,
+      startSocialOAuthAsSignUp = startSocialOAuthAsSignUp,
+      onAuthComplete = onAuthComplete,
+    )
   }
   entry<AuthDestination.SignInFactorOne> {
     SignInFactorOneView(factor = it.factor, onAuthComplete = onAuthComplete)

--- a/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedAuthScaffold.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedAuthScaffold.kt
@@ -253,7 +253,7 @@ private fun AuthSignedInAccountSheet(
       HorizontalDivider(color = ClerkMaterialTheme.computedColors.border)
       SignOutActionRow {
         scope.launch {
-          Clerk.auth.signOut()
+          Clerk.auth.signOut(sessionId = Clerk.session?.id)
           sheetState.hide()
           onDismissRequest()
         }

--- a/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedAuthScaffold.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedAuthScaffold.kt
@@ -252,8 +252,9 @@ private fun AuthSignedInAccountSheet(
       Spacers.Vertical.Spacer12()
       HorizontalDivider(color = ClerkMaterialTheme.computedColors.border)
       SignOutActionRow {
+        val sessionId = Clerk.session?.id ?: return@SignOutActionRow
         scope.launch {
-          Clerk.auth.signOut(sessionId = Clerk.session?.id)
+          Clerk.auth.signOut(sessionId = sessionId)
           sheetState.hide()
           onDismissRequest()
         }

--- a/source/ui/src/main/java/com/clerk/ui/userbutton/UserButton.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userbutton/UserButton.kt
@@ -31,7 +31,6 @@ import coil3.request.crossfade
 import com.clerk.api.Clerk
 import com.clerk.api.session.requiresForcedMfa
 import com.clerk.api.ui.ClerkTheme
-import com.clerk.api.user.User
 import com.clerk.telemetry.TelemetryEvents
 import com.clerk.ui.R
 import com.clerk.ui.auth.AuthView
@@ -76,17 +75,19 @@ fun UserButton(
       val sessionUser by Clerk.userFlow.collectAsStateWithLifecycle()
       val requiresForcedMfa = session?.requiresForcedMfa == true
       val user = if (treatPendingAsSignedOut) Clerk.activeUser else sessionUser
+      val telemetry = LocalTelemetryCollector.current
       var showProfile by rememberSaveable { mutableStateOf(false) }
-      var showAuth by rememberSaveable { mutableStateOf(false) }
-      var preferGoogleOneTapForAuth by rememberSaveable { mutableStateOf(true) }
+      var authMode by rememberSaveable { mutableStateOf<UserButtonAuthMode?>(null) }
       val shouldRenderButton =
         shouldShowUserButton(sessionUser != null, Clerk.activeUser != null, treatPendingAsSignedOut)
 
-      TrackUserButtonLoaded(user = user)
+      LaunchedEffect(user?.id) {
+        if (user != null) telemetry.record(TelemetryEvents.viewDidAppear("UserButton"))
+      }
       DismissAuthWhenMfaResolved(
         requiresForcedMfa = requiresForcedMfa,
-        showAuth = showAuth,
-        onDismissAuth = { showAuth = false },
+        authMode = authMode,
+        onDismissAuth = { authMode = null },
       )
 
       if (shouldRenderButton && user != null) {
@@ -97,10 +98,7 @@ fun UserButton(
               UserButtonClickAction.OPEN_PROFILE -> showProfile = true
               UserButtonClickAction.ROUTE_TO_AUTH -> {
                 onRequiresForcedMfaClick?.invoke()
-                  ?: run {
-                    preferGoogleOneTapForAuth = true
-                    showAuth = true
-                  }
+                  ?: run { authMode = UserButtonAuthMode.ForcedMfa }
               }
             }
           },
@@ -113,15 +111,10 @@ fun UserButton(
         onDismissProfile = { showProfile = false },
         onAddAccount = {
           showProfile = false
-          preferGoogleOneTapForAuth = false
-          showAuth = true
+          authMode = UserButtonAuthMode.AddAccount
         },
       )
-      AuthDialogHost(
-        showAuth = showAuth,
-        preferGoogleOneTapForAuth = preferGoogleOneTapForAuth,
-        onDismissAuth = { showAuth = false },
-      )
+      AuthDialogHost(authMode = authMode, onDismissAuth = { authMode = null })
     }
   }
 }
@@ -155,21 +148,13 @@ private fun UserButtonContent(imageUrl: String?, onClick: () -> Unit) {
 }
 
 @Composable
-private fun TrackUserButtonLoaded(user: User?) {
-  val telemetry = LocalTelemetryCollector.current
-  LaunchedEffect(user?.id) {
-    if (user != null) telemetry.record(TelemetryEvents.viewDidAppear("UserButton"))
-  }
-}
-
-@Composable
 private fun DismissAuthWhenMfaResolved(
   requiresForcedMfa: Boolean,
-  showAuth: Boolean,
+  authMode: UserButtonAuthMode?,
   onDismissAuth: () -> Unit,
 ) {
-  LaunchedEffect(requiresForcedMfa, showAuth) {
-    if (!requiresForcedMfa && showAuth) {
+  LaunchedEffect(requiresForcedMfa, authMode) {
+    if (shouldDismissAuthWhenMfaResolved(authMode, requiresForcedMfa)) {
       onDismissAuth()
     }
   }
@@ -194,13 +179,9 @@ private fun UserProfileDialogHost(
 }
 
 @Composable
-private fun AuthDialogHost(
-  showAuth: Boolean,
-  preferGoogleOneTapForAuth: Boolean,
-  onDismissAuth: () -> Unit,
-) {
-  if (showAuth) {
-    AuthDialog(preferGoogleOneTap = preferGoogleOneTapForAuth, onDismiss = onDismissAuth)
+private fun AuthDialogHost(authMode: UserButtonAuthMode?, onDismissAuth: () -> Unit) {
+  if (authMode != null) {
+    AuthDialog(preferGoogleOneTap = authMode.preferGoogleOneTap, onDismiss = onDismissAuth)
   }
 }
 
@@ -241,6 +222,18 @@ private fun AuthDialog(preferGoogleOneTap: Boolean, onDismiss: () -> Unit) {
 internal enum class UserButtonClickAction {
   OPEN_PROFILE,
   ROUTE_TO_AUTH,
+}
+
+internal enum class UserButtonAuthMode(val preferGoogleOneTap: Boolean) {
+  AddAccount(preferGoogleOneTap = false),
+  ForcedMfa(preferGoogleOneTap = true),
+}
+
+internal fun shouldDismissAuthWhenMfaResolved(
+  authMode: UserButtonAuthMode?,
+  requiresForcedMfa: Boolean,
+): Boolean {
+  return authMode == UserButtonAuthMode.ForcedMfa && !requiresForcedMfa
 }
 
 internal fun userButtonClickAction(

--- a/source/ui/src/main/java/com/clerk/ui/userbutton/UserButton.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userbutton/UserButton.kt
@@ -181,7 +181,11 @@ private fun UserProfileDialogHost(
 @Composable
 private fun AuthDialogHost(authMode: UserButtonAuthMode?, onDismissAuth: () -> Unit) {
   if (authMode != null) {
-    AuthDialog(preferGoogleOneTap = authMode.preferGoogleOneTap, onDismiss = onDismissAuth)
+    AuthDialog(
+      preferGoogleOneTap = authMode.preferGoogleOneTap,
+      startSocialOAuthAsSignUp = authMode.startSocialOAuthAsSignUp,
+      onDismiss = onDismissAuth,
+    )
   }
 }
 
@@ -206,7 +210,11 @@ private fun UserProfileDialog(
 }
 
 @Composable
-private fun AuthDialog(preferGoogleOneTap: Boolean, onDismiss: () -> Unit) {
+private fun AuthDialog(
+  preferGoogleOneTap: Boolean,
+  startSocialOAuthAsSignUp: Boolean,
+  onDismiss: () -> Unit,
+) {
   Dialog(
     onDismissRequest = onDismiss,
     properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
@@ -214,6 +222,7 @@ private fun AuthDialog(preferGoogleOneTap: Boolean, onDismiss: () -> Unit) {
     AuthView(
       modifier = Modifier.fillMaxSize(),
       preferGoogleOneTap = preferGoogleOneTap,
+      startSocialOAuthAsSignUp = startSocialOAuthAsSignUp,
       onAuthComplete = onDismiss,
     )
   }
@@ -224,9 +233,12 @@ internal enum class UserButtonClickAction {
   ROUTE_TO_AUTH,
 }
 
-internal enum class UserButtonAuthMode(val preferGoogleOneTap: Boolean) {
-  AddAccount(preferGoogleOneTap = false),
-  ForcedMfa(preferGoogleOneTap = true),
+internal enum class UserButtonAuthMode(
+  val preferGoogleOneTap: Boolean,
+  val startSocialOAuthAsSignUp: Boolean,
+) {
+  AddAccount(preferGoogleOneTap = false, startSocialOAuthAsSignUp = true),
+  ForcedMfa(preferGoogleOneTap = true, startSocialOAuthAsSignUp = false),
 }
 
 internal fun shouldDismissAuthWhenMfaResolved(

--- a/source/ui/src/main/java/com/clerk/ui/userbutton/UserButton.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userbutton/UserButton.kt
@@ -237,7 +237,7 @@ internal enum class UserButtonAuthMode(
   val preferGoogleOneTap: Boolean,
   val startSocialOAuthAsSignUp: Boolean,
 ) {
-  AddAccount(preferGoogleOneTap = false, startSocialOAuthAsSignUp = true),
+  AddAccount(preferGoogleOneTap = false, startSocialOAuthAsSignUp = false),
   ForcedMfa(preferGoogleOneTap = true, startSocialOAuthAsSignUp = false),
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/userbutton/UserButton.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userbutton/UserButton.kt
@@ -31,6 +31,7 @@ import coil3.request.crossfade
 import com.clerk.api.Clerk
 import com.clerk.api.session.requiresForcedMfa
 import com.clerk.api.ui.ClerkTheme
+import com.clerk.api.user.User
 import com.clerk.telemetry.TelemetryEvents
 import com.clerk.ui.R
 import com.clerk.ui.auth.AuthView
@@ -53,9 +54,9 @@ import com.clerk.ui.userprofile.custom.UserProfileCustomRow
  * @param routeToAuthWhenForcedMfa When `true` (default), clicking the button while the current
  *   session has unresolved MFA setup tasks routes to auth instead of opening profile.
  * @param customRows Custom rows to display on the profile account screen.
- * @param customDestination Composable that renders the destination for a given route key. The
- *   route key matches [UserProfileCustomRow.routeKey] of the tapped row. Custom destinations
- *   survive activity recreation (e.g. rotation).
+ * @param customDestination Composable that renders the destination for a given route key. The route
+ *   key matches [UserProfileCustomRow.routeKey] of the tapped row. Custom destinations survive
+ *   activity recreation (e.g. rotation).
  * @param onRequiresForcedMfaClick Optional callback used when the current session has outstanding
  *   MFA setup tasks. If not provided, the button will open [AuthView] in a full-screen dialog.
  */
@@ -75,54 +76,52 @@ fun UserButton(
       val sessionUser by Clerk.userFlow.collectAsStateWithLifecycle()
       val requiresForcedMfa = session?.requiresForcedMfa == true
       val user = if (treatPendingAsSignedOut) Clerk.activeUser else sessionUser
-      val telemetry = LocalTelemetryCollector.current
       var showProfile by rememberSaveable { mutableStateOf(false) }
       var showAuth by rememberSaveable { mutableStateOf(false) }
+      var preferGoogleOneTapForAuth by rememberSaveable { mutableStateOf(true) }
+      val shouldRenderButton =
+        shouldShowUserButton(sessionUser != null, Clerk.activeUser != null, treatPendingAsSignedOut)
 
-      LaunchedEffect(user?.id) {
-        if (user != null) telemetry.record(TelemetryEvents.viewDidAppear("UserButton"))
-      }
+      TrackUserButtonLoaded(user = user)
+      DismissAuthWhenMfaResolved(
+        requiresForcedMfa = requiresForcedMfa,
+        showAuth = showAuth,
+        onDismissAuth = { showAuth = false },
+      )
 
-      LaunchedEffect(requiresForcedMfa, showAuth) {
-        if (!requiresForcedMfa && showAuth) {
-          showAuth = false
-        }
-      }
-
-      if (
-        shouldShowUserButton(
-          sessionUser != null,
-          Clerk.activeUser != null,
-          treatPendingAsSignedOut,
-        ) && user != null
-      ) {
+      if (shouldRenderButton && user != null) {
         UserButtonContent(
           imageUrl = user.imageUrl,
           onClick = {
-            when (
-              userButtonClickAction(
-                requiresForcedMfa = requiresForcedMfa,
-                routeToAuthWhenForcedMfa = routeToAuthWhenForcedMfa,
-              )
-            ) {
+            when (userButtonClickAction(requiresForcedMfa, routeToAuthWhenForcedMfa)) {
               UserButtonClickAction.OPEN_PROFILE -> showProfile = true
               UserButtonClickAction.ROUTE_TO_AUTH -> {
-                onRequiresForcedMfaClick?.invoke() ?: run { showAuth = true }
+                onRequiresForcedMfaClick?.invoke()
+                  ?: run {
+                    preferGoogleOneTapForAuth = true
+                    showAuth = true
+                  }
               }
             }
           },
         )
-        if (showProfile) {
-          UserProfileDialog(
-            onDismiss = { showProfile = false },
-            customRows = customRows,
-            customDestination = customDestination,
-          )
-        }
-        if (showAuth) {
-          AuthDialog(onDismiss = { showAuth = false })
-        }
       }
+      UserProfileDialogHost(
+        showProfile = showProfile,
+        customRows = customRows,
+        customDestination = customDestination,
+        onDismissProfile = { showProfile = false },
+        onAddAccount = {
+          showProfile = false
+          preferGoogleOneTapForAuth = false
+          showAuth = true
+        },
+      )
+      AuthDialogHost(
+        showAuth = showAuth,
+        preferGoogleOneTapForAuth = preferGoogleOneTapForAuth,
+        onDismissAuth = { showAuth = false },
+      )
     }
   }
 }
@@ -156,8 +155,59 @@ private fun UserButtonContent(imageUrl: String?, onClick: () -> Unit) {
 }
 
 @Composable
+private fun TrackUserButtonLoaded(user: User?) {
+  val telemetry = LocalTelemetryCollector.current
+  LaunchedEffect(user?.id) {
+    if (user != null) telemetry.record(TelemetryEvents.viewDidAppear("UserButton"))
+  }
+}
+
+@Composable
+private fun DismissAuthWhenMfaResolved(
+  requiresForcedMfa: Boolean,
+  showAuth: Boolean,
+  onDismissAuth: () -> Unit,
+) {
+  LaunchedEffect(requiresForcedMfa, showAuth) {
+    if (!requiresForcedMfa && showAuth) {
+      onDismissAuth()
+    }
+  }
+}
+
+@Composable
+private fun UserProfileDialogHost(
+  showProfile: Boolean,
+  customRows: List<UserProfileCustomRow>,
+  customDestination: (@Composable (String) -> Unit)?,
+  onDismissProfile: () -> Unit,
+  onAddAccount: () -> Unit,
+) {
+  if (showProfile) {
+    UserProfileDialog(
+      onDismiss = onDismissProfile,
+      onAddAccount = onAddAccount,
+      customRows = customRows,
+      customDestination = customDestination,
+    )
+  }
+}
+
+@Composable
+private fun AuthDialogHost(
+  showAuth: Boolean,
+  preferGoogleOneTapForAuth: Boolean,
+  onDismissAuth: () -> Unit,
+) {
+  if (showAuth) {
+    AuthDialog(preferGoogleOneTap = preferGoogleOneTapForAuth, onDismiss = onDismissAuth)
+  }
+}
+
+@Composable
 private fun UserProfileDialog(
   onDismiss: () -> Unit,
+  onAddAccount: () -> Unit,
   customRows: List<UserProfileCustomRow> = emptyList(),
   customDestination: (@Composable (String) -> Unit)? = null,
 ) {
@@ -167,6 +217,7 @@ private fun UserProfileDialog(
   ) {
     UserProfileView(
       onDismiss = onDismiss,
+      onAddAccount = onAddAccount,
       customRows = customRows,
       customDestination = customDestination,
     )
@@ -174,12 +225,16 @@ private fun UserProfileDialog(
 }
 
 @Composable
-private fun AuthDialog(onDismiss: () -> Unit) {
+private fun AuthDialog(preferGoogleOneTap: Boolean, onDismiss: () -> Unit) {
   Dialog(
     onDismissRequest = onDismiss,
     properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
   ) {
-    AuthView(modifier = Modifier.fillMaxSize(), onAuthComplete = onDismiss)
+    AuthView(
+      modifier = Modifier.fillMaxSize(),
+      preferGoogleOneTap = preferGoogleOneTap,
+      onAuthComplete = onDismiss,
+    )
   }
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
@@ -78,6 +78,7 @@ internal fun UserProfileStateProvider(
  * @param customRows Custom rows to display on the profile account screen.
  * @param customDestination Composable that renders the destination for a given route key. The route
  *   key matches [UserProfileCustomRow.routeKey] of the tapped row.
+ * @param onAddAccount Optional callback for hosting the add-account auth flow outside the profile.
  * @param onDismiss Callback when the user profile view is dismissed.
  */
 @OptIn(ExperimentalAnimationApi::class)
@@ -88,6 +89,7 @@ fun UserProfileView(
   clerkTheme: ClerkTheme? = null,
   customRows: List<UserProfileCustomRow> = emptyList(),
   customDestination: (@Composable (String) -> Unit)? = null,
+  onAddAccount: (() -> Unit)? = null,
   onDismiss: () -> Unit = {},
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
@@ -99,7 +101,7 @@ fun UserProfileView(
       val telemetry = LocalTelemetryCollector.current
       val showAddAccountAuth = {
         showAccountSwitcher = false
-        showAuth = true
+        onAddAccount?.invoke() ?: run { showAuth = true }
       }
 
       LaunchedEffect(Unit) { telemetry.record(TelemetryEvents.viewDidAppear("UserProfileView")) }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
@@ -6,23 +6,35 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
+import com.clerk.api.Clerk
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.telemetry.TelemetryEvents
+import com.clerk.ui.auth.AuthView
 import com.clerk.ui.core.composition.LocalTelemetryCollector
 import com.clerk.ui.core.composition.TelemetryProvider
 import com.clerk.ui.theme.ClerkThemeOverrideProvider
+import com.clerk.ui.userprofile.account.UserProfileAccountSwitcherSheet
 import com.clerk.ui.userprofile.account.UserProfileAccountView
 import com.clerk.ui.userprofile.account.UserProfileAction
 import com.clerk.ui.userprofile.custom.CustomRouteNavKey
@@ -30,7 +42,6 @@ import com.clerk.ui.userprofile.custom.LocalUserProfileCustomNavigator
 import com.clerk.ui.userprofile.custom.UserProfileCustomNavigator
 import com.clerk.ui.userprofile.custom.UserProfileCustomRow
 import com.clerk.ui.userprofile.custom.effectiveCustomRows
-import kotlinx.collections.immutable.toImmutableList
 import com.clerk.ui.userprofile.detail.UserProfileDetailView
 import com.clerk.ui.userprofile.security.MfaType
 import com.clerk.ui.userprofile.security.Origin
@@ -39,6 +50,7 @@ import com.clerk.ui.userprofile.security.passkey.rename.UserProfilePasskeyRename
 import com.clerk.ui.userprofile.update.UserProfileUpdateProfileView
 import com.clerk.ui.userprofile.verify.Mode
 import com.clerk.ui.userprofile.verify.UserProfileVerifyView
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.serialization.Serializable
 
 @SuppressLint("ComposeCompositionLocalUsage")
@@ -66,11 +78,13 @@ internal fun UserProfileStateProvider(
  *
  * @param clerkTheme Optional theme customization for the user profile UI.
  * @param customRows Custom rows to display on the profile account screen.
- * @param customDestination Composable that renders the destination for a given route key. The
- *   route key matches [UserProfileCustomRow.routeKey] of the tapped row.
+ * @param customDestination Composable that renders the destination for a given route key. The route
+ *   key matches [UserProfileCustomRow.routeKey] of the tapped row.
  * @param onDismiss Callback when the user profile view is dismissed.
  */
 @OptIn(ExperimentalAnimationApi::class)
+@SuppressLint("ComposeUnstableReceiver")
+@Suppress("LongMethod")
 @Composable
 fun UserProfileView(
   clerkTheme: ClerkTheme? = null,
@@ -80,10 +94,18 @@ fun UserProfileView(
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
     val backStack = rememberNavBackStack(UserProfileDestination.UserProfileAccount)
+    val user by Clerk.userFlow.collectAsStateWithLifecycle()
+    var showAccountSwitcher by rememberSaveable { mutableStateOf(false) }
+    var showAuth by rememberSaveable { mutableStateOf(false) }
     UserProfileStateProvider(backStack) {
       val telemetry = LocalTelemetryCollector.current
 
       LaunchedEffect(Unit) { telemetry.record(TelemetryEvents.viewDidAppear("UserProfileView")) }
+      LaunchedEffect(user?.id) {
+        if (user == null) {
+          onDismiss()
+        }
+      }
 
       NavDisplay(
         backStack = backStack,
@@ -111,19 +133,39 @@ fun UserProfileView(
         },
         entryProvider =
           entryProvider {
-            UserProfileEntries(backStack, onDismiss, customRows, customDestination)
+            userProfileEntries(
+              backStack = backStack,
+              onDismiss = onDismiss,
+              customRows = customRows,
+              customDestination = customDestination,
+              onSwitchAccount = { showAccountSwitcher = true },
+              onAddAccount = { showAuth = true },
+            )
           },
       )
+
+      if (showAccountSwitcher) {
+        UserProfileAccountSwitcherSheet(
+          onDismissRequest = { showAccountSwitcher = false },
+          onAddAccount = { showAuth = true },
+        )
+      }
+
+      if (showAuth) {
+        AuthDialog(onDismiss = { showAuth = false })
+      }
     }
   }
 }
 
-@Composable
-private fun EntryProviderScope<NavKey>.UserProfileEntries(
+@Suppress("LongMethod", "LongParameterList")
+private fun EntryProviderScope<NavKey>.userProfileEntries(
   backStack: NavBackStack<NavKey>,
   onDismiss: () -> Unit,
   customRows: List<UserProfileCustomRow>,
   customDestination: (@Composable (String) -> Unit)?,
+  onSwitchAccount: () -> Unit,
+  onAddAccount: () -> Unit,
 ) {
   entry<UserProfileDestination.UserProfileAccount> {
     UserProfileAccountView(
@@ -132,6 +174,12 @@ private fun EntryProviderScope<NavKey>.UserProfileEntries(
           UserProfileAction.Profile -> backStack.add(UserProfileDestination.UserProfileDetail)
 
           UserProfileAction.Security -> backStack.add(UserProfileDestination.UserProfileSecurity)
+
+          UserProfileAction.SwitchAccount -> onSwitchAccount()
+
+          UserProfileAction.AddAccount -> onAddAccount()
+
+          UserProfileAction.SignOut -> Unit
         }
       },
       onBackPressed = {
@@ -178,9 +226,7 @@ private fun EntryProviderScope<NavKey>.UserProfileEntries(
                 backStack.removeLastOrNull()
               }
             },
-            navigateBackAction = {
-              if (backStack.size > 1) backStack.removeLastOrNull()
-            },
+            navigateBackAction = { if (backStack.size > 1) backStack.removeLastOrNull() },
           )
         }
       CompositionLocalProvider(LocalUserProfileCustomNavigator provides navigator) {
@@ -189,6 +235,16 @@ private fun EntryProviderScope<NavKey>.UserProfileEntries(
     } else {
       LaunchedEffect(Unit) { backStack.removeLastOrNull() }
     }
+  }
+}
+
+@Composable
+private fun AuthDialog(onDismiss: () -> Unit) {
+  Dialog(
+    onDismissRequest = onDismiss,
+    properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
+  ) {
+    AuthView(modifier = Modifier.fillMaxSize(), onAuthComplete = onDismiss)
   }
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
@@ -18,8 +18,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavBackStack
@@ -99,6 +97,10 @@ fun UserProfileView(
     var showAuth by rememberSaveable { mutableStateOf(false) }
     UserProfileStateProvider(backStack) {
       val telemetry = LocalTelemetryCollector.current
+      val showAddAccountAuth = {
+        showAccountSwitcher = false
+        showAuth = true
+      }
 
       LaunchedEffect(Unit) { telemetry.record(TelemetryEvents.viewDidAppear("UserProfileView")) }
       LaunchedEffect(user?.id, showAuth) {
@@ -107,52 +109,56 @@ fun UserProfileView(
         }
       }
 
-      NavDisplay(
-        backStack = backStack,
-        onBack = {
-          if (backStack.size == 1) {
-            onDismiss()
-          } else {
-            backStack.removeLastOrNull()
-          }
-        },
-        transitionSpec = {
-          val spec = tween<IntOffset>(durationMillis = 300)
-          slideInHorizontally(animationSpec = spec, initialOffsetX = { it }) togetherWith
-            slideOutHorizontally(animationSpec = spec, targetOffsetX = { -it })
-        },
-        popTransitionSpec = {
-          val spec = tween<IntOffset>(durationMillis = 300)
-          slideInHorizontally(animationSpec = spec, initialOffsetX = { -it }) togetherWith
-            slideOutHorizontally(animationSpec = spec, targetOffsetX = { it })
-        },
-        predictivePopTransitionSpec = { distance ->
-          // Use the provided distance to align with the system back gesture
-          slideInHorizontally(initialOffsetX = { -distance }) togetherWith
-            slideOutHorizontally(targetOffsetX = { distance })
-        },
-        entryProvider =
-          entryProvider {
-            userProfileEntries(
-              backStack = backStack,
-              onDismiss = onDismiss,
-              customRows = customRows,
-              customDestination = customDestination,
-              onSwitchAccount = { showAccountSwitcher = true },
-              onAddAccount = { showAuth = true },
-            )
-          },
-      )
-
-      if (showAccountSwitcher) {
-        UserProfileAccountSwitcherSheet(
-          onDismissRequest = { showAccountSwitcher = false },
-          onAddAccount = { showAuth = true },
-        )
-      }
-
       if (showAuth) {
-        AuthDialog(onDismiss = { showAuth = false })
+        AuthView(
+          modifier = Modifier.fillMaxSize(),
+          preferGoogleOneTap = false,
+          onAuthComplete = { showAuth = false },
+        )
+      } else {
+        NavDisplay(
+          backStack = backStack,
+          onBack = {
+            if (backStack.size == 1) {
+              onDismiss()
+            } else {
+              backStack.removeLastOrNull()
+            }
+          },
+          transitionSpec = {
+            val spec = tween<IntOffset>(durationMillis = 300)
+            slideInHorizontally(animationSpec = spec, initialOffsetX = { it }) togetherWith
+              slideOutHorizontally(animationSpec = spec, targetOffsetX = { -it })
+          },
+          popTransitionSpec = {
+            val spec = tween<IntOffset>(durationMillis = 300)
+            slideInHorizontally(animationSpec = spec, initialOffsetX = { -it }) togetherWith
+              slideOutHorizontally(animationSpec = spec, targetOffsetX = { it })
+          },
+          predictivePopTransitionSpec = { distance ->
+            // Use the provided distance to align with the system back gesture
+            slideInHorizontally(initialOffsetX = { -distance }) togetherWith
+              slideOutHorizontally(targetOffsetX = { distance })
+          },
+          entryProvider =
+            entryProvider {
+              userProfileEntries(
+                backStack = backStack,
+                onDismiss = onDismiss,
+                customRows = customRows,
+                customDestination = customDestination,
+                onSwitchAccount = { showAccountSwitcher = true },
+                onAddAccount = showAddAccountAuth,
+              )
+            },
+        )
+
+        if (showAccountSwitcher) {
+          UserProfileAccountSwitcherSheet(
+            onDismissRequest = { showAccountSwitcher = false },
+            onAddAccount = showAddAccountAuth,
+          )
+        }
       }
     }
   }
@@ -235,20 +241,6 @@ private fun EntryProviderScope<NavKey>.userProfileEntries(
     } else {
       LaunchedEffect(Unit) { backStack.removeLastOrNull() }
     }
-  }
-}
-
-@Composable
-private fun AuthDialog(onDismiss: () -> Unit) {
-  Dialog(
-    onDismissRequest = onDismiss,
-    properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
-  ) {
-    AuthView(
-      modifier = Modifier.fillMaxSize(),
-      preferGoogleOneTap = false,
-      onAuthComplete = onDismiss,
-    )
   }
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
@@ -101,8 +101,8 @@ fun UserProfileView(
       val telemetry = LocalTelemetryCollector.current
 
       LaunchedEffect(Unit) { telemetry.record(TelemetryEvents.viewDidAppear("UserProfileView")) }
-      LaunchedEffect(user?.id) {
-        if (user == null) {
+      LaunchedEffect(user?.id, showAuth) {
+        if (user == null && !showAuth) {
           onDismiss()
         }
       }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
@@ -244,7 +244,11 @@ private fun AuthDialog(onDismiss: () -> Unit) {
     onDismissRequest = onDismiss,
     properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
   ) {
-    AuthView(modifier = Modifier.fillMaxSize(), onAuthComplete = onDismiss)
+    AuthView(
+      modifier = Modifier.fillMaxSize(),
+      preferGoogleOneTap = false,
+      onAuthComplete = onDismiss,
+    )
   }
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountSwitcher.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountSwitcher.kt
@@ -52,108 +52,110 @@ internal fun UserProfileAccountSwitcherSheet(
   onAddAccount: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  val sessions by Clerk.sessionsFlow.collectAsStateWithLifecycle()
-  val currentSession by Clerk.sessionFlow.collectAsStateWithLifecycle()
-  val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-  val scope = rememberCoroutineScope()
-  var loadingActionId by rememberSaveable { mutableStateOf<String?>(null) }
-  var errorMessage by rememberSaveable { mutableStateOf<String?>(null) }
-  val sortedSessions =
-    sessions.sortedWith(
-      compareByDescending<Session> { it.id == currentSession?.id }
-        .thenByDescending { it.lastActiveAt }
-    )
-
-  ModalBottomSheet(
-    modifier = modifier,
-    onDismissRequest = onDismissRequest,
-    sheetState = sheetState,
-    containerColor = ClerkMaterialTheme.colors.background,
-    contentColor = ClerkMaterialTheme.colors.foreground,
-  ) {
-    Column(modifier = Modifier.fillMaxWidth()) {
-      Text(
-        modifier = Modifier.padding(horizontal = dp24, vertical = dp16),
-        text = stringResource(R.string.switch_account),
-        style = ClerkMaterialTheme.typography.titleMedium.withMediumWeight(),
-        color = ClerkMaterialTheme.colors.foreground,
+  ClerkMaterialTheme {
+    val sessions by Clerk.sessionsFlow.collectAsStateWithLifecycle()
+    val currentSession by Clerk.sessionFlow.collectAsStateWithLifecycle()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+    var loadingActionId by rememberSaveable { mutableStateOf<String?>(null) }
+    var errorMessage by rememberSaveable { mutableStateOf<String?>(null) }
+    val sortedSessions =
+      sessions.sortedWith(
+        compareByDescending<Session> { it.id == currentSession?.id }
+          .thenByDescending { it.lastActiveAt }
       )
-      HorizontalDivider(color = ClerkMaterialTheme.computedColors.border)
 
-      sortedSessions.forEach { session ->
-        val user = session.user
-        if (user != null) {
-          AccountSessionRow(
-            session = session,
-            user = user,
-            isCurrent = session.id == currentSession?.id,
-            isLoading = loadingActionId == session.id,
-            onClick = {
-              if (session.id == currentSession?.id || loadingActionId != null)
-                return@AccountSessionRow
-              loadingActionId = session.id
-              errorMessage = null
-              scope.launch {
-                when (val result = Clerk.auth.setActive(sessionId = session.id)) {
-                  is ClerkResult.Success -> {
-                    loadingActionId = null
-                    sheetState.hide()
-                    onDismissRequest()
-                  }
-                  is ClerkResult.Failure -> {
-                    loadingActionId = null
-                    errorMessage = result.errorMessage
+    ModalBottomSheet(
+      modifier = modifier,
+      onDismissRequest = onDismissRequest,
+      sheetState = sheetState,
+      containerColor = ClerkMaterialTheme.colors.background,
+      contentColor = ClerkMaterialTheme.colors.foreground,
+    ) {
+      Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+          modifier = Modifier.padding(horizontal = dp24, vertical = dp16),
+          text = stringResource(R.string.switch_account),
+          style = ClerkMaterialTheme.typography.titleMedium.withMediumWeight(),
+          color = ClerkMaterialTheme.colors.foreground,
+        )
+        HorizontalDivider(color = ClerkMaterialTheme.computedColors.border)
+
+        sortedSessions.forEach { session ->
+          val user = session.user
+          if (user != null) {
+            AccountSessionRow(
+              session = session,
+              user = user,
+              isCurrent = session.id == currentSession?.id,
+              isLoading = loadingActionId == session.id,
+              onClick = {
+                if (session.id == currentSession?.id || loadingActionId != null)
+                  return@AccountSessionRow
+                loadingActionId = session.id
+                errorMessage = null
+                scope.launch {
+                  when (val result = Clerk.auth.setActive(sessionId = session.id)) {
+                    is ClerkResult.Success -> {
+                      loadingActionId = null
+                      sheetState.hide()
+                      onDismissRequest()
+                    }
+                    is ClerkResult.Failure -> {
+                      loadingActionId = null
+                      errorMessage = result.errorMessage
+                    }
                   }
                 }
-              }
-            },
-          )
-          HorizontalDivider(color = ClerkMaterialTheme.computedColors.border)
+              },
+            )
+            HorizontalDivider(color = ClerkMaterialTheme.computedColors.border)
+          }
         }
-      }
 
-      AccountActionRow(
-        iconResId = R.drawable.ic_plus,
-        text = stringResource(R.string.add_account),
-        enabled = loadingActionId == null,
-        onClick = {
-          onDismissRequest()
-          onAddAccount()
-        },
-      )
-      HorizontalDivider(color = ClerkMaterialTheme.computedColors.border)
-      AccountActionRow(
-        iconResId = R.drawable.ic_sign,
-        text = stringResource(R.string.sign_out_of_all_accounts),
-        enabled = loadingActionId == null,
-        isLoading = loadingActionId == SIGN_OUT_ALL_ACTION_ID,
-        onClick = {
-          if (loadingActionId != null) return@AccountActionRow
-          loadingActionId = SIGN_OUT_ALL_ACTION_ID
-          errorMessage = null
-          scope.launch {
-            when (val result = Clerk.auth.signOut()) {
-              is ClerkResult.Success -> {
-                loadingActionId = null
-                sheetState.hide()
-                onDismissRequest()
-              }
-              is ClerkResult.Failure -> {
-                loadingActionId = null
-                errorMessage = result.errorMessage
+        AccountActionRow(
+          iconResId = R.drawable.ic_plus,
+          text = stringResource(R.string.add_account),
+          enabled = loadingActionId == null,
+          onClick = {
+            onDismissRequest()
+            onAddAccount()
+          },
+        )
+        HorizontalDivider(color = ClerkMaterialTheme.computedColors.border)
+        AccountActionRow(
+          iconResId = R.drawable.ic_sign,
+          text = stringResource(R.string.sign_out_of_all_accounts),
+          enabled = loadingActionId == null,
+          isLoading = loadingActionId == SIGN_OUT_ALL_ACTION_ID,
+          onClick = {
+            if (loadingActionId != null) return@AccountActionRow
+            loadingActionId = SIGN_OUT_ALL_ACTION_ID
+            errorMessage = null
+            scope.launch {
+              when (val result = Clerk.auth.signOut()) {
+                is ClerkResult.Success -> {
+                  loadingActionId = null
+                  sheetState.hide()
+                  onDismissRequest()
+                }
+                is ClerkResult.Failure -> {
+                  loadingActionId = null
+                  errorMessage = result.errorMessage
+                }
               }
             }
-          }
-        },
-      )
-
-      errorMessage?.let {
-        Text(
-          modifier = Modifier.padding(horizontal = dp24, vertical = dp12),
-          text = it,
-          style = ClerkMaterialTheme.typography.bodyMedium,
-          color = ClerkMaterialTheme.colors.danger,
+          },
         )
+
+        errorMessage?.let {
+          Text(
+            modifier = Modifier.padding(horizontal = dp24, vertical = dp12),
+            text = it,
+            style = ClerkMaterialTheme.typography.bodyMedium,
+            color = ClerkMaterialTheme.colors.danger,
+          )
+        }
       }
     }
   }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountSwitcher.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountSwitcher.kt
@@ -1,0 +1,257 @@
+package com.clerk.ui.userprofile.account
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.clerk.api.Clerk
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.network.serialization.errorMessage
+import com.clerk.api.session.Session
+import com.clerk.api.user.User
+import com.clerk.api.user.fullName
+import com.clerk.ui.R
+import com.clerk.ui.core.avatar.AvatarSize
+import com.clerk.ui.core.avatar.AvatarType
+import com.clerk.ui.core.avatar.AvatarView
+import com.clerk.ui.core.dimens.dp12
+import com.clerk.ui.core.dimens.dp16
+import com.clerk.ui.core.dimens.dp2
+import com.clerk.ui.core.dimens.dp20
+import com.clerk.ui.core.dimens.dp24
+import com.clerk.ui.core.extensions.withMediumWeight
+import com.clerk.ui.theme.ClerkMaterialTheme
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Suppress("LongMethod")
+@Composable
+internal fun UserProfileAccountSwitcherSheet(
+  onDismissRequest: () -> Unit,
+  onAddAccount: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val sessions by Clerk.sessionsFlow.collectAsStateWithLifecycle()
+  val currentSession by Clerk.sessionFlow.collectAsStateWithLifecycle()
+  val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+  val scope = rememberCoroutineScope()
+  var loadingActionId by rememberSaveable { mutableStateOf<String?>(null) }
+  var errorMessage by rememberSaveable { mutableStateOf<String?>(null) }
+  val sortedSessions =
+    sessions.sortedWith(
+      compareByDescending<Session> { it.id == currentSession?.id }
+        .thenByDescending { it.lastActiveAt }
+    )
+
+  ModalBottomSheet(
+    modifier = modifier,
+    onDismissRequest = onDismissRequest,
+    sheetState = sheetState,
+    containerColor = ClerkMaterialTheme.colors.background,
+    contentColor = ClerkMaterialTheme.colors.foreground,
+  ) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+      Text(
+        modifier = Modifier.padding(horizontal = dp24, vertical = dp16),
+        text = stringResource(R.string.switch_account),
+        style = ClerkMaterialTheme.typography.titleMedium.withMediumWeight(),
+        color = ClerkMaterialTheme.colors.foreground,
+      )
+      HorizontalDivider(color = ClerkMaterialTheme.computedColors.border)
+
+      sortedSessions.forEach { session ->
+        val user = session.user
+        if (user != null) {
+          AccountSessionRow(
+            session = session,
+            user = user,
+            isCurrent = session.id == currentSession?.id,
+            isLoading = loadingActionId == session.id,
+            onClick = {
+              if (session.id == currentSession?.id || loadingActionId != null)
+                return@AccountSessionRow
+              loadingActionId = session.id
+              errorMessage = null
+              scope.launch {
+                when (val result = Clerk.auth.setActive(sessionId = session.id)) {
+                  is ClerkResult.Success -> {
+                    loadingActionId = null
+                    sheetState.hide()
+                    onDismissRequest()
+                  }
+                  is ClerkResult.Failure -> {
+                    loadingActionId = null
+                    errorMessage = result.errorMessage
+                  }
+                }
+              }
+            },
+          )
+          HorizontalDivider(color = ClerkMaterialTheme.computedColors.border)
+        }
+      }
+
+      AccountActionRow(
+        iconResId = R.drawable.ic_plus,
+        text = stringResource(R.string.add_account),
+        enabled = loadingActionId == null,
+        onClick = {
+          onDismissRequest()
+          onAddAccount()
+        },
+      )
+      HorizontalDivider(color = ClerkMaterialTheme.computedColors.border)
+      AccountActionRow(
+        iconResId = R.drawable.ic_sign,
+        text = stringResource(R.string.sign_out_of_all_accounts),
+        enabled = loadingActionId == null,
+        isLoading = loadingActionId == SIGN_OUT_ALL_ACTION_ID,
+        onClick = {
+          if (loadingActionId != null) return@AccountActionRow
+          loadingActionId = SIGN_OUT_ALL_ACTION_ID
+          errorMessage = null
+          scope.launch {
+            when (val result = Clerk.auth.signOut()) {
+              is ClerkResult.Success -> {
+                loadingActionId = null
+                sheetState.hide()
+                onDismissRequest()
+              }
+              is ClerkResult.Failure -> {
+                loadingActionId = null
+                errorMessage = result.errorMessage
+              }
+            }
+          }
+        },
+      )
+
+      errorMessage?.let {
+        Text(
+          modifier = Modifier.padding(horizontal = dp24, vertical = dp12),
+          text = it,
+          style = ClerkMaterialTheme.typography.bodyMedium,
+          color = ClerkMaterialTheme.colors.danger,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun AccountSessionRow(
+  session: Session,
+  user: User,
+  isCurrent: Boolean,
+  isLoading: Boolean,
+  onClick: () -> Unit,
+) {
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .clickable(enabled = !isCurrent && !isLoading, onClick = onClick)
+        .padding(horizontal = dp24, vertical = dp16),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    AvatarView(
+      size = AvatarSize.MEDIUM,
+      shape = CircleShape,
+      avatarType = AvatarType.USER,
+      imageUrl = user.imageUrl,
+    )
+    Column(modifier = Modifier.weight(1f).padding(start = dp12)) {
+      val displayName = user.displayName()
+      if (displayName.isNotBlank()) {
+        Text(
+          text = displayName,
+          style = ClerkMaterialTheme.typography.bodyLarge.withMediumWeight(),
+          color = ClerkMaterialTheme.colors.foreground,
+        )
+      }
+      session.displayIdentifier(user)?.let {
+        Text(
+          text = it,
+          style = ClerkMaterialTheme.typography.bodyMedium,
+          color = ClerkMaterialTheme.colors.mutedForeground,
+        )
+      }
+    }
+    when {
+      isLoading -> CircularProgressIndicator(modifier = Modifier.size(dp20), strokeWidth = dp2)
+      isCurrent ->
+        Icon(
+          modifier = Modifier.size(dp20),
+          painter = painterResource(R.drawable.ic_check),
+          contentDescription = null,
+          tint = ClerkMaterialTheme.colors.primary,
+        )
+    }
+  }
+}
+
+@Composable
+private fun AccountActionRow(
+  iconResId: Int,
+  text: String,
+  enabled: Boolean,
+  onClick: () -> Unit,
+  isLoading: Boolean = false,
+) {
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .clickable(enabled = enabled, onClick = onClick)
+        .padding(horizontal = dp24, vertical = dp16),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Icon(
+      modifier = Modifier.size(dp20),
+      painter = painterResource(iconResId),
+      contentDescription = null,
+      tint = ClerkMaterialTheme.colors.mutedForeground,
+    )
+    Text(
+      modifier = Modifier.weight(1f).padding(start = dp12),
+      text = text,
+      style = ClerkMaterialTheme.typography.bodyLarge.withMediumWeight(),
+      color = ClerkMaterialTheme.colors.foreground,
+    )
+    if (isLoading) {
+      CircularProgressIndicator(modifier = Modifier.size(dp20), strokeWidth = dp2)
+    }
+  }
+}
+
+private fun User.displayName(): String = fullName().ifBlank { username.orEmpty() }
+
+private fun Session.displayIdentifier(user: User): String? {
+  return publicUserData?.identifier?.takeIf { it.isNotBlank() }
+    ?: user.username?.takeIf { it.isNotBlank() }
+    ?: user.emailAddresses
+      ?.firstOrNull { it.id == user.primaryEmailAddressId }
+      ?.emailAddress
+      ?.takeIf { it.isNotBlank() }
+}
+
+private const val SIGN_OUT_ALL_ACTION_ID = "sign_out_all"

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
@@ -48,6 +48,7 @@ internal fun UserProfileAccountView(
   onCustomRowClick: (routeKey: String) -> Unit = {},
 ) {
   val sessions = Clerk.sessionsFlow.collectAsStateWithLifecycle().value
+  val multiSessionModeIsEnabled = Clerk.multiSessionModeIsEnabled
 
   UserProfileAccountViewImpl(
     modifier = modifier,
@@ -55,6 +56,7 @@ internal fun UserProfileAccountView(
     userFullName = Clerk.user?.fullName(),
     username = Clerk.user?.username,
     sessionCount = sessions.size,
+    multiSessionModeIsEnabled = multiSessionModeIsEnabled,
     onClick = onClick,
     onBackPressed = onBackPressed,
     onEditAvatarClick = onClickEdit,
@@ -69,6 +71,7 @@ private fun UserProfileAccountViewImpl(
   userFullName: String?,
   username: String?,
   sessionCount: Int,
+  multiSessionModeIsEnabled: Boolean,
   onClick: (UserProfileAction) -> Unit,
   onBackPressed: () -> Unit,
   onEditAvatarClick: () -> Unit,
@@ -110,6 +113,7 @@ private fun UserProfileAccountViewImpl(
       bottomContent = {
         AccountSectionRows(
           sessionCount = sessionCount,
+          multiSessionModeIsEnabled = multiSessionModeIsEnabled,
           onClick = handleAccountClick,
           customRows = customRows,
           onCustomRowClick = onCustomRowClick,
@@ -233,13 +237,18 @@ private fun ProfileSectionRows(
 @Composable
 private fun AccountSectionRows(
   sessionCount: Int,
+  multiSessionModeIsEnabled: Boolean,
   onClick: (UserProfileAction) -> Unit,
   customRows: ImmutableList<UserProfileCustomRow>,
   onCustomRowClick: (routeKey: String) -> Unit,
 ) {
   val rows =
     buildRenderedRows(
-      builtInRows = accountBuiltInRows(sessionCount = sessionCount),
+      builtInRows =
+        accountBuiltInRows(
+          sessionCount = sessionCount,
+          multiSessionModeIsEnabled = multiSessionModeIsEnabled,
+        ),
       section = UserProfileSection.Account,
       customRows = customRows,
     )
@@ -290,11 +299,19 @@ internal enum class UserProfileAction {
   SignOut,
 }
 
-internal fun accountBuiltInRows(sessionCount: Int): List<UserProfileRow> = buildList {
-  if (sessionCount > 1) {
-    add(UserProfileRow.SwitchAccount)
+internal fun accountBuiltInRows(sessionCount: Int): List<UserProfileRow> =
+  accountBuiltInRows(sessionCount = sessionCount, multiSessionModeIsEnabled = true)
+
+internal fun accountBuiltInRows(
+  sessionCount: Int,
+  multiSessionModeIsEnabled: Boolean,
+): List<UserProfileRow> = buildList {
+  if (multiSessionModeIsEnabled) {
+    if (sessionCount > 1) {
+      add(UserProfileRow.SwitchAccount)
+    }
+    add(UserProfileRow.AddAccount)
   }
-  add(UserProfileRow.AddAccount)
   add(UserProfileRow.SignOut)
 }
 
@@ -306,6 +323,7 @@ private fun Preview() {
       userFullName = "Cameron Walker",
       username = "cameronw",
       sessionCount = 2,
+      multiSessionModeIsEnabled = true,
       onClick = {},
       onBackPressed = {},
       onEditAvatarClick = {},

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
@@ -54,7 +54,6 @@ internal fun UserProfileAccountView(
     imageUrl = Clerk.user?.imageUrl,
     userFullName = Clerk.user?.fullName(),
     username = Clerk.user?.username,
-    multiSessionModeIsEnabled = Clerk.multiSessionModeIsEnabled,
     sessionCount = sessions.size,
     onClick = onClick,
     onBackPressed = onBackPressed,
@@ -69,7 +68,6 @@ internal fun UserProfileAccountView(
 private fun UserProfileAccountViewImpl(
   userFullName: String?,
   username: String?,
-  multiSessionModeIsEnabled: Boolean,
   sessionCount: Int,
   onClick: (UserProfileAction) -> Unit,
   onBackPressed: () -> Unit,
@@ -111,7 +109,6 @@ private fun UserProfileAccountViewImpl(
       },
       bottomContent = {
         AccountSectionRows(
-          multiSessionModeIsEnabled = multiSessionModeIsEnabled,
           sessionCount = sessionCount,
           onClick = handleAccountClick,
           customRows = customRows,
@@ -235,24 +232,14 @@ private fun ProfileSectionRows(
 
 @Composable
 private fun AccountSectionRows(
-  multiSessionModeIsEnabled: Boolean,
   sessionCount: Int,
   onClick: (UserProfileAction) -> Unit,
   customRows: ImmutableList<UserProfileCustomRow>,
   onCustomRowClick: (routeKey: String) -> Unit,
 ) {
-  val builtInRows = buildList {
-    if (multiSessionModeIsEnabled) {
-      if (sessionCount > 1) {
-        add(UserProfileRow.SwitchAccount)
-      }
-      add(UserProfileRow.AddAccount)
-    }
-    add(UserProfileRow.SignOut)
-  }
   val rows =
     buildRenderedRows(
-      builtInRows = builtInRows,
+      builtInRows = accountBuiltInRows(sessionCount = sessionCount),
       section = UserProfileSection.Account,
       customRows = customRows,
     )
@@ -303,6 +290,14 @@ internal enum class UserProfileAction {
   SignOut,
 }
 
+internal fun accountBuiltInRows(sessionCount: Int): List<UserProfileRow> = buildList {
+  if (sessionCount > 1) {
+    add(UserProfileRow.SwitchAccount)
+  }
+  add(UserProfileRow.AddAccount)
+  add(UserProfileRow.SignOut)
+}
+
 @PreviewLightDark
 @Composable
 private fun Preview() {
@@ -310,7 +305,6 @@ private fun Preview() {
     UserProfileAccountViewImpl(
       userFullName = "Cameron Walker",
       username = "cameronw",
-      multiSessionModeIsEnabled = true,
       sessionCount = 2,
       onClick = {},
       onBackPressed = {},

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.clerk.api.Clerk
 import com.clerk.api.user.fullName
@@ -46,12 +47,15 @@ internal fun UserProfileAccountView(
   customRows: ImmutableList<UserProfileCustomRow> = persistentListOf(),
   onCustomRowClick: (routeKey: String) -> Unit = {},
 ) {
+  val sessions = Clerk.sessionsFlow.collectAsStateWithLifecycle().value
 
   UserProfileAccountViewImpl(
     modifier = modifier,
     imageUrl = Clerk.user?.imageUrl,
     userFullName = Clerk.user?.fullName(),
     username = Clerk.user?.username,
+    multiSessionModeIsEnabled = Clerk.multiSessionModeIsEnabled,
+    sessionCount = sessions.size,
     onClick = onClick,
     onBackPressed = onBackPressed,
     onEditAvatarClick = onClickEdit,
@@ -61,9 +65,12 @@ internal fun UserProfileAccountView(
 }
 
 @Composable
+@Suppress("LongParameterList")
 private fun UserProfileAccountViewImpl(
   userFullName: String?,
   username: String?,
+  multiSessionModeIsEnabled: Boolean,
+  sessionCount: Int,
   onClick: (UserProfileAction) -> Unit,
   onBackPressed: () -> Unit,
   onEditAvatarClick: () -> Unit,
@@ -73,6 +80,13 @@ private fun UserProfileAccountViewImpl(
   customRows: ImmutableList<UserProfileCustomRow> = persistentListOf(),
   onCustomRowClick: (routeKey: String) -> Unit = {},
 ) {
+  val handleAccountClick: (UserProfileAction) -> Unit = { action ->
+    if (action == UserProfileAction.SignOut) {
+      viewModel.signOut()
+    }
+    onClick(action)
+  }
+
   ClerkMaterialTheme {
     ClerkThemedProfileScaffold(
       modifier = modifier,
@@ -97,7 +111,9 @@ private fun UserProfileAccountViewImpl(
       },
       bottomContent = {
         AccountSectionRows(
-          viewModel = viewModel,
+          multiSessionModeIsEnabled = multiSessionModeIsEnabled,
+          sessionCount = sessionCount,
+          onClick = handleAccountClick,
           customRows = customRows,
           onCustomRowClick = onCustomRowClick,
         )
@@ -202,6 +218,8 @@ private fun ProfileSectionRows(
                 text = stringResource(R.string.security),
                 onClick = { onClick(UserProfileAction.Security) },
               )
+            UserProfileRow.SwitchAccount,
+            UserProfileRow.AddAccount,
             UserProfileRow.SignOut -> {} // Handled in account section
           }
         is UserProfileListRow.Custom ->
@@ -217,13 +235,24 @@ private fun ProfileSectionRows(
 
 @Composable
 private fun AccountSectionRows(
-  viewModel: UserProfileAccountViewModel,
+  multiSessionModeIsEnabled: Boolean,
+  sessionCount: Int,
+  onClick: (UserProfileAction) -> Unit,
   customRows: ImmutableList<UserProfileCustomRow>,
   onCustomRowClick: (routeKey: String) -> Unit,
 ) {
+  val builtInRows = buildList {
+    if (multiSessionModeIsEnabled) {
+      if (sessionCount > 1) {
+        add(UserProfileRow.SwitchAccount)
+      }
+      add(UserProfileRow.AddAccount)
+    }
+    add(UserProfileRow.SignOut)
+  }
   val rows =
     buildRenderedRows(
-      builtInRows = listOf(UserProfileRow.SignOut),
+      builtInRows = builtInRows,
       section = UserProfileSection.Account,
       customRows = customRows,
     )
@@ -231,12 +260,31 @@ private fun AccountSectionRows(
     HorizontalDivider(thickness = dp1, color = ClerkMaterialTheme.computedColors.border)
     when (row) {
       is UserProfileListRow.BuiltIn ->
-        UserProfileIconActionRow(
-          backgroundColor = ClerkMaterialTheme.colors.background,
-          iconResId = R.drawable.ic_sign,
-          text = stringResource(R.string.log_out),
-          onClick = { viewModel.signOut() },
-        )
+        when (row.row) {
+          UserProfileRow.SwitchAccount ->
+            UserProfileIconActionRow(
+              backgroundColor = ClerkMaterialTheme.colors.background,
+              iconResId = R.drawable.ic_switch,
+              text = stringResource(R.string.switch_account),
+              onClick = { onClick(UserProfileAction.SwitchAccount) },
+            )
+          UserProfileRow.AddAccount ->
+            UserProfileIconActionRow(
+              backgroundColor = ClerkMaterialTheme.colors.background,
+              iconResId = R.drawable.ic_plus,
+              text = stringResource(R.string.add_account),
+              onClick = { onClick(UserProfileAction.AddAccount) },
+            )
+          UserProfileRow.SignOut ->
+            UserProfileIconActionRow(
+              backgroundColor = ClerkMaterialTheme.colors.background,
+              iconResId = R.drawable.ic_sign,
+              text = stringResource(R.string.sign_out),
+              onClick = { onClick(UserProfileAction.SignOut) },
+            )
+          UserProfileRow.ManageAccount,
+          UserProfileRow.Security -> Unit
+        }
       is UserProfileListRow.Custom ->
         CustomRowView(
           customRow = row.customRow,
@@ -250,6 +298,9 @@ private fun AccountSectionRows(
 internal enum class UserProfileAction {
   Profile,
   Security,
+  SwitchAccount,
+  AddAccount,
+  SignOut,
 }
 
 @PreviewLightDark
@@ -259,6 +310,8 @@ private fun Preview() {
     UserProfileAccountViewImpl(
       userFullName = "Cameron Walker",
       username = "cameronw",
+      multiSessionModeIsEnabled = true,
+      sessionCount = 2,
       onClick = {},
       onBackPressed = {},
       onEditAvatarClick = {},

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -48,7 +49,7 @@ internal fun UserProfileAccountView(
   onCustomRowClick: (routeKey: String) -> Unit = {},
 ) {
   val sessions = Clerk.sessionsFlow.collectAsStateWithLifecycle().value
-  val multiSessionModeIsEnabled = Clerk.multiSessionModeIsEnabled
+  val multiSessionModeIsEnabled by Clerk.multiSessionModeIsEnabledFlow.collectAsStateWithLifecycle()
 
   UserProfileAccountViewImpl(
     modifier = modifier,

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountViewModel.kt
@@ -20,7 +20,7 @@ internal class UserProfileAccountViewModel : ViewModel() {
   val deleteAccountStateFlow = _deleteAccountStateFlow.asStateFlow()
 
   fun signOut() {
-    viewModelScope.launch { Clerk.auth.signOut() }
+    viewModelScope.launch { Clerk.auth.signOut(sessionId = Clerk.session?.id) }
   }
 
   fun deleteAccount() {

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountViewModel.kt
@@ -20,7 +20,8 @@ internal class UserProfileAccountViewModel : ViewModel() {
   val deleteAccountStateFlow = _deleteAccountStateFlow.asStateFlow()
 
   fun signOut() {
-    viewModelScope.launch { Clerk.auth.signOut(sessionId = Clerk.session?.id) }
+    val sessionId = Clerk.session?.id ?: return
+    viewModelScope.launch { Clerk.auth.signOut(sessionId = sessionId) }
   }
 
   fun deleteAccount() {

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/custom/UserProfileCustomRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/custom/UserProfileCustomRow.kt
@@ -14,10 +14,15 @@ sealed interface UserProfileRowIcon {
   data class Vector(val imageVector: ImageVector) : UserProfileRowIcon
 }
 
-/** Built-in rows in [com.clerk.ui.userprofile.UserProfileView] that can be used as placement anchors. */
+/**
+ * Built-in rows in [com.clerk.ui.userprofile.UserProfileView] that can be used as placement
+ * anchors.
+ */
 enum class UserProfileRow {
   ManageAccount,
   Security,
+  SwitchAccount,
+  AddAccount,
   SignOut,
 }
 
@@ -26,7 +31,7 @@ enum class UserProfileSection {
   /** Contains [UserProfileRow.ManageAccount] and [UserProfileRow.Security]. */
   Profile,
 
-  /** Contains [UserProfileRow.SignOut]. */
+  /** Contains account switching and sign-out rows. */
   Account,
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/custom/UserProfileRowOrdering.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/custom/UserProfileRowOrdering.kt
@@ -5,6 +5,8 @@ internal val UserProfileRow.section: UserProfileSection
     when (this) {
       UserProfileRow.ManageAccount,
       UserProfileRow.Security -> UserProfileSection.Profile
+      UserProfileRow.SwitchAccount,
+      UserProfileRow.AddAccount,
       UserProfileRow.SignOut -> UserProfileSection.Account
     }
 

--- a/source/ui/src/main/res/values/strings.xml
+++ b/source/ui/src/main/res/values/strings.xml
@@ -162,6 +162,10 @@
     <string name="security">Security</string>
     <string name="edit_profile">Edit profile</string>
     <string name="manage_account">Manage account</string>
+    <string name="switch_account" tools:ignore="MissingTranslation">Switch account</string>
+    <string name="add_account" tools:ignore="MissingTranslation">Add account</string>
+    <string name="sign_out" tools:ignore="MissingTranslation">Sign out</string>
+    <string name="sign_out_of_all_accounts" tools:ignore="MissingTranslation">Sign out of all accounts</string>
     <string name="log_out">Log out</string>
     <string name="take_a_photo">Take a photo</string>
     <string name="choose_photo">Choose photo</string>

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.clerk.ui.auth
 
 import app.cash.turbine.test
+import com.clerk.api.Clerk
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
@@ -8,6 +9,7 @@ import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.OAuthResult
 import com.clerk.api.sso.ResultType
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -294,5 +296,48 @@ class AuthViewModelTest {
     val testProviders = listOf(google, facebook)
     assertTrue("Should contain Google", testProviders.contains(OAuthProvider.GOOGLE))
     assertTrue("Should contain Facebook", testProviders.contains(OAuthProvider.FACEBOOK))
+  }
+
+  @Test
+  fun googleSocialAuthUsesBrowserRedirectWhenOneTapIsNotPreferred() = runTest {
+    mockkObject(SignIn.Companion)
+    val mockSignIn = mockk<SignIn>(relaxed = true)
+
+    coEvery { SignIn.authenticateWithGoogleOneTap(any()) } returns
+      ClerkResult.success(OAuthResult(signIn = mockSignIn))
+    coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
+      ClerkResult.success(OAuthResult(signIn = mockSignIn))
+
+    viewModel.authenticateWithSocialProvider(
+      provider = OAuthProvider.GOOGLE,
+      transferable = true,
+      preferGoogleOneTap = false,
+    )
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    coVerify(exactly = 0) { SignIn.authenticateWithGoogleOneTap(any()) }
+    coVerify(exactly = 1) { SignIn.authenticateWithRedirect(any(), true) }
+  }
+
+  @Test
+  fun googleSocialAuthUsesOneTapWhenPreferredAndEnabled() = runTest {
+    mockkObject(Clerk)
+    every { Clerk.isGoogleOneTapEnabled } returns true
+    mockkObject(SignIn.Companion)
+    val mockSignIn = mockk<SignIn>(relaxed = true)
+
+    coEvery { SignIn.authenticateWithGoogleOneTap(any()) } returns
+      ClerkResult.success(OAuthResult(signIn = mockSignIn))
+    coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
+      ClerkResult.success(OAuthResult(signIn = mockSignIn))
+
+    viewModel.authenticateWithSocialProvider(
+      provider = OAuthProvider.GOOGLE,
+      transferable = true,
+      preferGoogleOneTap = true,
+    )
+
+    coVerify(timeout = 1_000, exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
+    coVerify(exactly = 0) { SignIn.authenticateWithRedirect(any(), any()) }
   }
 }

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -320,6 +320,29 @@ class AuthViewModelTest {
   }
 
   @Test
+  fun socialOAuthCanStartWithSignUp() = runTest {
+    mockkObject(SignIn.Companion)
+    mockkObject(SignUp.Companion)
+    val mockSignUp = mockk<SignUp>(relaxed = true)
+
+    coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
+      ClerkResult.success(OAuthResult(signIn = mockk(relaxed = true)))
+    coEvery { SignUp.authenticateWithRedirect(any()) } returns
+      ClerkResult.success(OAuthResult(signUp = mockSignUp))
+
+    viewModel.authenticateWithSocialProvider(
+      provider = OAuthProvider.GOOGLE,
+      transferable = true,
+      preferGoogleOneTap = false,
+      startOAuthWithSignUp = true,
+    )
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    coVerify(exactly = 1) { SignUp.authenticateWithRedirect(any()) }
+    coVerify(exactly = 0) { SignIn.authenticateWithRedirect(any(), any()) }
+  }
+
+  @Test
   fun googleSocialAuthUsesOneTapWhenPreferredAndEnabled() = runTest {
     mockkObject(Clerk)
     every { Clerk.isGoogleOneTapEnabled } returns true

--- a/source/ui/src/test/java/com/clerk/ui/userbutton/UserButtonBehaviorTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userbutton/UserButtonBehaviorTest.kt
@@ -49,4 +49,29 @@ class UserButtonBehaviorTest {
       )
     )
   }
+
+  @Test
+  fun `forced mfa auth dismisses when mfa is resolved`() {
+    assertTrue(
+      shouldDismissAuthWhenMfaResolved(
+        authMode = UserButtonAuthMode.ForcedMfa,
+        requiresForcedMfa = false,
+      )
+    )
+  }
+
+  @Test
+  fun `add account auth stays open when mfa is not required`() {
+    assertFalse(
+      shouldDismissAuthWhenMfaResolved(
+        authMode = UserButtonAuthMode.AddAccount,
+        requiresForcedMfa = false,
+      )
+    )
+  }
+
+  @Test
+  fun `add account auth uses browser OAuth`() {
+    assertFalse(UserButtonAuthMode.AddAccount.preferGoogleOneTap)
+  }
 }

--- a/source/ui/src/test/java/com/clerk/ui/userbutton/UserButtonBehaviorTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userbutton/UserButtonBehaviorTest.kt
@@ -76,8 +76,8 @@ class UserButtonBehaviorTest {
   }
 
   @Test
-  fun `add account auth starts browser social OAuth as sign up`() {
-    assertTrue(UserButtonAuthMode.AddAccount.startSocialOAuthAsSignUp)
+  fun `add account auth uses sign in first social OAuth`() {
+    assertFalse(UserButtonAuthMode.AddAccount.startSocialOAuthAsSignUp)
     assertFalse(UserButtonAuthMode.ForcedMfa.startSocialOAuthAsSignUp)
   }
 }

--- a/source/ui/src/test/java/com/clerk/ui/userbutton/UserButtonBehaviorTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userbutton/UserButtonBehaviorTest.kt
@@ -74,4 +74,10 @@ class UserButtonBehaviorTest {
   fun `add account auth uses browser OAuth`() {
     assertFalse(UserButtonAuthMode.AddAccount.preferGoogleOneTap)
   }
+
+  @Test
+  fun `add account auth starts browser social OAuth as sign up`() {
+    assertTrue(UserButtonAuthMode.AddAccount.startSocialOAuthAsSignUp)
+    assertFalse(UserButtonAuthMode.ForcedMfa.startSocialOAuthAsSignUp)
+  }
 }

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/account/UserProfileAccountViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/account/UserProfileAccountViewModelTest.kt
@@ -47,4 +47,20 @@ class UserProfileAccountViewModelTest {
 
     coVerify { Clerk.auth.signOut(sessionId = "sess_123") }
   }
+
+  @Test
+  fun signOut_doesNothingWhenCurrentSessionIsNull() = runTest {
+    every { Clerk.session } returns null
+    coEvery { Clerk.auth.signOut(sessionId = any()) } returns ClerkResult.success(Unit)
+    coEvery { Clerk.auth.signOut(sessionId = null) } returns ClerkResult.success(Unit)
+
+    val viewModel = UserProfileAccountViewModel()
+
+    viewModel.signOut()
+    advanceUntilIdle()
+
+    // Must not collapse to signOut(null) / signOut() — that would sign out every account.
+    coVerify(exactly = 0) { Clerk.auth.signOut(sessionId = any()) }
+    coVerify(exactly = 0) { Clerk.auth.signOut(sessionId = null) }
+  }
 }

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/account/UserProfileAccountViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/account/UserProfileAccountViewModelTest.kt
@@ -2,8 +2,11 @@ package com.clerk.ui.userprofile.account
 
 import com.clerk.api.Clerk
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import kotlin.test.AfterTest
@@ -31,14 +34,17 @@ class UserProfileAccountViewModelTest {
   }
 
   @Test
-  fun signOut_invokesClerkSignOut() = runTest {
-    coEvery { Clerk.auth.signOut() } returns ClerkResult.success(Unit)
+  fun signOut_invokesClerkSignOutForCurrentSession() = runTest {
+    val session = mockk<Session>()
+    every { session.id } returns "sess_123"
+    every { Clerk.session } returns session
+    coEvery { Clerk.auth.signOut(sessionId = "sess_123") } returns ClerkResult.success(Unit)
 
     val viewModel = UserProfileAccountViewModel()
 
     viewModel.signOut()
     advanceUntilIdle()
 
-    coVerify { Clerk.auth.signOut() }
+    coVerify { Clerk.auth.signOut(sessionId = "sess_123") }
   }
 }

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/account/UserProfileAccountViewTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/account/UserProfileAccountViewTest.kt
@@ -1,0 +1,24 @@
+package com.clerk.ui.userprofile.account
+
+import com.clerk.ui.userprofile.custom.UserProfileRow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UserProfileAccountViewTest {
+
+  @Test
+  fun accountBuiltInRows_includesAddAccountWithOneSession() {
+    assertEquals(
+      listOf(UserProfileRow.AddAccount, UserProfileRow.SignOut),
+      accountBuiltInRows(sessionCount = 1),
+    )
+  }
+
+  @Test
+  fun accountBuiltInRows_includesSwitchAccountWithMultipleSessions() {
+    assertEquals(
+      listOf(UserProfileRow.SwitchAccount, UserProfileRow.AddAccount, UserProfileRow.SignOut),
+      accountBuiltInRows(sessionCount = 2),
+    )
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/account/UserProfileAccountViewTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/account/UserProfileAccountViewTest.kt
@@ -21,4 +21,12 @@ class UserProfileAccountViewTest {
       accountBuiltInRows(sessionCount = 2),
     )
   }
+
+  @Test
+  fun accountBuiltInRows_hidesMultiSessionRowsWhenDisabled() {
+    assertEquals(
+      listOf(UserProfileRow.SignOut),
+      accountBuiltInRows(sessionCount = 2, multiSessionModeIsEnabled = false),
+    )
+  }
 }

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/custom/UserProfileRowOrderingTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/custom/UserProfileRowOrderingTest.kt
@@ -5,10 +5,7 @@ import kotlin.test.assertEquals
 
 class UserProfileRowOrderingTest {
 
-  private fun customRow(
-    routeKey: String,
-    placement: UserProfileCustomRowPlacement,
-  ) =
+  private fun customRow(routeKey: String, placement: UserProfileCustomRowPlacement) =
     UserProfileCustomRow(
       routeKey = routeKey,
       title = routeKey,
@@ -36,7 +33,8 @@ class UserProfileRowOrderingTest {
 
   @Test
   fun `sectionStart rows appear before all built-in rows`() {
-    val custom = customRow("start", UserProfileCustomRowPlacement.SectionStart(UserProfileSection.Profile))
+    val custom =
+      customRow("start", UserProfileCustomRowPlacement.SectionStart(UserProfileSection.Profile))
     val rows =
       buildRenderedRows(
         builtInRows = listOf(UserProfileRow.ManageAccount, UserProfileRow.Security),
@@ -50,7 +48,8 @@ class UserProfileRowOrderingTest {
 
   @Test
   fun `sectionEnd rows appear after all built-in rows`() {
-    val custom = customRow("end", UserProfileCustomRowPlacement.SectionEnd(UserProfileSection.Profile))
+    val custom =
+      customRow("end", UserProfileCustomRowPlacement.SectionEnd(UserProfileSection.Profile))
     val rows =
       buildRenderedRows(
         builtInRows = listOf(UserProfileRow.ManageAccount, UserProfileRow.Security),
@@ -64,7 +63,8 @@ class UserProfileRowOrderingTest {
 
   @Test
   fun `before placement inserts custom row before the anchor`() {
-    val custom = customRow("beforeSec", UserProfileCustomRowPlacement.Before(UserProfileRow.Security))
+    val custom =
+      customRow("beforeSec", UserProfileCustomRowPlacement.Before(UserProfileRow.Security))
     val rows =
       buildRenderedRows(
         builtInRows = listOf(UserProfileRow.ManageAccount, UserProfileRow.Security),
@@ -84,7 +84,8 @@ class UserProfileRowOrderingTest {
 
   @Test
   fun `after placement inserts custom row after the anchor`() {
-    val custom = customRow("afterManage", UserProfileCustomRowPlacement.After(UserProfileRow.ManageAccount))
+    val custom =
+      customRow("afterManage", UserProfileCustomRowPlacement.After(UserProfileRow.ManageAccount))
     val rows =
       buildRenderedRows(
         builtInRows = listOf(UserProfileRow.ManageAccount, UserProfileRow.Security),
@@ -148,9 +149,12 @@ class UserProfileRowOrderingTest {
 
   @Test
   fun `mixed placements produce correct ordering`() {
-    val start = customRow("start", UserProfileCustomRowPlacement.SectionStart(UserProfileSection.Profile))
-    val beforeSec = customRow("beforeSec", UserProfileCustomRowPlacement.Before(UserProfileRow.Security))
-    val afterSec = customRow("afterSec", UserProfileCustomRowPlacement.After(UserProfileRow.Security))
+    val start =
+      customRow("start", UserProfileCustomRowPlacement.SectionStart(UserProfileSection.Profile))
+    val beforeSec =
+      customRow("beforeSec", UserProfileCustomRowPlacement.Before(UserProfileRow.Security))
+    val afterSec =
+      customRow("afterSec", UserProfileCustomRowPlacement.After(UserProfileRow.Security))
     val end = customRow("end", UserProfileCustomRowPlacement.SectionEnd(UserProfileSection.Profile))
     val rows =
       buildRenderedRows(
@@ -188,6 +192,32 @@ class UserProfileRowOrderingTest {
     assertEquals(
       listOf(
         UserProfileListRow.Custom(beforeSignOut),
+        UserProfileListRow.BuiltIn(UserProfileRow.SignOut),
+      ),
+      rows,
+    )
+  }
+
+  @Test
+  fun `account section supports switch and add account anchors`() {
+    val afterSwitch =
+      customRow("afterSwitch", UserProfileCustomRowPlacement.After(UserProfileRow.SwitchAccount))
+    val beforeAdd =
+      customRow("beforeAdd", UserProfileCustomRowPlacement.Before(UserProfileRow.AddAccount))
+    val rows =
+      buildRenderedRows(
+        builtInRows =
+          listOf(UserProfileRow.SwitchAccount, UserProfileRow.AddAccount, UserProfileRow.SignOut),
+        section = UserProfileSection.Account,
+        customRows = listOf(afterSwitch, beforeAdd),
+      )
+
+    assertEquals(
+      listOf(
+        UserProfileListRow.BuiltIn(UserProfileRow.SwitchAccount),
+        UserProfileListRow.Custom(afterSwitch),
+        UserProfileListRow.Custom(beforeAdd),
+        UserProfileListRow.BuiltIn(UserProfileRow.AddAccount),
         UserProfileListRow.BuiltIn(UserProfileRow.SignOut),
       ),
       rows,

--- a/workbench/src/main/java/com/clerk/workbench/WorkbenchAuthGate.kt
+++ b/workbench/src/main/java/com/clerk/workbench/WorkbenchAuthGate.kt
@@ -25,9 +25,7 @@ internal fun WorkbenchAuthGate(
 
   LaunchedEffect(isInitialized, user?.id, session?.id, pendingTaskKey) {
     if (!isInitialized) return@LaunchedEffect
-    if (user == null || pendingTaskKey != null) {
-      isAuthFlowActive = true
-    }
+    isAuthFlowActive = user == null || pendingTaskKey != null
   }
 
   when {


### PR DESCRIPTION
## Summary
- Add multi-session state to the SDK and expose session lists alongside the current session
- Mirror iOS sign-out semantics: no-arg sign-out clears all accounts, explicit session sign-out removes one account
- Add account switching, add-account, and sign-out actions to the user profile and auth scaffolds
- Update client sync handling and tests to cover the new session lifecycle behavior

## Testing
- `:source:api:testDebugUnitTest`
- `:source:ui:testDebugUnitTest`
- `:source:ui:compileDebugKotlin`
- `spotlessCheck`
- `detekt`
- Local UI and API validation passed under Java 21; UI lint still reports unrelated pre-existing issues outside the staged changes