### PR TITLE
Add development mode warning detection to API models

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -227,6 +227,13 @@ object Clerk {
         InstanceEnvironmentType.PRODUCTION
       else InstanceEnvironmentType.DEVELOPMENT
 
+  internal val shouldShowDevelopmentModeWarning: Boolean
+    get() {
+      val displayConfig = environment?.displayConfig ?: return false
+      return displayConfig.showDevModeWarning &&
+        displayConfig.instanceEnvironmentType != InstanceEnvironmentType.PRODUCTION
+    }
+
   /**
    * A list of enabled first factor attributes, sorted by priority.
    *

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/DisplayConfig.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/DisplayConfig.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.Serializable
  * @property instanceEnvironmentType The type of environment (development, staging, production)
  * @property applicationName The display name of the application
  * @property preferredSignInStrategy The preferred sign-in strategy for the application
+ * @property showDevModeWarning Whether development mode warnings should be shown
  * @property branded Whether the application uses Clerk branding
  * @property logoImageUrl URL of the application's logo image
  * @property homeUrl The home URL of the application
@@ -32,6 +33,9 @@ internal data class DisplayConfig(
   /** The preferred sign-in strategy for the application */
   @SerialName("preferred_sign_in_strategy")
   val preferredSignInStrategy: PreferredSignInStrategy = PreferredSignInStrategy.UNKNOWN,
+
+  /** Whether development mode warnings should be shown */
+  @SerialName("show_devmode_warning") val showDevModeWarning: Boolean = false,
 
   /** Whether the application uses Clerk branding */
   @SerialName("branded") val branded: Boolean,

--- a/source/api/src/test/java/com/clerk/api/network/model/environment/DisplayConfigSerializationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/model/environment/DisplayConfigSerializationTest.kt
@@ -1,0 +1,45 @@
+package com.clerk.api.network.model.environment
+
+import com.clerk.api.network.ClerkApi
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DisplayConfigSerializationTest {
+
+  @Test
+  fun `show dev mode warning deserializes correctly`() {
+    val displayConfig = ClerkApi.json.decodeFromString<DisplayConfig>(displayConfigJson(true))
+
+    assertTrue(displayConfig.showDevModeWarning)
+  }
+
+  @Test
+  fun `show dev mode warning defaults to false`() {
+    val displayConfig =
+      ClerkApi.json.decodeFromString<DisplayConfig>(displayConfigJson(showDevModeWarning = null))
+
+    assertFalse(displayConfig.showDevModeWarning)
+  }
+
+  private fun displayConfigJson(showDevModeWarning: Boolean?): String {
+    val showDevModeWarningJson =
+      showDevModeWarning?.let { """"show_devmode_warning":$it,""" }.orEmpty()
+
+    return """
+      {
+        "instance_environment_type":"development",
+        "application_name":"Test App",
+        "preferred_sign_in_strategy":"password",
+        $showDevModeWarningJson
+        "branded":true,
+        "logo_image_url":"https://example.com/logo.png",
+        "home_url":"/",
+        "privacy_policy_url":null,
+        "terms_url":null,
+        "google_one_tap_client_id":null
+      }
+    """
+      .trimIndent()
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkDevelopmentModeWarningTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkDevelopmentModeWarningTest.kt
@@ -1,0 +1,85 @@
+package com.clerk.api.sdk
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.environment.AuthConfig
+import com.clerk.api.network.model.environment.DisplayConfig
+import com.clerk.api.network.model.environment.Environment
+import com.clerk.api.network.model.environment.InstanceEnvironmentType
+import com.clerk.api.network.model.environment.UserSettings
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClerkDevelopmentModeWarningTest {
+
+  @Test
+  fun `shouldShowDevelopmentModeWarning returns true for development with warning enabled`() {
+    Clerk.updateEnvironment(
+      testEnvironment(
+        instanceEnvironmentType = InstanceEnvironmentType.DEVELOPMENT,
+        showDevModeWarning = true,
+      )
+    )
+
+    assertTrue(Clerk.shouldShowDevelopmentModeWarning)
+  }
+
+  @Test
+  fun `shouldShowDevelopmentModeWarning returns false for production`() {
+    Clerk.updateEnvironment(
+      testEnvironment(
+        instanceEnvironmentType = InstanceEnvironmentType.PRODUCTION,
+        showDevModeWarning = true,
+      )
+    )
+
+    assertFalse(Clerk.shouldShowDevelopmentModeWarning)
+  }
+
+  @Test
+  fun `shouldShowDevelopmentModeWarning returns false when warning disabled`() {
+    Clerk.updateEnvironment(
+      testEnvironment(
+        instanceEnvironmentType = InstanceEnvironmentType.DEVELOPMENT,
+        showDevModeWarning = false,
+      )
+    )
+
+    assertFalse(Clerk.shouldShowDevelopmentModeWarning)
+  }
+
+  private fun testEnvironment(
+    instanceEnvironmentType: InstanceEnvironmentType,
+    showDevModeWarning: Boolean,
+  ): Environment {
+    return Environment(
+      authConfig = AuthConfig(singleSessionMode = false),
+      displayConfig =
+        DisplayConfig(
+          instanceEnvironmentType = instanceEnvironmentType,
+          applicationName = "Test App",
+          showDevModeWarning = showDevModeWarning,
+          branded = true,
+          logoImageUrl = "https://example.com/logo.png",
+          homeUrl = "/",
+          privacyPolicyUrl = null,
+          termsUrl = null,
+          googleOneTapClientId = null,
+        ),
+      userSettings =
+        UserSettings(
+          attributes = emptyMap(),
+          signUp =
+            UserSettings.SignUpUserSettings(
+              customActionRequired = false,
+              progressive = false,
+              mode = "public",
+              legalConsentEnabled = false,
+            ),
+          social = emptyMap(),
+          actions = UserSettings.Actions(),
+          passkeySettings = null,
+        ),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add `showDevModeWarning` to `DisplayConfig`, serialized from `show_devmode_warning` with a default of `false`
- Add internal `Clerk.shouldShowDevelopmentModeWarning` to gate warnings on the server flag plus non-production environment data
- Add unit coverage for deserialization and warning-gating behavior across development, production, and disabled cases

## Testing
- `./gradlew spotlessApply`
- Focused API unit tests for the new `DisplayConfig` serialization and `Clerk` warning helper passed
- `./gradlew :source:api:test` was run, but the full suite still has unrelated pre-existing failures outside this change