### PR TITLE
Mirror iOS OTP sign-in behavior in Auth.signInWithOtp

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -26,7 +26,6 @@ import com.clerk.api.session.Session
 import com.clerk.api.session.fetchToken
 import com.clerk.api.session.revoke
 import com.clerk.api.signin.SignIn
-import com.clerk.api.signin.toMap
 import com.clerk.api.signout.SignOutService
 import com.clerk.api.signup.SignUp
 import com.clerk.api.sso.OAuthProvider
@@ -209,8 +208,8 @@ class Auth internal constructor() {
   /**
    * Signs in with OTP - automatically sends the verification code.
    *
-   * This is a one-shot method that creates the sign-in and immediately prepares the first factor
-   * verification, sending the code to the specified channel.
+   * This is a one-shot method that creates the sign-in with an OTP strategy, sending the code to
+   * the specified channel.
    *
    * @param block Builder block to configure the email or phone.
    * @return A [ClerkResult] containing the [SignIn] object on success, or a [ClerkErrorResponse] on
@@ -238,29 +237,7 @@ class Auth internal constructor() {
         "locale" to Clerk.locale.value.orEmpty(),
       )
 
-    val result =
-      when (val createResult = ClerkApi.signIn.createSignIn(params)) {
-        is ClerkResult.Failure -> createResult
-        is ClerkResult.Success -> {
-          val signIn = createResult.value
-          // Prepare first factor to send the code
-          val prepareParams =
-            if (builder.email != null) {
-              SignIn.PrepareFirstFactorParams.EmailCode(
-                emailAddressId =
-                  signIn.supportedFirstFactors?.find { it.strategy == EMAIL_CODE }?.emailAddressId
-                    ?: ""
-              )
-            } else {
-              SignIn.PrepareFirstFactorParams.PhoneCode(
-                phoneNumberId =
-                  signIn.supportedFirstFactors?.find { it.strategy == PHONE_CODE }?.phoneNumberId
-                    ?: ""
-              )
-            }
-          ClerkApi.signIn.prepareSignInFirstFactor(signIn.id, prepareParams.toMap())
-        }
-      }
+    val result = ClerkApi.signIn.createSignIn(params)
     result.onFailure { emitAuthError(it) }
     return result
   }

--- a/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
+++ b/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
@@ -4,11 +4,13 @@ import com.clerk.api.Clerk
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.api.ClientApi
 import com.clerk.api.network.api.SessionApi
+import com.clerk.api.network.api.SignInApi
 import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
+import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.OAuthResult
@@ -19,6 +21,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.slot
 import io.mockk.unmockkAll
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.take
@@ -125,6 +128,50 @@ class AuthTest {
     )
     coVerify(exactly = 1) { SignUp.authenticateWithGoogleOneTap() }
   }
+
+  @Test
+  fun `signInWithOtp email creates sign in with strategy without preparing first factor`() =
+    runTest {
+      val signInApi = mockk<SignInApi>(relaxed = true)
+      val createdSignIn = SignIn(id = "sign_in_123")
+      val createParams = slot<Map<String, String>>()
+      mockkObject(ClerkApi)
+      every { ClerkApi.signIn } returns signInApi
+      coEvery { signInApi.createSignIn(capture(createParams)) } returns
+        ClerkResult.success(createdSignIn)
+
+      val result = Auth().signInWithOtp { email = "user@example.com" }
+
+      assertTrue(result is ClerkResult.Success)
+      assertSame(createdSignIn, (result as ClerkResult.Success).value)
+      assertEquals("user@example.com", createParams.captured["identifier"])
+      assertEquals("email_code", createParams.captured["strategy"])
+      assertTrue(createParams.captured.containsKey("locale"))
+      coVerify(exactly = 1) { signInApi.createSignIn(any()) }
+      coVerify(exactly = 0) { signInApi.prepareSignInFirstFactor(any(), any()) }
+    }
+
+  @Test
+  fun `signInWithOtp phone creates sign in with strategy without preparing first factor`() =
+    runTest {
+      val signInApi = mockk<SignInApi>(relaxed = true)
+      val createdSignIn = SignIn(id = "sign_in_123")
+      val createParams = slot<Map<String, String>>()
+      mockkObject(ClerkApi)
+      every { ClerkApi.signIn } returns signInApi
+      coEvery { signInApi.createSignIn(capture(createParams)) } returns
+        ClerkResult.success(createdSignIn)
+
+      val result = Auth().signInWithOtp { phone = "+15555550123" }
+
+      assertTrue(result is ClerkResult.Success)
+      assertSame(createdSignIn, (result as ClerkResult.Success).value)
+      assertEquals("+15555550123", createParams.captured["identifier"])
+      assertEquals("phone_code", createParams.captured["strategy"])
+      assertTrue(createParams.captured.containsKey("locale"))
+      coVerify(exactly = 1) { signInApi.createSignIn(any()) }
+      coVerify(exactly = 0) { signInApi.prepareSignInFirstFactor(any(), any()) }
+    }
 
   @Test
   fun `sessions exposes all sessions on the current client`() {


### PR DESCRIPTION
## Summary
- Make `Auth.signInWithOtp` follow the iOS one-shot flow by creating the sign-in with the OTP strategy and returning that result directly.
- Remove the extra first-factor preparation step that could trigger duplicate OTP deliveries.
- Add regression coverage for email and phone OTP paths to assert the create call includes the strategy and no prepare call occurs.

## Testing
- `spotlessCheck` passed.
- Focused `AuthTest` unit tests passed, including the new OTP regression cases.
- Verified the API test task locally with `ANDROID_HOME` configured for this workspace.