### PR TITLE
fix(api): defer auth state sync until explicit session activation

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/network/middleware/incoming/ClientSyncingMiddleware.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/middleware/incoming/ClientSyncingMiddleware.kt
@@ -63,7 +63,12 @@ internal class ClientSyncingMiddleware(private val json: Json) : Interceptor {
                 // Extract and set the client
                 val client = json.decodeFromJsonElement<Client>(clientJson)
                 ClerkLog.d("Client synced: ${client.id}")
-                Clerk.updateClient(client)
+                if (shouldDeferSessionStateSync(request = request, jsonObject = jsonElement)) {
+                  ClerkLog.d("Client sync deferred session state updates for auth completion flow")
+                  Clerk.client = client
+                } else {
+                  Clerk.updateClient(client)
+                }
               }
             }
           }
@@ -154,5 +159,27 @@ internal class ClientSyncingMiddleware(private val json: Json) : Interceptor {
 
   private fun isSignUpCreationRequest(path: String, method: String): Boolean {
     return method == "POST" && path.endsWith("/${ApiPaths.Client.SignUp.BASE}")
+  }
+
+  private fun shouldDeferSessionStateSync(request: Request, jsonObject: JsonObject): Boolean {
+    val requestPath = request.url.encodedPath
+    val isSignInCompletion =
+      requestPath.endsWith("/${ApiPaths.Client.SignIn.ATTEMPT_FIRST_FACTOR}") ||
+        requestPath.endsWith("/${ApiPaths.Client.SignIn.ATTEMPT_SECOND_FACTOR}")
+    val isSignUpCompletion = requestPath.endsWith("/${ApiPaths.Client.SignUp.ATTEMPT_VERIFICATION}")
+    if (!isSignInCompletion && !isSignUpCompletion) return false
+
+    val responseElement = jsonObject["response"] ?: return false
+    val isCompleteSignIn =
+      runCatching { json.decodeFromJsonElement<SignIn>(responseElement) }
+        .getOrNull()
+        ?.let { it.status == SignIn.Status.COMPLETE && it.createdSessionId != null }
+        ?: false
+    val isCompleteSignUp =
+      runCatching { json.decodeFromJsonElement<SignUp>(responseElement) }
+        .getOrNull()
+        ?.let { it.status == SignUp.Status.COMPLETE && it.createdSessionId != null }
+        ?: false
+    return isCompleteSignIn || isCompleteSignUp
   }
 }

--- a/source/api/src/test/java/com/clerk/api/network/middleware/incoming/ClientSyncingMiddlewareTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/middleware/incoming/ClientSyncingMiddlewareTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.encodeToString
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Protocol
@@ -178,6 +179,65 @@ class ClientSyncingMiddlewareTest {
 
     assertEquals(client, Clerk.client)
     assertEquals(listOf(session), Clerk.sessionsFlow.value)
+  }
+
+  @Test
+  fun `intercept defers auth state updates for complete sign up verification`() {
+    val middleware = ClientSyncingMiddleware(json = ClerkApi.json)
+    val session = testSession("sess_from_signup")
+    val syncedClient =
+      Client(
+        id = "client_signup",
+        sessions = listOf(session),
+        lastActiveSessionId = session.id,
+      )
+
+    val request =
+      Request.Builder()
+        .url("https://api.clerk.com/v1/client/sign_ups/su_123/attempt_verification")
+        .post("".toRequestBody("application/x-www-form-urlencoded".toMediaType()))
+        .build()
+
+    val responseBody =
+      """
+      {
+        "response": {
+          "id": "su_123",
+          "status": "complete",
+          "required_fields": [],
+          "optional_fields": [],
+          "missing_fields": [],
+          "unverified_fields": [],
+          "verifications": {},
+          "password_enabled": false,
+          "created_session_id": "${session.id}",
+          "created_at": 0,
+          "updated_at": 0
+        },
+        "client": ${ClerkApi.json.encodeToString(syncedClient)}
+      }
+      """
+        .trimIndent()
+        .toResponseBody("application/json".toMediaType())
+
+    val response =
+      Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .body(responseBody)
+        .build()
+
+    val chain = mockk<Interceptor.Chain>()
+    every { chain.request() } returns request
+    every { chain.proceed(request) } returns response
+
+    middleware.intercept(chain)
+
+    assertEquals(syncedClient, Clerk.client)
+    assertEquals(emptyList<Session>(), Clerk.sessionsFlow.value)
+    assertEquals(null, Clerk.sessionFlow.value)
   }
 
   private fun testSession(id: String): Session =


### PR DESCRIPTION
### Motivation
- Prevent the SDK from emitting `SignedIn`/non-null `userFlow` during OTP sign-in/sign-up verification before app code has called `auth.setActive(...)`, addressing the behavior reported in issue #644.
- Ensure the client payload is still synced but avoid immediately propagating session/user flows for flows that return a `created_session_id` until explicit activation occurs.

### Description
- Update `ClientSyncingMiddleware` to detect sign-in/sign-up verification completion on endpoints `client/sign_ins/{id}/attempt_first_factor`, `.../attempt_second_factor`, and `client/sign_ups/{id}/attempt_verification`, and when the decoded `SignIn`/`SignUp` is `COMPLETE` with a non-null `created_session_id`, defer session/user flow updates.
- When deferral is required, the middleware now assigns the raw `Client` to `Clerk.client` instead of calling `Clerk.updateClient(...)` so the SDK does not update `_session`/`_userFlow` prematurely; otherwise it retains the previous behavior and calls `Clerk.updateClient(...)`.
- Add helper `shouldDeferSessionStateSync(...)` to encapsulate detection logic and keep `emitAuthEvents(...)` behavior unchanged.
- Add a regression test `intercept defers auth state updates for complete sign up verification` to `ClientSyncingMiddlewareTest` that verifies the middleware updates `Clerk.client` but does not mutate `sessionsFlow`/`sessionFlow` for a completed sign-up verification payload.

### Testing
- Added unit test `intercept defers auth state updates for complete sign up verification` in `source/api/src/test/java/com/clerk/api/network/middleware/incoming/ClientSyncingMiddlewareTest.kt` to cover the regression case; this test is included in the commit.
- Attempted to run the specific middleware tests with `./gradlew :source:api:test --tests "com.clerk.api.network.middleware.incoming.ClientSyncingMiddlewareTest"` but the invocation failed in this environment because the project Gradle task did not accept `--tests` as used.
- Attempted `./gradlew :source:api:tasks --all` for broader validation but the build failed in this environment due to repository state (`No such reference 'origin/main'`) which prevents Spotless/task creation; no automated tests completed successfully here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fd0fef3648322a6560129454af8c6)