### PR TITLE
Add organization API primitives for prebuilt org management

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -24,6 +24,8 @@ import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.network.model.factor.isResetFactor
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.organizations.Organization
+import com.clerk.api.organizations.OrganizationMembership
 import com.clerk.api.session.Session
 import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
@@ -508,6 +510,29 @@ object Clerk {
    */
   val activeUser: User?
     get() = activeSession?.user
+
+  /**
+   * The current user's membership in the active organization.
+   *
+   * Returns the membership whose organization matches [Session.lastActiveOrganizationId] on the
+   * current session, or `null` when there is no active organization selection.
+   */
+  val organizationMembership: OrganizationMembership?
+    get() {
+      val activeOrganizationId = session?.lastActiveOrganizationId ?: return null
+      return user?.organizationMemberships?.firstOrNull {
+        it.organization.id == activeOrganizationId
+      }
+    }
+
+  /**
+   * The active organization for the current session.
+   *
+   * Returns `null` when there is no current session, no active organization selection, or the
+   * current user does not have a matching hydrated organization membership.
+   */
+  val organization: Organization?
+    get() = organizationMembership?.organization
 
   // endregion
 

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -515,12 +515,14 @@ object Clerk {
    * The current user's membership in the active organization.
    *
    * Returns the membership whose organization matches [Session.lastActiveOrganizationId] on the
-   * current session, or `null` when there is no active organization selection.
+   * active session. Returns `null` when there is no active session, no active organization
+   * selection, or the user has no matching hydrated organization membership.
    */
   val organizationMembership: OrganizationMembership?
     get() {
-      val activeOrganizationId = session?.lastActiveOrganizationId ?: return null
-      return user?.organizationMemberships?.firstOrNull {
+      val activeSession = activeSession ?: return null
+      val activeOrganizationId = activeSession.lastActiveOrganizationId ?: return null
+      return activeSession.user?.organizationMemberships?.firstOrNull {
         it.organization.id == activeOrganizationId
       }
     }

--- a/source/api/src/main/kotlin/com/clerk/api/network/ClerkPaginatedResponse.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ClerkPaginatedResponse.kt
@@ -11,4 +11,6 @@ data class ClerkPaginatedResponse<T>(
   val data: List<T>,
   /** The total count of resources */
   val totalCount: Int,
+  /** Whether organization role updates are temporarily disabled while roles migrate. */
+  val hasRoleSetMigration: Boolean? = null,
 )

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationDomain.kt
@@ -42,6 +42,33 @@ data class OrganizationDomain(
   val publicOrganizationData: PublicOrganizationData? = null,
   val totalPendingSuggestions: Int,
 ) {
+  /** The typed enrollment mode for new users joining an organization through this domain. */
+  sealed class EnrollmentMode(val value: String) {
+    data object ManualInvitation : EnrollmentMode("manual_invitation")
+
+    data object AutomaticInvitation : EnrollmentMode("automatic_invitation")
+
+    data object AutomaticSuggestion : EnrollmentMode("automatic_suggestion")
+
+    data class Unknown(val rawValue: String) : EnrollmentMode(rawValue)
+
+    companion object {
+      fun fromValue(value: String): EnrollmentMode =
+        when (value) {
+          ManualInvitation.value -> ManualInvitation
+          AutomaticInvitation.value -> AutomaticInvitation
+          AutomaticSuggestion.value -> AutomaticSuggestion
+          else -> Unknown(value)
+        }
+    }
+  }
+
+  val enrollmentModeType: EnrollmentMode
+    get() = EnrollmentMode.fromValue(enrollmentMode)
+
+  val isVerified: Boolean
+    get() = verification?.status == "verified"
+
   /**
    * Represents the verification details for an organization domain.
    *
@@ -123,6 +150,13 @@ suspend fun OrganizationDomain.updateEnrollmentMode(
     enrollmentMode = enrollmentMode,
     deletePending = deletePending,
   )
+}
+
+suspend fun OrganizationDomain.updateEnrollmentMode(
+  enrollmentMode: OrganizationDomain.EnrollmentMode,
+  deletePending: Boolean? = null,
+): ClerkResult<OrganizationDomain, ClerkErrorResponse> {
+  return updateEnrollmentMode(enrollmentMode = enrollmentMode.value, deletePending = deletePending)
 }
 
 /**

--- a/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationMembership.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/organizations/OrganizationMembership.kt
@@ -5,8 +5,27 @@ import com.clerk.api.network.model.deleted.DeletedObject
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.userdata.PublicUserData
 import com.clerk.api.network.serialization.ClerkResult
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
+
+/** Clerk-provided organization system permission keys. */
+@Serializable
+enum class OrganizationSystemPermission(val value: String) {
+  @SerialName("org:sys_profile:manage") MANAGE_PROFILE("org:sys_profile:manage"),
+  @SerialName("org:sys_profile:delete") DELETE_PROFILE("org:sys_profile:delete"),
+  @SerialName("org:sys_memberships:read") READ_MEMBERSHIPS("org:sys_memberships:read"),
+  @SerialName("org:sys_memberships:manage") MANAGE_MEMBERSHIPS("org:sys_memberships:manage"),
+  @SerialName("org:sys_domains:read") READ_DOMAINS("org:sys_domains:read"),
+  @SerialName("org:sys_domains:manage") MANAGE_DOMAINS("org:sys_domains:manage"),
+  @SerialName("org:sys_billing:read") READ_BILLING("org:sys_billing:read"),
+  @SerialName("org:sys_billing:manage") MANAGE_BILLING("org:sys_billing:manage"),
+  @SerialName("org:sys_api_keys:read") READ_API_KEYS("org:sys_api_keys:read"),
+  @SerialName("org:sys_api_keys:manage") MANAGE_API_KEYS("org:sys_api_keys:manage");
+
+  val key: String
+    get() = value
+}
 
 /**
  * The [OrganizationMembership] object is the model around an organization membership entity and
@@ -35,7 +54,47 @@ data class OrganizationMembership(
   val createdAt: Long,
   /** The timestamp when the organization membership was last updated */
   val updatedAt: Long,
-)
+) {
+  /** Returns whether this membership includes the provided organization system permission. */
+  fun hasPermission(permission: OrganizationSystemPermission): Boolean {
+    return hasPermission(permission.value)
+  }
+
+  /** Returns whether this membership includes the provided organization permission key. */
+  fun hasPermission(permission: String): Boolean {
+    return permissions?.contains(permission) == true
+  }
+
+  val canManageProfile: Boolean
+    get() = hasPermission(OrganizationSystemPermission.MANAGE_PROFILE)
+
+  val canDeleteOrganization: Boolean
+    get() = hasPermission(OrganizationSystemPermission.DELETE_PROFILE)
+
+  val canReadMemberships: Boolean
+    get() = hasPermission(OrganizationSystemPermission.READ_MEMBERSHIPS)
+
+  val canManageMemberships: Boolean
+    get() = hasPermission(OrganizationSystemPermission.MANAGE_MEMBERSHIPS)
+
+  val canReadDomains: Boolean
+    get() = hasPermission(OrganizationSystemPermission.READ_DOMAINS)
+
+  val canManageDomains: Boolean
+    get() = hasPermission(OrganizationSystemPermission.MANAGE_DOMAINS)
+
+  val canReadBilling: Boolean
+    get() = hasPermission(OrganizationSystemPermission.READ_BILLING)
+
+  val canManageBilling: Boolean
+    get() = hasPermission(OrganizationSystemPermission.MANAGE_BILLING)
+
+  val canReadApiKeys: Boolean
+    get() = hasPermission(OrganizationSystemPermission.READ_API_KEYS)
+
+  val canManageApiKeys: Boolean
+    get() = hasPermission(OrganizationSystemPermission.MANAGE_API_KEYS)
+}
 
 /**
  * Updates the role of a member within the organization.

--- a/source/api/src/test/java/com/clerk/api/network/ClerkPaginatedResponseTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/ClerkPaginatedResponseTest.kt
@@ -1,0 +1,45 @@
+package com.clerk.api.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ClerkPaginatedResponseTest {
+
+  @Test
+  fun `decodes role set migration flag when present`() {
+    val response =
+      ClerkApi.json.decodeFromString<ClerkPaginatedResponse<String>>(
+        """
+        {
+          "data": ["item"],
+          "total_count": 1,
+          "has_role_set_migration": true
+        }
+        """
+          .trimIndent()
+      )
+
+    assertEquals(listOf("item"), response.data)
+    assertEquals(1, response.totalCount)
+    assertEquals(true, response.hasRoleSetMigration)
+  }
+
+  @Test
+  fun `hasRoleSetMigration is null when omitted`() {
+    val response =
+      ClerkApi.json.decodeFromString<ClerkPaginatedResponse<String>>(
+        """
+        {
+          "data": [],
+          "total_count": 0
+        }
+        """
+          .trimIndent()
+      )
+
+    assertEquals(emptyList<String>(), response.data)
+    assertEquals(0, response.totalCount)
+    assertNull(response.hasRoleSetMigration)
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/organizations/OrganizationDomainTest.kt
+++ b/source/api/src/test/java/com/clerk/api/organizations/OrganizationDomainTest.kt
@@ -1,0 +1,80 @@
+package com.clerk.api.organizations
+
+import com.clerk.api.network.ClerkApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OrganizationDomainTest {
+
+  @Test
+  fun `enrollmentModeType maps known enrollment modes`() {
+    val knownModes =
+      mapOf(
+        "manual_invitation" to OrganizationDomain.EnrollmentMode.ManualInvitation,
+        "automatic_invitation" to OrganizationDomain.EnrollmentMode.AutomaticInvitation,
+        "automatic_suggestion" to OrganizationDomain.EnrollmentMode.AutomaticSuggestion,
+      )
+
+    knownModes.forEach { (rawValue, enrollmentMode) ->
+      assertEquals(enrollmentMode, organizationDomain(enrollmentMode = rawValue).enrollmentModeType)
+    }
+  }
+
+  @Test
+  fun `enrollmentModeType preserves unknown enrollment modes`() {
+    val domain = organizationDomain(enrollmentMode = "future_mode")
+
+    assertEquals(
+      OrganizationDomain.EnrollmentMode.Unknown("future_mode"),
+      domain.enrollmentModeType,
+    )
+  }
+
+  @Test
+  fun `isVerified reflects verification status`() {
+    assertTrue(organizationDomain(verificationStatus = "verified").isVerified)
+    assertFalse(organizationDomain(verificationStatus = "unverified").isVerified)
+    assertFalse(organizationDomain(verificationStatus = null).isVerified)
+  }
+
+  private fun organizationDomain(
+    enrollmentMode: String = "manual_invitation",
+    verificationStatus: String? = "verified",
+  ): OrganizationDomain {
+    val verification =
+      if (verificationStatus == null) {
+        "null"
+      } else {
+        """
+        {
+          "status": "$verificationStatus",
+          "strategy": "email_code",
+          "attempts": 0,
+          "expire_at": null
+        }
+        """
+          .trimIndent()
+      }
+
+    return ClerkApi.json.decodeFromString(
+      """
+      {
+        "id": "orgdmn_123",
+        "name": "example.com",
+        "organization_id": "org_123",
+        "enrollment_mode": "$enrollmentMode",
+        "verification": $verification,
+        "affiliation_email_address": null,
+        "total_pending_invitations": 0,
+        "created_at": 1713200000000,
+        "updated_at": 1713200000000,
+        "public_organization_data": null,
+        "total_pending_suggestions": 0
+      }
+      """
+        .trimIndent()
+    )
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/organizations/OrganizationMembershipTest.kt
+++ b/source/api/src/test/java/com/clerk/api/organizations/OrganizationMembershipTest.kt
@@ -1,0 +1,85 @@
+package com.clerk.api.organizations
+
+import kotlinx.serialization.json.JsonObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OrganizationMembershipTest {
+
+  @Test
+  fun `permission helpers read raw and system permission keys`() {
+    val membership =
+      organizationMembership(
+        permissions =
+          listOf(
+            "custom:permission",
+            OrganizationSystemPermission.MANAGE_PROFILE.value,
+            OrganizationSystemPermission.DELETE_PROFILE.value,
+            OrganizationSystemPermission.READ_MEMBERSHIPS.value,
+            OrganizationSystemPermission.MANAGE_MEMBERSHIPS.value,
+            OrganizationSystemPermission.READ_DOMAINS.value,
+            OrganizationSystemPermission.MANAGE_DOMAINS.value,
+            OrganizationSystemPermission.READ_BILLING.value,
+            OrganizationSystemPermission.MANAGE_BILLING.value,
+            OrganizationSystemPermission.READ_API_KEYS.value,
+            OrganizationSystemPermission.MANAGE_API_KEYS.value,
+          )
+      )
+
+    assertTrue(membership.hasPermission("custom:permission"))
+    assertTrue(membership.hasPermission(OrganizationSystemPermission.MANAGE_PROFILE))
+    assertTrue(membership.canManageProfile)
+    assertTrue(membership.canDeleteOrganization)
+    assertTrue(membership.canReadMemberships)
+    assertTrue(membership.canManageMemberships)
+    assertTrue(membership.canReadDomains)
+    assertTrue(membership.canManageDomains)
+    assertTrue(membership.canReadBilling)
+    assertTrue(membership.canManageBilling)
+    assertTrue(membership.canReadApiKeys)
+    assertTrue(membership.canManageApiKeys)
+  }
+
+  @Test
+  fun `permission helpers return false for missing permissions`() {
+    val membership = organizationMembership(permissions = null)
+
+    assertFalse(membership.hasPermission("custom:permission"))
+    assertFalse(membership.hasPermission(OrganizationSystemPermission.MANAGE_PROFILE))
+    assertFalse(membership.canManageProfile)
+    assertFalse(membership.canDeleteOrganization)
+    assertFalse(membership.canReadMemberships)
+    assertFalse(membership.canManageMemberships)
+    assertFalse(membership.canReadDomains)
+    assertFalse(membership.canManageDomains)
+    assertFalse(membership.canReadBilling)
+    assertFalse(membership.canManageBilling)
+    assertFalse(membership.canReadApiKeys)
+    assertFalse(membership.canManageApiKeys)
+  }
+
+  private fun organizationMembership(permissions: List<String>?): OrganizationMembership {
+    return OrganizationMembership(
+      id = "orgmem_123",
+      publicMetadata = JsonObject(emptyMap()),
+      role = "org:admin",
+      roleName = "Admin",
+      permissions = permissions,
+      organization =
+        Organization(
+          id = "org_123",
+          name = "Acme",
+          slug = "acme",
+          imageUrl = "https://example.com/acme.png",
+          maxAllowedMemberships = 5,
+          adminDeleteEnabled = true,
+          createdAt = 1_000,
+          updatedAt = 1_000,
+          publicMetadata = JsonObject(emptyMap()),
+        ),
+      createdAt = 1_000,
+      updatedAt = 1_000,
+    )
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkOrganizationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkOrganizationTest.kt
@@ -1,0 +1,110 @@
+package com.clerk.api.sdk
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.client.Client
+import com.clerk.api.organizations.Organization
+import com.clerk.api.organizations.OrganizationMembership
+import com.clerk.api.session.Session
+import com.clerk.api.user.User
+import kotlinx.serialization.json.JsonObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ClerkOrganizationTest {
+
+  @After
+  fun tearDown() {
+    Clerk.updateClient(Client())
+    Clerk.clearSessionAndUserState()
+  }
+
+  @Test
+  fun `organizationMembership returns membership matching active organization id`() {
+    val activeOrganization = organization(id = "org_active", name = "Acme")
+    val otherOrganization = organization(id = "org_other", name = "Other")
+    val activeMembership = membership(id = "orgmem_active", organization = activeOrganization)
+    val otherMembership = membership(id = "orgmem_other", organization = otherOrganization)
+    val session =
+      session(
+        lastActiveOrganizationId = activeOrganization.id,
+        user = user(memberships = listOf(otherMembership, activeMembership)),
+      )
+
+    Clerk.updateClient(Client(sessions = listOf(session), lastActiveSessionId = session.id))
+
+    assertEquals(activeMembership, Clerk.organizationMembership)
+    assertEquals(activeOrganization, Clerk.organization)
+  }
+
+  @Test
+  fun `organizationMembership returns null when no active organization id exists`() {
+    val membership = membership(organization = organization(id = "org_active", name = "Acme"))
+    val session =
+      session(lastActiveOrganizationId = null, user = user(memberships = listOf(membership)))
+
+    Clerk.updateClient(Client(sessions = listOf(session), lastActiveSessionId = session.id))
+
+    assertNull(Clerk.organizationMembership)
+    assertNull(Clerk.organization)
+  }
+
+  private fun session(lastActiveOrganizationId: String?, user: User): Session {
+    return Session(
+      id = "sess_123",
+      status = Session.SessionStatus.ACTIVE,
+      expireAt = 10_000,
+      lastActiveAt = 1_000,
+      lastActiveOrganizationId = lastActiveOrganizationId,
+      user = user,
+      createdAt = 1_000,
+      updatedAt = 1_000,
+    )
+  }
+
+  @Suppress("DEPRECATION")
+  private fun user(memberships: List<OrganizationMembership>): User {
+    return User(
+      id = "user_123",
+      hasImage = false,
+      imageUrl = "https://example.com/user.png",
+      organizationMemberships = memberships,
+      passkeys = emptyList(),
+      passwordEnabled = true,
+      phoneNumbers = emptyList(),
+      totpEnabled = false,
+      twoFactorEnabled = false,
+      updatedAt = 1_000,
+    )
+  }
+
+  private fun membership(
+    id: String = "orgmem_123",
+    organization: Organization,
+  ): OrganizationMembership {
+    return OrganizationMembership(
+      id = id,
+      publicMetadata = JsonObject(emptyMap()),
+      role = "org:admin",
+      roleName = "Admin",
+      organization = organization,
+      createdAt = 1_000,
+      updatedAt = 1_000,
+    )
+  }
+
+  private fun organization(id: String, name: String): Organization {
+    return Organization(
+      id = id,
+      name = name,
+      slug = name.lowercase(),
+      imageUrl = "https://example.com/$id.png",
+      maxAllowedMemberships = 5,
+      adminDeleteEnabled = true,
+      createdAt = 1_000,
+      updatedAt = 1_000,
+      publicMetadata = JsonObject(emptyMap()),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Added active organization convenience accessors on `Clerk` for the current organization and membership.
- Introduced typed organization permission keys and membership permission helpers, including profile, membership, domain, billing, and API key checks.
- Added typed domain enrollment mode support plus `isVerified` and a typed `updateEnrollmentMode` overload.
- Extended `ClerkPaginatedResponse` with nullable `hasRoleSetMigration` for role-editing gates during migration.
- Added focused unit tests covering organization resolution, permission helpers, enrollment mode decoding, and pagination decoding.

## Testing
- `:source:api:spotlessCheck` passed.
- `:source:api:detekt` passed.
- `:source:api:testDebugUnitTest` passed.
- Targeted release unit tests for the new classes passed.
- `:source:api:checkLegacyAbi` ran successfully.
- `:source:api:test` and `:source:api:lintDebug` still fail on unrelated existing issues elsewhere in the module.