### PR TITLE
Stabilize custom OTP Trailblaze replay

### DIFF
--- a/scripts/run-trailblaze-tests.sh
+++ b/scripts/run-trailblaze-tests.sh
@@ -59,6 +59,7 @@ wait_for_android_device() {
   fi
 
   adb -s "$serial" shell input keyevent 82 >/dev/null 2>&1 || true
+  dismiss_android_system_interruptions "$serial"
   reset_adb_forward_state "$serial"
   verify_adb_forward "$serial"
 }
@@ -85,6 +86,21 @@ verify_adb_forward() {
   adb -s "$serial" wait-for-device
   adb -s "$serial" forward "tcp:$port" "tcp:$port"
   adb -s "$serial" forward --remove "tcp:$port" >/dev/null 2>&1 || true
+}
+
+dismiss_android_system_interruptions() {
+  local serial="$1"
+
+  # CI can surface stale launcher ANR dialogs above the e2e app before the first assertion.
+  adb -s "$serial" shell am force-stop com.google.android.apps.nexuslauncher >/dev/null 2>&1 || true
+  adb -s "$serial" shell am force-stop com.android.launcher3 >/dev/null 2>&1 || true
+  adb -s "$serial" shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS >/dev/null 2>&1 || true
+}
+
+trailblaze_log_has_failure() {
+  local log_file="$1"
+
+  grep -Eq "FAILED:|Recording failed|failed tool:|Results: .* [1-9][0-9]* failed" "$log_file"
 }
 
 if [[ "${TRAILBLAZE_WARN_PLACEHOLDER_KEY:-1}" == "1" ]] &&
@@ -155,6 +171,11 @@ while true; do
   "${cmd[@]}" 2>&1 | tee "$log_file"
   status=${PIPESTATUS[0]}
   set -e
+
+  if [[ "$status" -eq 0 ]] && trailblaze_log_has_failure "$log_file"; then
+    echo "Trailblaze reported a failed run in $log_file despite exiting successfully."
+    status=1
+  fi
 
   if [[ "$status" -eq 0 ]]; then
     exit 0

--- a/trails/e2e/sign-in-profile-sign-out/android-phone.trail.yaml
+++ b/trails/e2e/sign-in-profile-sign-out/android-phone.trail.yaml
@@ -50,11 +50,11 @@
                   textRegex: Phone number
           - inputText:
               text: 555-555-0100
-          - tapOnElementBySelector:
-              reason: Submit the phone number to request an OTP.
-              nodeSelector:
-                androidAccessibility:
-                  textRegex: Continue
+              hideKeyboardAfter: false
+          - tapOnPoint:
+              reasoning: Submit the phone number to request an OTP.
+              x: 540
+              y: 1257
           - assertVisibleBySelector:
               reason: Verify the verification code field is visible.
               nodeSelector:
@@ -67,11 +67,11 @@
                   textRegex: Verification code
           - inputText:
               text: "424242"
-          - tapOnElementBySelector:
-              reason: Verify the custom OTP code.
-              nodeSelector:
-                androidAccessibility:
-                  textRegex: Verify
+              hideKeyboardAfter: false
+          - tapOnPoint:
+              reasoning: Verify the custom OTP code.
+              x: 540
+              y: 1257
           - assertVisibleBySelector:
               reason: Verify the custom profile is shown after sign-in.
               nodeSelector:
@@ -150,6 +150,7 @@
                   textRegex: Check your phone
           - inputText:
               text: "424242"
+              hideKeyboardAfter: false
           - assertVisibleBySelector:
               reason: Verify the prebuilt user profile account screen is shown after sign-in.
               nodeSelector:


### PR DESCRIPTION
## Summary
- keep Trailblaze text input from auto-dismissing the keyboard during OTP entry
- use the recorded custom OTP button coordinates for the two submit taps after text entry

## Verification
- ANDROID_HOME="/Users/sam/Library/Android/sdk" ORG_GRADLE_PROJECT_E2E_CLERK_PUBLISHABLE_KEY="pk_test_bGVhcm5pbmctbW9sbHktMzguY2xlcmsuYWNjb3VudHMuZGV2JA" TRAILBLAZE_DEVICE="android/emulator-5554" TRAILBLAZE_EXTRA_ARGS="--no-capture-video" TRAILBLAZE_ADB_TIMEOUT_MS="30000" TRAILBLAZE_ATTEMPTS="2" scripts/run-trailblaze-tests.sh
- bash -n scripts/run-trailblaze-tests.sh && git diff --check