### PR TITLE
fix(ui): respect dark mode in dev warning

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: "17"
-          distribution: "temurin"
+          java-version: "21"
+          distribution: "zulu"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ authentication and reset password. See the [README](samples/custom-flows/README.
 and includes Sign in with Google, Passkey authentication, Sign out, and Email Code Authentication. See the [README](samples/linear-clone/README.md) for more info.
 
 #### Prebuilt UI
-`samples/prebuilt-ui`: This is an example that shows how to integrate the Clerk prebuilt UI components. See the [README](samples/prebuilt-ui/README.md) for more info. 
+`samples/prebuilt-ui`: This is an example that shows how to integrate the Clerk prebuilt UI components. See the [README](samples/prebuilt-ui/README.md) for more info.
 
 ## Documentation
 

--- a/source/api/src/main/AndroidManifest.xml
+++ b/source/api/src/main/AndroidManifest.xml
@@ -11,11 +11,11 @@
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|keyboard|keyboardHidden"
             android:exported="false"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar" />
+            android:theme="@style/Theme.Clerk.AuthBridge" />
         <activity
             android:name="com.clerk.api.sso.SSOReceiverActivity"
             android:exported="true"
-            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+            android:theme="@style/Theme.Clerk.AuthBridge">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -330,6 +330,15 @@ object Clerk {
   val organizationDefaultRoleKey: String?
     get() = environment?.organizationSettings?.domains?.defaultRole
 
+  private val _organizationLogoUrlFlow = MutableStateFlow<String?>(null)
+
+  /**
+   * Reactive image URL for the application logo used in authentication UI components.
+   *
+   * Emits `null` until the SDK environment is initialized or when no logo URL is configured.
+   */
+  val organizationLogoUrlFlow: StateFlow<String?> = _organizationLogoUrlFlow.asStateFlow()
+
   /**
    * The image URL for the application logo used in authentication UI components.
    *
@@ -847,6 +856,7 @@ object Clerk {
    */
   internal fun updateEnvironment(environment: Environment) {
     this.environment = environment
+    _organizationLogoUrlFlow.value = environment.displayConfig.logoImageUrl
     _multiSessionModeIsEnabled.value = !environment.authConfig.singleSessionMode
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/Constants.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Constants.kt
@@ -9,6 +9,7 @@ object Constants {
   object Strategy {
     const val PHONE_CODE = "phone_code"
     const val EMAIL_CODE = "email_code"
+    const val EMAIL_LINK = "email_link"
     const val TOTP = "totp"
     const val BACKUP_CODE = "backup_code"
     const val PASSWORD = "password"

--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -14,6 +14,11 @@ import com.clerk.api.auth.builders.SignUpBuilder
 import com.clerk.api.auth.builders.SignUpWithIdTokenBuilder
 import com.clerk.api.auth.types.IdTokenProvider
 import com.clerk.api.log.ClerkLog
+import com.clerk.api.magiclink.NativeMagicLinkAuthResult
+import com.clerk.api.magiclink.NativeMagicLinkError
+import com.clerk.api.magiclink.NativeMagicLinkManager
+import com.clerk.api.magiclink.NativeMagicLinkService
+import com.clerk.api.magiclink.canHandleNativeMagicLink
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.api.SET_ACTIVE_INTENT_SELECT_ORG
 import com.clerk.api.network.model.client.Client
@@ -126,6 +131,10 @@ class Auth internal constructor() {
    */
   val currentSignUp: SignUp?
     get() = if (Clerk.clientInitialized) Clerk.client.signUp else null
+
+  /** Native magic-link manager for PKCE-bound email link flows. */
+  val nativeMagicLink: NativeMagicLinkManager
+    get() = NativeMagicLinkService
 
   /**
    * The sessions currently known on this client.
@@ -369,6 +378,33 @@ class Auth internal constructor() {
     val result = ClerkApi.signIn.createSignIn(params)
     result.onFailure { emitAuthError(it) }
     return result
+  }
+
+  /**
+   * Starts a native email-link sign-in flow secured by PKCE.
+   *
+   * The flow sends only a code challenge to Clerk and expects completion through a deep-link
+   * callback carrying `flow_id` and `approval_token`.
+   */
+  suspend fun startEmailLinkSignIn(email: String): ClerkResult<SignIn, NativeMagicLinkError> {
+    return nativeMagicLink.startEmailLinkSignIn(email)
+  }
+
+  /**
+   * Handles a native magic-link deep-link callback and completes sign-in or sign-up using a ticket.
+   */
+  suspend fun handleMagicLinkDeepLink(
+    uri: Uri
+  ): ClerkResult<NativeMagicLinkAuthResult, NativeMagicLinkError> {
+    return nativeMagicLink.handleMagicLinkDeepLink(uri)
+  }
+
+  /** Completes a pending native magic-link flow using callback values from the deep link. */
+  suspend fun completeMagicLink(
+    flowId: String,
+    approvalToken: String,
+  ): ClerkResult<NativeMagicLinkAuthResult, NativeMagicLinkError> {
+    return nativeMagicLink.complete(flowId, approvalToken)
   }
 
   // endregion
@@ -816,10 +852,10 @@ class Auth internal constructor() {
   // region Deep Link Handling
 
   /**
-   * Handles OAuth/SSO deep link callbacks.
+   * Handles OAuth/SSO and native magic-link deep link callbacks.
    *
-   * Call this method from your Activity when receiving a deep link callback from an OAuth or SSO
-   * provider.
+   * Call this method from your Activity when receiving a deep link callback from Clerk
+   * authentication flows.
    *
    * @param uri The deep link URI received from the callback.
    * @return true if the URI was handled, false otherwise.
@@ -827,19 +863,24 @@ class Auth internal constructor() {
    * ### Example usage:
    * ```kotlin
    * // In your Activity's onCreate or onNewIntent
-   * clerk.auth.handle(intent.data)
+   * lifecycleScope.launch {
+   *   clerk.auth.handle(intent.data)
+   * }
    * ```
    */
-  fun handle(uri: Uri?): Boolean {
-    // Check if this is a Clerk OAuth callback
-    val isClerkCallback = uri?.scheme?.startsWith("clerk") == true
-
-    if (isClerkCallback) {
-      // Let the SSO service handle the callback
-      kotlinx.coroutines.runBlocking { SSOService.completeAuthenticateWithRedirect(uri) }
+  suspend fun handle(uri: Uri?): Boolean {
+    val callbackUri = uri ?: return false
+    val handledByMagicLink = canHandleNativeMagicLink(callbackUri)
+    if (handledByMagicLink) {
+      NativeMagicLinkService.handleMagicLinkDeepLink(callbackUri)
     }
 
-    return isClerkCallback
+    val isClerkCallback = callbackUri.scheme?.startsWith("clerk") == true
+    if (!handledByMagicLink && isClerkCallback) {
+      SSOService.completeAuthenticateWithRedirect(callbackUri)
+    }
+
+    return handledByMagicLink || isClerkCallback
   }
 
   // endregion

--- a/source/api/src/main/kotlin/com/clerk/api/log/SafeUriLog.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/log/SafeUriLog.kt
@@ -1,0 +1,55 @@
+package com.clerk.api.log
+
+import android.net.Uri
+
+internal object SafeUriLog {
+  fun describe(uri: Uri?): String {
+    if (uri == null) return "uri=null"
+
+    val queryKeys = queryParamKeys(uri)
+    val fragmentKeys = fragmentParamKeys(uri.encodedFragment)
+    val allKeys = (queryKeys + fragmentKeys).sorted()
+
+    val port = if (uri.port == -1) "-" else uri.port.toString()
+    val path = uri.path ?: "-"
+    val scheme = uri.scheme ?: "-"
+    val host = uri.host ?: "-"
+
+    return buildString {
+      append("scheme=$scheme")
+      append(", host=$host")
+      append(", port=$port")
+      append(", path=$path")
+      append(", query_keys=")
+      append(queryKeys.sorted())
+      append(", fragment_keys=")
+      append(fragmentKeys.sorted())
+      append(", has_flow_id=")
+      append("flow_id" in allKeys)
+      append(", has_approval_token=")
+      append("approval_token" in allKeys)
+      append(", has_token=")
+      append("token" in allKeys)
+      append(", has_rotating_token_nonce=")
+      append("rotating_token_nonce" in allKeys)
+    }
+  }
+
+  private fun queryParamKeys(uri: Uri): Set<String> =
+    runCatching { uri.queryParameterNames.map { it.trim() }.filter { it.isNotEmpty() }.toSet() }
+      .getOrDefault(emptySet())
+
+  private fun fragmentParamKeys(fragment: String?): Set<String> {
+    if (fragment.isNullOrBlank()) return emptySet()
+
+    return fragment
+      .split("&")
+      .mapNotNull { entry ->
+        val separator = entry.indexOf("=")
+        val rawKey = if (separator >= 0) entry.substring(0, separator) else entry
+        val key = Uri.decode(rawKey).trim()
+        key.takeIf { it.isNotEmpty() }
+      }
+      .toSet()
+  }
+}

--- a/source/api/src/main/kotlin/com/clerk/api/magiclink/NativeMagicLinkCompletionRunner.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/magiclink/NativeMagicLinkCompletionRunner.kt
@@ -1,0 +1,156 @@
+package com.clerk.api.magiclink
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.model.magiclink.NativeMagicLinkCompleteRequest
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signup.SignUp
+
+internal class NativeMagicLinkCompletionRunner(
+  private val attestationProvider: NativeMagicLinkAttestationProvider?,
+  private val clearPendingFlow: suspend () -> Unit,
+  private val activateCreatedSession: suspend (String?) -> ClerkResult<Unit, NativeMagicLinkError>,
+  private val refreshClientState: suspend () -> Unit,
+) {
+  suspend fun complete(
+    flowId: String,
+    approvalToken: String,
+    pending: PendingNativeMagicLinkFlow,
+  ): ClerkResult<NativeMagicLinkAuthResult, NativeMagicLinkError> {
+    val completeRequest =
+      NativeMagicLinkCompleteRequest(
+        flowId = flowId,
+        approvalToken = approvalToken,
+        codeVerifier = pending.codeVerifier,
+        attestation = attestationProvider?.attestation(),
+      )
+
+    NativeMagicLinkLogger.completeApiStarted(
+      state = pending.state,
+      hasAttestation = completeRequest.attestation != null,
+    )
+
+    return when (val completeResult = ClerkApi.magicLink.complete(completeRequest.toFields())) {
+      is ClerkResult.Failure -> handleCompleteApiFailure(completeResult)
+      is ClerkResult.Success -> {
+        NativeMagicLinkLogger.ticketReceived(pending.state)
+        completeFromTicket(completeResult.value.ticket, pending.state)
+      }
+    }
+  }
+
+  private suspend fun handleCompleteApiFailure(
+    completeResult: ClerkResult.Failure<ClerkErrorResponse>
+  ): ClerkResult.Failure<NativeMagicLinkError> {
+    val mapped = completeResult.toNativeMagicLinkError(NativeMagicLinkReason.COMPLETE_FAILED)
+    if (mapped.reasonCode in TERMINAL_REASON_CODES) {
+      clearPendingFlow()
+    }
+    NativeMagicLinkLogger.completeFailure(mapped.reasonCode)
+    return ClerkResult.apiFailure(mapped)
+  }
+
+  private suspend fun completeFromTicket(
+    ticket: String,
+    state: PendingNativeMagicLinkState,
+  ): ClerkResult<NativeMagicLinkAuthResult, NativeMagicLinkError> {
+    return when (state) {
+      PendingNativeMagicLinkState.SIGN_IN -> {
+        when (val ticketSignInResult = Clerk.auth.signInWithTicket(ticket)) {
+          is ClerkResult.Failure -> {
+            clearPendingFlow()
+            val mapped =
+              ticketSignInResult.toNativeMagicLinkError(NativeMagicLinkReason.TICKET_SIGN_IN_FAILED)
+            NativeMagicLinkLogger.completeFailure(mapped.reasonCode)
+            ClerkResult.apiFailure(mapped)
+          }
+          is ClerkResult.Success -> {
+            NativeMagicLinkLogger.ticketExchangeSuccess(
+              state = state,
+              createdSessionId = ticketSignInResult.value.createdSessionId,
+            )
+            completeAfterTicketSignIn(ticketSignInResult.value)
+          }
+        }
+      }
+      PendingNativeMagicLinkState.SIGN_UP -> {
+        when (val ticketSignUpResult = Clerk.auth.signUpWithTicket(ticket)) {
+          is ClerkResult.Failure -> {
+            clearPendingFlow()
+            val mapped =
+              ticketSignUpResult.toNativeMagicLinkError(NativeMagicLinkReason.TICKET_SIGN_UP_FAILED)
+            NativeMagicLinkLogger.completeFailure(mapped.reasonCode)
+            ClerkResult.apiFailure(mapped)
+          }
+          is ClerkResult.Success -> {
+            NativeMagicLinkLogger.ticketExchangeSuccess(
+              state = state,
+              createdSessionId = ticketSignUpResult.value.createdSessionId,
+            )
+            completeAfterTicketSignUp(ticketSignUpResult.value)
+          }
+        }
+      }
+    }
+  }
+
+  private suspend fun completeAfterTicketSignIn(
+    signIn: SignIn
+  ): ClerkResult<NativeMagicLinkAuthResult, NativeMagicLinkError> {
+    if (signIn.createdSessionId == null) {
+      clearPendingFlow()
+      NativeMagicLinkLogger.completeSuccess()
+      return ClerkResult.success(NativeMagicLinkAuthResult.SignIn(signIn))
+    }
+
+    NativeMagicLinkLogger.sessionActivationStarted(
+      state = PendingNativeMagicLinkState.SIGN_IN,
+      createdSessionId = signIn.createdSessionId,
+    )
+    val activationResult = activateCreatedSession(signIn.createdSessionId)
+    return if (activationResult is ClerkResult.Failure) {
+      clearPendingFlow()
+      val reasonCode =
+        activationResult.error?.reasonCode ?: NativeMagicLinkReason.SESSION_ACTIVATION_FAILED.code
+      val error = activationResult.error ?: NativeMagicLinkError(reasonCode = reasonCode)
+      NativeMagicLinkLogger.completeFailure(reasonCode)
+      ClerkResult.apiFailure(error)
+    } else {
+      clearPendingFlow()
+      refreshClientState()
+      NativeMagicLinkLogger.completeSuccess()
+      ClerkResult.success(NativeMagicLinkAuthResult.SignIn(signIn))
+    }
+  }
+
+  private suspend fun completeAfterTicketSignUp(
+    signUp: SignUp
+  ): ClerkResult<NativeMagicLinkAuthResult, NativeMagicLinkError> {
+    if (signUp.createdSessionId == null) {
+      clearPendingFlow()
+      NativeMagicLinkLogger.completeSuccess()
+      return ClerkResult.success(NativeMagicLinkAuthResult.SignUp(signUp))
+    }
+
+    NativeMagicLinkLogger.sessionActivationStarted(
+      state = PendingNativeMagicLinkState.SIGN_UP,
+      createdSessionId = signUp.createdSessionId,
+    )
+    val activationResult = activateCreatedSession(signUp.createdSessionId)
+    return if (activationResult is ClerkResult.Failure) {
+      clearPendingFlow()
+      val reasonCode =
+        activationResult.error?.reasonCode ?: NativeMagicLinkReason.SESSION_ACTIVATION_FAILED.code
+      val error = activationResult.error ?: NativeMagicLinkError(reasonCode = reasonCode)
+      NativeMagicLinkLogger.completeFailure(reasonCode)
+      ClerkResult.apiFailure(error)
+    } else {
+      clearPendingFlow()
+      refreshClientState()
+      NativeMagicLinkLogger.completeSuccess()
+      ClerkResult.success(NativeMagicLinkAuthResult.SignUp(signUp))
+    }
+  }
+}

--- a/source/api/src/main/kotlin/com/clerk/api/magiclink/NativeMagicLinkManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/magiclink/NativeMagicLinkManager.kt
@@ -1,0 +1,725 @@
+@file:Suppress("TooManyFunctions")
+
+package com.clerk.api.magiclink
+
+import android.net.Uri
+import com.clerk.api.Clerk
+import com.clerk.api.Constants.Strategy.EMAIL_LINK
+import com.clerk.api.log.ClerkLog
+import com.clerk.api.log.SafeUriLog
+import com.clerk.api.network.ApiParams
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.client.Client
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.model.error.Error
+import com.clerk.api.network.model.magiclink.NativeMagicLinkPrepareRequest
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signup.SignUp
+import com.clerk.api.sso.RedirectConfiguration
+import com.clerk.api.storage.StorageHelper
+import com.clerk.api.storage.StorageKey
+import java.net.URL
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+private const val PENDING_FLOW_TTL_MS = 10 * 60 * 1000L
+
+public interface NativeMagicLinkManager {
+  public var attestationProvider: NativeMagicLinkAttestationProvider?
+
+  public suspend fun startEmailLinkSignIn(email: String): ClerkResult<SignIn, NativeMagicLinkError>
+
+  public suspend fun handleMagicLinkDeepLink(
+    uri: Uri
+  ): ClerkResult<NativeMagicLinkAuthResult, NativeMagicLinkError>
+
+  public suspend fun complete(
+    flowId: String,
+    approvalToken: String,
+  ): ClerkResult<NativeMagicLinkAuthResult, NativeMagicLinkError>
+}
+
+public sealed interface NativeMagicLinkAuthResult {
+  public data class SignIn(public val signIn: com.clerk.api.signin.SignIn) :
+    NativeMagicLinkAuthResult
+
+  public data class SignUp(public val signUp: com.clerk.api.signup.SignUp) :
+    NativeMagicLinkAuthResult
+}
+
+internal object NativeMagicLinkService : NativeMagicLinkManager {
+  private val mutex = Mutex()
+  private val pendingFlowStore: PendingNativeMagicLinkStore =
+    PersistentPendingNativeMagicLinkStore()
+
+  override var attestationProvider: NativeMagicLinkAttestationProvider? = null
+
+  override suspend fun startEmailLinkSignIn(
+    email: String
+  ): ClerkResult<SignIn, NativeMagicLinkError> {
+    NativeMagicLinkLogger.start()
+    val identifier = email.trim()
+    val invalidIdentifierFailure =
+      if (identifier.isEmpty()) {
+        ClerkResult.apiFailure(
+          NativeMagicLinkError(reasonCode = NativeMagicLinkReason.INVALID_IDENTIFIER.code)
+        )
+      } else {
+        null
+      }
+
+    return invalidIdentifierFailure ?: createAndPrepareEmailLinkSignIn(identifier)
+  }
+
+  private suspend fun createAndPrepareEmailLinkSignIn(
+    identifier: String
+  ): ClerkResult<SignIn, NativeMagicLinkError> {
+    val signInResult =
+      ClerkApi.signIn.createSignIn(
+        mapOf("identifier" to identifier, "locale" to Clerk.locale.value.orEmpty())
+      )
+
+    return when (signInResult) {
+      is ClerkResult.Failure ->
+        ClerkResult.apiFailure(
+          signInResult.toNativeMagicLinkError(NativeMagicLinkReason.START_FAILED)
+        )
+
+      is ClerkResult.Success -> prepareEmailLinkSignIn(signInResult.value)
+    }
+  }
+
+  private suspend fun prepareEmailLinkSignIn(
+    signIn: SignIn
+  ): ClerkResult<SignIn, NativeMagicLinkError> {
+    val emailAddressId = signIn.emailLinkAddressId()
+    val redirectUri = resolveNativeEmailLinkRedirectUri()
+    val missingReason =
+      when {
+        emailAddressId == null -> NativeMagicLinkReason.EMAIL_LINK_NOT_SUPPORTED
+        redirectUri == null -> NativeMagicLinkReason.START_FAILED
+        else -> null
+      }
+
+    return if (missingReason != null) {
+      ClerkResult.apiFailure(NativeMagicLinkError(reasonCode = missingReason.code))
+    } else {
+      val requiredEmailAddressId = checkNotNull(emailAddressId)
+      val requiredRedirectUri = checkNotNull(redirectUri)
+      val pkcePair = PkceUtil.generatePair()
+      val prepareRequest =
+        NativeMagicLinkPrepareRequest(
+          emailAddressId = requiredEmailAddressId,
+          redirectUri = requiredRedirectUri,
+          codeChallenge = pkcePair.challenge,
+        )
+      when (
+        val prepareResult =
+          ClerkApi.signIn.prepareSignInFirstFactor(signIn.id, prepareRequest.toFields())
+      ) {
+        is ClerkResult.Failure ->
+          ClerkResult.apiFailure(
+            prepareResult.toNativeMagicLinkError(NativeMagicLinkReason.PREPARE_FAILED)
+          )
+
+        is ClerkResult.Success -> {
+          NativeMagicLinkLogger.prepareSuccess(
+            state = PendingNativeMagicLinkState.SIGN_IN,
+            flowId = signIn.id,
+          )
+          persistPendingFlow(
+            createPendingFlow(
+              codeVerifier = pkcePair.verifier,
+              state = PendingNativeMagicLinkState.SIGN_IN,
+              flowId = signIn.id,
+            )
+          )
+          ClerkResult.success(prepareResult.value)
+        }
+      }
+    }
+  }
+
+  internal suspend fun prepareSignUpEmailLink(
+    signUpId: String,
+    strategy: SignUp.PrepareVerificationParams.Strategy.EmailLink,
+  ): ClerkResult<SignUp, ClerkErrorResponse> {
+    val applicationId = Clerk.applicationId
+    val redirectUri =
+      strategy.redirectUri
+        ?: strategy.redirectUrl
+        ?: if (applicationId.isNullOrBlank()) null
+        else {
+          RedirectConfiguration.emailLinkRedirectUrl(
+            applicationId = applicationId,
+            proxyUrl = Clerk.proxyUrl,
+          )
+        }
+
+    if (redirectUri.isNullOrBlank()) {
+      return ClerkResult.apiFailure(
+        ClerkErrorResponse(
+          errors =
+            listOf(
+              Error(
+                message = "is invalid",
+                longMessage = "redirect_uri is required for native email-link verification",
+                code = "native_redirect_uri_required",
+              )
+            )
+        )
+      )
+    }
+
+    val pkcePair = PkceUtil.generatePair()
+    val fields =
+      mapOf(
+        ApiParams.STRATEGY to EMAIL_LINK,
+        ApiParams.REDIRECT_URI to redirectUri,
+        ApiParams.CODE_CHALLENGE to pkcePair.challenge,
+        ApiParams.CODE_CHALLENGE_METHOD to NativeMagicLinkPrepareRequest.PKCE_METHOD_S256,
+      )
+
+    return when (val prepareResult = ClerkApi.signUp.prepareSignUpVerification(signUpId, fields)) {
+      is ClerkResult.Failure -> prepareResult
+      is ClerkResult.Success -> {
+        NativeMagicLinkLogger.prepareSuccess(
+          state = PendingNativeMagicLinkState.SIGN_UP,
+          flowId = signUpId,
+        )
+        persistPendingFlow(
+          createPendingFlow(
+            codeVerifier = pkcePair.verifier,
+            state = PendingNativeMagicLinkState.SIGN_UP,
+            flowId = signUpId,
+          )
+        )
+        prepareResult
+      }
+    }
+  }
+
+  override suspend fun handleMagicLinkDeepLink(
+    uri: Uri
+  ): ClerkResult<NativeMagicLinkAuthResult, NativeMagicLinkError> {
+    NativeMagicLinkLogger.deepLinkReceived(uri)
+    val parsed = parseMagicLinkCallback(uri)
+    return when (parsed) {
+      is ClerkResult.Failure -> {
+        val reason = parsed.error?.reasonCode ?: NativeMagicLinkReason.COMPLETE_FAILED.code
+        NativeMagicLinkLogger.completeFailure(reason)
+        parsed
+      }
+
+      is ClerkResult.Success -> complete(parsed.value.flowId, parsed.value.approvalToken)
+    }
+  }
+
+  override suspend fun complete(
+    flowId: String,
+    approvalToken: String,
+  ): ClerkResult<NativeMagicLinkAuthResult, NativeMagicLinkError> {
+    val pendingState = lookupPendingFlow(flowId)
+    logCompletionRequested(flowId, pendingState)
+    return when (pendingState) {
+      PendingFlowLookup.None -> nativeMagicLinkFailure(NativeMagicLinkReason.NO_PENDING_FLOW)
+      is PendingFlowLookup.Mismatched -> {
+        logFlowIdMismatch(pendingState.expectedFlowId, flowId)
+        nativeMagicLinkFailure(NativeMagicLinkReason.FLOW_ID_MISMATCH)
+      }
+
+      is PendingFlowLookup.Found ->
+        createCompletionRunner(pendingState.flow)
+          .complete(flowId = flowId, approvalToken = approvalToken, pending = pendingState.flow)
+    }
+  }
+
+  internal fun resetForTests() {
+    pendingFlowStore.clear()
+    attestationProvider = null
+  }
+
+  private suspend fun persistPendingFlow(flow: PendingNativeMagicLinkFlow) {
+    NativeMagicLinkLogger.pendingFlowSaved(flow)
+    mutex.withLock { pendingFlowStore.save(flow) }
+  }
+
+  private suspend fun lookupPendingFlow(flowId: String): PendingFlowLookup {
+    return mutex.withLock {
+      val flow = pendingFlowStore.load()
+      when {
+        flow == null -> PendingFlowLookup.None
+        flow.expiresAtEpochMs <= currentTimeMillis() -> {
+          pendingFlowStore.clear()
+          PendingFlowLookup.None
+        }
+
+        flow.flowId != null && flow.flowId != flowId -> PendingFlowLookup.Mismatched(flow.flowId)
+        else -> PendingFlowLookup.Found(flow)
+      }
+    }
+  }
+
+  private fun logCompletionRequested(flowId: String, pendingState: PendingFlowLookup) {
+    val details = pendingState.toCompletionRequestLogDetails()
+    NativeMagicLinkLogger.completeRequested(
+      flowId = flowId,
+      pendingLookupOutcome = details.pendingLookupOutcome,
+      pendingState = details.pendingState,
+      expectedFlowId = details.expectedFlowId,
+    )
+  }
+
+  private fun createCompletionRunner(
+    pendingFlow: PendingNativeMagicLinkFlow
+  ): NativeMagicLinkCompletionRunner {
+    val clearPendingFlow: suspend () -> Unit = {
+      mutex.withLock {
+        if (pendingFlowStore.load() == pendingFlow) {
+          pendingFlowStore.clear()
+        }
+      }
+    }
+    return NativeMagicLinkCompletionRunner(
+      attestationProvider = attestationProvider,
+      clearPendingFlow = clearPendingFlow,
+      activateCreatedSession = { createdSessionId -> activateCreatedSession(createdSessionId) },
+      refreshClientState = { refreshClientState() },
+    )
+  }
+
+  private suspend fun refreshClientState() {
+    when (val clientResult = Client.get()) {
+      is ClerkResult.Success -> Clerk.updateClient(clientResult.value)
+      is ClerkResult.Failure -> ClerkLog.w("event=native_magic_link_client_refresh_failure")
+    }
+  }
+
+  private suspend fun activateCreatedSession(
+    createdSessionId: String?
+  ): ClerkResult<Unit, NativeMagicLinkError> {
+    createdSessionId ?: return ClerkResult.success(Unit)
+    return when (val activationResult = Clerk.auth.setActive(createdSessionId)) {
+      is ClerkResult.Success -> ClerkResult.success(Unit)
+      is ClerkResult.Failure -> {
+        refreshClientState()
+        val isAlreadyActive =
+          runCatching { Clerk.client.lastActiveSessionId }.getOrNull() == createdSessionId
+        if (isAlreadyActive) {
+          ClerkResult.success(Unit)
+        } else {
+          ClerkResult.apiFailure(
+            activationResult.toNativeMagicLinkError(NativeMagicLinkReason.SESSION_ACTIVATION_FAILED)
+          )
+        }
+      }
+    }
+  }
+}
+
+public fun interface NativeMagicLinkAttestationProvider {
+  suspend fun attestation(): String?
+}
+
+@Serializable
+internal data class PendingNativeMagicLinkFlow(
+  val codeVerifier: String,
+  val state: PendingNativeMagicLinkState,
+  val createdAtEpochMs: Long,
+  val expiresAtEpochMs: Long,
+  val flowId: String? = null,
+)
+
+@Serializable
+internal enum class PendingNativeMagicLinkState {
+  SIGN_IN,
+  SIGN_UP,
+}
+
+internal interface PendingNativeMagicLinkStore {
+  fun save(flow: PendingNativeMagicLinkFlow)
+
+  fun load(): PendingNativeMagicLinkFlow?
+
+  fun clear()
+}
+
+internal class PersistentPendingNativeMagicLinkStore(
+  private val json: Json = Json { ignoreUnknownKeys = true }
+) : PendingNativeMagicLinkStore {
+  override fun save(flow: PendingNativeMagicLinkFlow) {
+    StorageHelper.saveValue(StorageKey.PENDING_NATIVE_MAGIC_LINK_FLOW, json.encodeToString(flow))
+  }
+
+  override fun load(): PendingNativeMagicLinkFlow? {
+    val encoded = StorageHelper.loadValue(StorageKey.PENDING_NATIVE_MAGIC_LINK_FLOW) ?: return null
+    return runCatching { json.decodeFromString<PendingNativeMagicLinkFlow>(encoded) }
+      .getOrElse { error ->
+        ClerkLog.w("event=native_magic_link_pending_flow_decode_failure message=${error.message}")
+        clear()
+        null
+      }
+  }
+
+  override fun clear() {
+    StorageHelper.deleteValue(StorageKey.PENDING_NATIVE_MAGIC_LINK_FLOW)
+  }
+}
+
+internal data class ParsedMagicLinkDeepLink(val flowId: String, val approvalToken: String)
+
+private sealed interface PendingFlowLookup {
+  data object None : PendingFlowLookup
+
+  data class Found(val flow: PendingNativeMagicLinkFlow) : PendingFlowLookup
+
+  data class Mismatched(val expectedFlowId: String?) : PendingFlowLookup
+}
+
+private data class CompletionRequestLogDetails(
+  val pendingLookupOutcome: String,
+  val pendingState: String,
+  val expectedFlowId: String,
+)
+
+private fun createPendingFlow(
+  codeVerifier: String,
+  state: PendingNativeMagicLinkState,
+  flowId: String,
+): PendingNativeMagicLinkFlow {
+  val createdAtEpochMs = currentTimeMillis()
+  return PendingNativeMagicLinkFlow(
+    codeVerifier = codeVerifier,
+    state = state,
+    createdAtEpochMs = createdAtEpochMs,
+    expiresAtEpochMs = createdAtEpochMs + PENDING_FLOW_TTL_MS,
+    flowId = flowId,
+  )
+}
+
+internal fun canHandleNativeMagicLink(uri: Uri?): Boolean {
+  return uri?.let {
+    queryOrFragmentParam(it, "flow_id") != null ||
+      queryOrFragmentParam(it, "approval_token") != null
+  } ?: false
+}
+
+internal fun parseMagicLinkCallback(
+  uri: Uri
+): ClerkResult<ParsedMagicLinkDeepLink, NativeMagicLinkError> {
+  val flowId = queryOrFragmentParam(uri, "flow_id")
+  val approvalToken = queryOrFragmentParam(uri, "approval_token")
+
+  return when {
+    flowId.isNullOrBlank() ->
+      ClerkResult.apiFailure(
+        NativeMagicLinkError(reasonCode = NativeMagicLinkReason.MISSING_FLOW_ID.code)
+      )
+
+    approvalToken.isNullOrBlank() ->
+      ClerkResult.apiFailure(
+        NativeMagicLinkError(reasonCode = NativeMagicLinkReason.MISSING_APPROVAL_TOKEN.code)
+      )
+
+    else ->
+      ClerkResult.success(ParsedMagicLinkDeepLink(flowId = flowId, approvalToken = approvalToken))
+  }
+}
+
+internal fun queryOrFragmentParam(uri: Uri, key: String): String? {
+  val queryValue = uri.getQueryParameter(key)?.takeIf { it.isNotBlank() }
+  val fragmentValue =
+    uri.encodedFragment
+      ?.split("&")
+      .orEmpty()
+      .asSequence()
+      .mapNotNull { entry ->
+        val index = entry.indexOf('=')
+        val rawKey = if (index >= 0) entry.substring(0, index) else entry
+        val rawValue = if (index >= 0) entry.substring(index + 1) else ""
+        val decodedKey = Uri.decode(rawKey)
+        if (decodedKey == key) Uri.decode(rawValue) else null
+      }
+      .firstOrNull()
+      ?.takeIf { it.isNotBlank() }
+
+  return queryValue ?: fragmentValue
+}
+
+private fun SignIn.emailLinkAddressId(): String? {
+  return supportedFirstFactors
+    ?.firstOrNull { it.strategy == EMAIL_LINK && it.emailAddressId != null }
+    ?.emailAddressId
+}
+
+private fun resolveNativeEmailLinkRedirectUri(): String? {
+  val applicationId = Clerk.applicationId
+  return if (applicationId.isNullOrBlank()) {
+    null
+  } else {
+    RedirectConfiguration.emailLinkRedirectUrl(
+      applicationId = applicationId,
+      proxyUrl = Clerk.proxyUrl,
+    )
+  }
+}
+
+private fun nativeMagicLinkFailure(
+  reason: NativeMagicLinkReason
+): ClerkResult.Failure<NativeMagicLinkError> {
+  NativeMagicLinkLogger.completeFailure(reason.code)
+  return ClerkResult.apiFailure(NativeMagicLinkError(reasonCode = reason.code))
+}
+
+private fun currentTimeMillis(): Long = System.currentTimeMillis()
+
+class NativeMagicLinkError(val reasonCode: String, val message: String? = null)
+
+internal enum class NativeMagicLinkReason(val code: String) {
+  APPROVAL_TOKEN_CONSUMED("approval_token_consumed"),
+  APPROVAL_TOKEN_EXPIRED("approval_token_expired"),
+  APPROVAL_TOKEN_INVALID("approval_token_invalid"),
+  PKCE_VERIFICATION_FAILED("pkce_verification_failed"),
+  FLOW_NOT_APPROVED("flow_not_approved"),
+  MISSING_FLOW_ID("missing_flow_id"),
+  MISSING_APPROVAL_TOKEN("missing_approval_token"),
+  INVALID_IDENTIFIER("invalid_identifier"),
+  EMAIL_LINK_NOT_SUPPORTED("email_link_not_supported"),
+  NATIVE_API_DISABLED_FOR_INSTANCE("native_api_disabled_for_instance"),
+  NATIVE_API_DISABLED("native_api_disabled"),
+  NO_PENDING_FLOW("no_pending_flow"),
+  FLOW_ID_MISMATCH("native_magic_link_flow_id_mismatch"),
+  SESSION_ACTIVATION_FAILED("native_magic_link_session_activation_failed"),
+  START_FAILED("native_magic_link_start_failed"),
+  PREPARE_FAILED("native_magic_link_prepare_failed"),
+  COMPLETE_FAILED("native_magic_link_complete_failed"),
+  TICKET_SIGN_IN_FAILED("native_magic_link_ticket_sign_in_failed"),
+  TICKET_SIGN_UP_FAILED("native_magic_link_ticket_sign_up_failed"),
+}
+
+internal val TERMINAL_REASON_CODES =
+  setOf(
+    NativeMagicLinkReason.APPROVAL_TOKEN_CONSUMED.code,
+    NativeMagicLinkReason.APPROVAL_TOKEN_EXPIRED.code,
+    NativeMagicLinkReason.APPROVAL_TOKEN_INVALID.code,
+    NativeMagicLinkReason.PKCE_VERIFICATION_FAILED.code,
+    NativeMagicLinkReason.FLOW_NOT_APPROVED.code,
+  )
+
+internal fun ClerkResult.Failure<ClerkErrorResponse>.toNativeMagicLinkError(
+  fallbackReason: NativeMagicLinkReason
+): NativeMagicLinkError {
+  val firstError = error?.errors?.firstOrNull()
+  val backendCode = firstError?.code?.takeIf { it.isNotBlank() }
+  val normalizedCode = backendCode ?: fallbackReason.code
+  val mapped =
+    when (normalizedCode) {
+      NativeMagicLinkReason.APPROVAL_TOKEN_CONSUMED.code ->
+        NativeMagicLinkReason.APPROVAL_TOKEN_CONSUMED
+
+      NativeMagicLinkReason.APPROVAL_TOKEN_EXPIRED.code ->
+        NativeMagicLinkReason.APPROVAL_TOKEN_EXPIRED
+
+      NativeMagicLinkReason.APPROVAL_TOKEN_INVALID.code ->
+        NativeMagicLinkReason.APPROVAL_TOKEN_INVALID
+
+      NativeMagicLinkReason.PKCE_VERIFICATION_FAILED.code ->
+        NativeMagicLinkReason.PKCE_VERIFICATION_FAILED
+
+      NativeMagicLinkReason.FLOW_NOT_APPROVED.code -> NativeMagicLinkReason.FLOW_NOT_APPROVED
+      NativeMagicLinkReason.NATIVE_API_DISABLED_FOR_INSTANCE.code ->
+        NativeMagicLinkReason.NATIVE_API_DISABLED_FOR_INSTANCE
+
+      NativeMagicLinkReason.NATIVE_API_DISABLED.code -> NativeMagicLinkReason.NATIVE_API_DISABLED
+      else -> null
+    }
+  val reasonCode = mapped?.code ?: normalizedCode
+  return NativeMagicLinkError(
+    reasonCode = reasonCode,
+    message = firstError?.longMessage ?: firstError?.message,
+  )
+}
+
+private fun PendingFlowLookup.toCompletionRequestLogDetails(): CompletionRequestLogDetails {
+  return when (this) {
+    PendingFlowLookup.None ->
+      CompletionRequestLogDetails(
+        pendingLookupOutcome = "none",
+        pendingState = "-",
+        expectedFlowId = "-",
+      )
+
+    is PendingFlowLookup.Found ->
+      CompletionRequestLogDetails(
+        pendingLookupOutcome = "found",
+        pendingState = flow.state.logName(),
+        expectedFlowId = flow.flowId ?: "-",
+      )
+
+    is PendingFlowLookup.Mismatched ->
+      CompletionRequestLogDetails(
+        pendingLookupOutcome = "mismatched",
+        pendingState = "-",
+        expectedFlowId = expectedFlowId ?: "-",
+      )
+  }
+}
+
+internal object NativeMagicLinkLogger {
+  fun start() {
+    nativeMagicLinkInfo("native_magic_link_start")
+  }
+
+  fun prepareSuccess(state: PendingNativeMagicLinkState, flowId: String) {
+    nativeMagicLinkInfo(
+      event = "native_magic_link_prepare_success",
+      "state" to state.logName(),
+      "flow_id" to flowId,
+    )
+  }
+
+  fun deepLinkReceived(uri: Uri) {
+    nativeMagicLinkInfo(
+      event = "native_magic_link_deeplink_received",
+      "uri_shape" to "{${SafeUriLog.describe(uri)}}",
+    )
+  }
+
+  fun pendingFlowSaved(flow: PendingNativeMagicLinkFlow) {
+    nativeMagicLinkInfo(
+      event = "native_magic_link_pending_flow_saved",
+      "state" to flow.state.logName(),
+      "flow_id" to (flow.flowId ?: "-"),
+      "expires_in_ms" to (flow.expiresAtEpochMs - currentTimeMillis()).toString(),
+    )
+  }
+
+  fun completeRequested(
+    flowId: String,
+    pendingLookupOutcome: String,
+    pendingState: String,
+    expectedFlowId: String,
+  ) {
+    nativeMagicLinkInfo(
+      event = "native_magic_link_complete_requested",
+      "flow_id" to flowId,
+      "pending_lookup" to pendingLookupOutcome,
+      "pending_state" to pendingState,
+      "expected_flow_id" to expectedFlowId,
+    )
+  }
+
+  fun completeApiStarted(state: PendingNativeMagicLinkState, hasAttestation: Boolean) {
+    nativeMagicLinkInfo(
+      event = "native_magic_link_complete_api_started",
+      "state" to state.logName(),
+      "has_attestation" to hasAttestation.toString(),
+    )
+  }
+
+  fun ticketReceived(state: PendingNativeMagicLinkState) {
+    nativeMagicLinkInfo(event = "native_magic_link_ticket_received", "state" to state.logName())
+  }
+
+  fun ticketExchangeSuccess(state: PendingNativeMagicLinkState, createdSessionId: String?) {
+    nativeMagicLinkInfo(
+      event = "native_magic_link_ticket_exchange_success",
+      "state" to state.logName(),
+      "has_created_session" to (createdSessionId != null).toString(),
+    )
+  }
+
+  fun sessionActivationStarted(state: PendingNativeMagicLinkState, createdSessionId: String?) {
+    nativeMagicLinkInfo(
+      event = "native_magic_link_session_activation_started",
+      "state" to state.logName(),
+      "has_created_session" to (createdSessionId != null).toString(),
+    )
+  }
+
+  fun completeSuccess() {
+    nativeMagicLinkInfo("native_magic_link_complete_success")
+  }
+
+  fun completeFailure(reasonCode: String) {
+    nativeMagicLinkWarn(event = "native_magic_link_complete_failure", "reason_code" to reasonCode)
+  }
+}
+
+private fun PendingNativeMagicLinkState.logName(): String = name.lowercase()
+
+private fun logFlowIdMismatch(expectedFlowId: String?, actualFlowId: String) {
+  ClerkLog.w(
+    "event=native_magic_link_flow_id_mismatch expected=$expectedFlowId actual=$actualFlowId"
+  )
+}
+
+private fun nativeMagicLinkInfo(event: String, vararg fields: Pair<String, String>) {
+  ClerkLog.i(nativeMagicLinkLogMessage(event, *fields))
+}
+
+private fun nativeMagicLinkWarn(event: String, vararg fields: Pair<String, String>) {
+  ClerkLog.w(nativeMagicLinkLogMessage(event, *fields))
+}
+
+private fun nativeMagicLinkLogMessage(event: String, vararg fields: Pair<String, String>): String {
+  return buildString {
+    append("event=")
+    append(event)
+    fields.forEach { (key, value) ->
+      append(" ")
+      append(key)
+      append("=")
+      append(value)
+    }
+    append(" context={")
+    append(nativeMagicLinkRuntimeContext())
+    append("}")
+  }
+}
+
+private fun nativeMagicLinkRuntimeContext(): String {
+  val baseUrl = runCatching { Clerk.baseUrl }.getOrNull()
+  val proxyUrl = Clerk.proxyUrl
+  val redirectUri =
+    Clerk.applicationId?.let {
+      RedirectConfiguration.emailLinkRedirectUrl(applicationId = it, proxyUrl = proxyUrl)
+    }
+
+  return buildString {
+    append("app_id=")
+    append(Clerk.applicationId ?: "-")
+    append(", base=")
+    append(describeUrlForNativeMagicLink(baseUrl))
+    append(", proxy=")
+    append(describeUrlForNativeMagicLink(proxyUrl))
+    append(", redirect=")
+    append(redirectUri ?: "-")
+  }
+}
+
+private fun describeUrlForNativeMagicLink(value: String?): String {
+  return if (value.isNullOrBlank()) {
+    "-"
+  } else {
+    val parsed = runCatching { URL(value) }.getOrNull()
+    if (parsed == null) {
+      value
+    } else {
+      val port = parsed.port.takeIf { it > 0 } ?: parsed.defaultPort
+      buildString {
+        append(parsed.protocol)
+        append("://")
+        append(parsed.host)
+        if (port > 0) {
+          append(":")
+          append(port)
+        }
+      }
+    }
+  }
+}

--- a/source/api/src/main/kotlin/com/clerk/api/magiclink/PkceUtil.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/magiclink/PkceUtil.kt
@@ -1,0 +1,34 @@
+package com.clerk.api.magiclink
+
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+internal object PkceUtil {
+  private val secureRandom = SecureRandom()
+  private val urlEncoder = Base64.getUrlEncoder().withoutPadding()
+
+  fun generateCodeVerifier(bytes: Int = DEFAULT_VERIFIER_BYTES): String {
+    require(bytes > 0) { "bytes must be positive" }
+    val random = ByteArray(bytes)
+    secureRandom.nextBytes(random)
+    return urlEncoder.encodeToString(random)
+  }
+
+  fun createS256CodeChallenge(codeVerifier: String): String {
+    require(codeVerifier.isNotBlank()) { "codeVerifier must not be blank" }
+    val digest =
+      MessageDigest.getInstance(SHA_256).digest(codeVerifier.toByteArray(Charsets.US_ASCII))
+    return urlEncoder.encodeToString(digest)
+  }
+
+  fun generatePair(): PkcePair {
+    val verifier = generateCodeVerifier()
+    return PkcePair(verifier = verifier, challenge = createS256CodeChallenge(verifier))
+  }
+
+  private const val SHA_256 = "SHA-256"
+  private const val DEFAULT_VERIFIER_BYTES = 32
+}
+
+internal data class PkcePair(val verifier: String, val challenge: String)

--- a/source/api/src/main/kotlin/com/clerk/api/network/ApiParams.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ApiParams.kt
@@ -24,6 +24,10 @@ internal object ApiParams {
   // Request parameters
   internal const val STRATEGY = "strategy"
   internal const val CODE = "code"
+  internal const val REDIRECT_URL = "redirect_url"
+  internal const val REDIRECT_URI = "redirect_uri"
+  internal const val CODE_CHALLENGE = "code_challenge"
+  internal const val CODE_CHALLENGE_METHOD = "code_challenge_method"
   internal const val CLERK_SESSION_ID = "_clerk_session_id"
 
   internal const val ROLE = "role"

--- a/source/api/src/main/kotlin/com/clerk/api/network/ApiPaths.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ApiPaths.kt
@@ -42,6 +42,12 @@ internal object ApiPaths {
       internal const val RESET_PASSWORD = "${WITH_ID}/reset_password"
     }
 
+    /** Magic link endpoints */
+    internal object MagicLinks {
+      internal const val BASE = "${Client.BASE}/magic_links"
+      internal const val COMPLETE = "${BASE}/complete"
+    }
+
     /** Sign-up endpoints */
     internal object SignUp {
       internal const val BASE = "${Client.BASE}/sign_ups"

--- a/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
@@ -5,6 +5,7 @@ import com.clerk.api.Clerk
 import com.clerk.api.network.api.ClientApi
 import com.clerk.api.network.api.DeviceAttestationApi
 import com.clerk.api.network.api.EnvironmentApi
+import com.clerk.api.network.api.MagicLinkApi
 import com.clerk.api.network.api.OrganizationApi
 import com.clerk.api.network.api.SessionApi
 import com.clerk.api.network.api.SignInApi
@@ -69,6 +70,10 @@ internal object ClerkApi {
   val organization: OrganizationApi
     get() = _organization ?: error("ClerkApi is not configured.")
 
+  private var _magicLink: MagicLinkApi? = null
+  val magicLink: MagicLinkApi
+    get() = _magicLink ?: error("ClerkApi is not configured.")
+
   // Exposed for internal testing/verification
   internal var configuredBaseUrl: String? = null
     private set
@@ -89,6 +94,7 @@ internal object ClerkApi {
     _user = retrofit.create(UserApi::class.java)
     _deviceAttestation = retrofit.create(DeviceAttestationApi::class.java)
     _organization = retrofit.create(OrganizationApi::class.java)
+    _magicLink = retrofit.create(MagicLinkApi::class.java)
   }
 
   /** Clears all configured Retrofit services. */

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/MagicLinkApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/MagicLinkApi.kt
@@ -1,0 +1,17 @@
+package com.clerk.api.network.api
+
+import com.clerk.api.network.ApiPaths
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.model.magiclink.NativeMagicLinkCompleteResponse
+import com.clerk.api.network.serialization.ClerkResult
+import retrofit2.http.FieldMap
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
+
+internal interface MagicLinkApi {
+  @FormUrlEncoded
+  @POST(ApiPaths.Client.MagicLinks.COMPLETE)
+  suspend fun complete(
+    @FieldMap fields: Map<String, String>
+  ): ClerkResult<NativeMagicLinkCompleteResponse, ClerkErrorResponse>
+}

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/SignUpApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/SignUpApi.kt
@@ -41,7 +41,7 @@ internal interface SignUpApi {
   @POST(ApiPaths.Client.SignUp.PREPARE_VERIFICATION)
   suspend fun prepareSignUpVerification(
     @Path(ApiParams.ID) signUpId: String,
-    @Field(ApiParams.STRATEGY) strategy: String,
+    @FieldMap fields: Map<String, String>,
   ): ClerkResult<SignUp, ClerkErrorResponse>
 
   /** @see [com.clerk.api.signup.attemptVerification] */

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/magiclink/NativeMagicLinkRequests.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/magiclink/NativeMagicLinkRequests.kt
@@ -1,0 +1,44 @@
+package com.clerk.api.network.model.magiclink
+
+import com.clerk.api.Constants.Strategy.EMAIL_LINK
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class NativeMagicLinkPrepareRequest(
+  val strategy: String = EMAIL_LINK,
+  @SerialName("email_address_id") val emailAddressId: String,
+  @SerialName("redirect_uri") val redirectUri: String,
+  @SerialName("code_challenge") val codeChallenge: String,
+  @SerialName("code_challenge_method") val codeChallengeMethod: String = PKCE_METHOD_S256,
+) {
+  fun toFields(): Map<String, String> =
+    mapOf(
+      "strategy" to strategy,
+      "email_address_id" to emailAddressId,
+      "redirect_uri" to redirectUri,
+      "code_challenge" to codeChallenge,
+      "code_challenge_method" to codeChallengeMethod,
+    )
+
+  companion object {
+    const val PKCE_METHOD_S256 = "S256"
+  }
+}
+
+@Serializable
+internal data class NativeMagicLinkCompleteRequest(
+  @SerialName("flow_id") val flowId: String,
+  @SerialName("approval_token") val approvalToken: String,
+  @SerialName("code_verifier") val codeVerifier: String,
+  @SerialName("attestation") val attestation: String? = null,
+) {
+  fun toFields(): Map<String, String> = buildMap {
+    put("flow_id", flowId)
+    put("approval_token", approvalToken)
+    put("code_verifier", codeVerifier)
+    attestation?.let { put("attestation", it) }
+  }
+}
+
+@Serializable internal data class NativeMagicLinkCompleteResponse(val ticket: String)

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
@@ -3,6 +3,7 @@ package com.clerk.api.signin
 import com.clerk.api.Clerk
 import com.clerk.api.Constants.Strategy.BACKUP_CODE
 import com.clerk.api.Constants.Strategy.EMAIL_CODE
+import com.clerk.api.Constants.Strategy.EMAIL_LINK
 import com.clerk.api.Constants.Strategy.ENTERPRISE_SSO
 import com.clerk.api.Constants.Strategy.PASSKEY
 import com.clerk.api.Constants.Strategy.PASSWORD
@@ -14,6 +15,7 @@ import com.clerk.api.Constants.Strategy.TOTP as STRATEGY_TOTP
 import com.clerk.api.Constants.Strategy.TRANSFER
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
@@ -407,6 +409,16 @@ data class SignIn(
 
     @AutoMap
     @Serializable
+    data class EmailLink(
+      @SerialName("email_address_id") val emailAddressId: String,
+      @SerialName("redirect_uri") val redirectUri: String,
+      @SerialName("code_challenge") val codeChallenge: String,
+      @SerialName("code_challenge_method") val codeChallengeMethod: String = "S256",
+      override val strategy: String = EMAIL_LINK,
+    ) : PrepareFirstFactorParams
+
+    @AutoMap
+    @Serializable
     data class ResetPasswordEmailCode(
       @SerialName("email_address_id") val emailAddressId: String,
       override val strategy: String = RESET_PASSWORD_EMAIL_CODE,
@@ -732,7 +744,26 @@ data class SignIn(
 suspend fun SignIn.prepareFirstFactor(
   params: SignIn.PrepareFirstFactorParams
 ): ClerkResult<SignIn, ClerkErrorResponse> {
-  return ClerkApi.signIn.prepareSignInFirstFactor(this.id, params.toMap())
+  val isResetPasswordStrategy =
+    params.strategy == RESET_PASSWORD_EMAIL_CODE || params.strategy == RESET_PASSWORD_PHONE_CODE
+
+  val supportedFirstFactorStrategies = supportedFirstFactors?.map { it.strategy }.orEmpty()
+  val validationError =
+    when {
+      !isResetPasswordStrategy && status != SignIn.Status.NEEDS_FIRST_FACTOR ->
+        invalidPrepareState(
+          code = "sign_in_status_invalid",
+          longMessage = "Cannot prepare first factor while sign-in status is ${status.name}",
+        )
+      !isResetPasswordStrategy && params.strategy !in supportedFirstFactorStrategies ->
+        invalidPrepareState(
+          code = "first_factor_strategy_not_supported",
+          longMessage = "${params.strategy} is not supported for this sign-in attempt",
+        )
+      else -> null
+    }
+
+  return validationError ?: ClerkApi.signIn.prepareSignInFirstFactor(this.id, params.toMap())
 }
 
 /**
@@ -789,6 +820,13 @@ suspend fun SignIn.prepareSecondFactor(
   phoneNumberId: String? = null,
   emailAddressId: String? = null,
 ): ClerkResult<SignIn, ClerkErrorResponse> {
+  if (status != SignIn.Status.NEEDS_SECOND_FACTOR && status != SignIn.Status.NEEDS_CLIENT_TRUST) {
+    return invalidPrepareState(
+      code = "sign_in_status_invalid",
+      longMessage = "Cannot prepare second factor while sign-in status is ${status.name}",
+    )
+  }
+
   val strategy =
     when {
       supportedSecondFactors?.any { it.strategy == SignIn.PrepareSecondFactorParams.PHONE_CODE } ==
@@ -814,6 +852,17 @@ suspend fun SignIn.prepareSecondFactor(
 
   val params = strategy.toParams()
   return ClerkApi.signIn.prepareSecondFactor(id = id, params = params.toMap())
+}
+
+private fun invalidPrepareState(
+  code: String,
+  longMessage: String,
+): ClerkResult.Failure<ClerkErrorResponse> {
+  return ClerkResult.apiFailure(
+    ClerkErrorResponse(
+      errors = listOf(Error(message = "is invalid", longMessage = longMessage, code = code))
+    )
+  )
 }
 
 /**

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
@@ -4,6 +4,7 @@ package com.clerk.api.signin
 
 import com.clerk.api.Clerk
 import com.clerk.api.Constants.Strategy.EMAIL_CODE
+import com.clerk.api.Constants.Strategy.EMAIL_LINK
 import com.clerk.api.Constants.Strategy.PHONE_CODE
 import com.clerk.api.Constants.Strategy.RESET_PASSWORD_EMAIL_CODE
 import com.clerk.api.Constants.Strategy.RESET_PASSWORD_PHONE_CODE
@@ -79,11 +80,15 @@ fun SignIn.alternativeSecondFactors(factor: Factor): List<Factor> {
  *   is found.
  */
 val SignIn.startingFirstFactor: Factor?
-  get() =
-    when (Clerk.environment?.displayConfig?.preferredSignInStrategy) {
+  get() {
+    preparedFirstFactor?.let {
+      return it
+    }
+    return when (Clerk.environment?.displayConfig?.preferredSignInStrategy) {
       PreferredSignInStrategy.PASSWORD -> this.factorWhenPasswordIsPreferred
       else -> this.factorWhenOtpIsPreferred
     }
+  }
 
 val SignIn.startingSecondFactor: Factor?
   get() {
@@ -102,9 +107,11 @@ val SignIn.startingSecondFactor: Factor?
 
 private val SignIn.factorWhenPasswordIsPreferred: Factor?
   get() {
-    // email links are not supported on iOS (keeping the same exclusion here)
-    val availableFirstFactors =
-      supportedFirstFactors?.filter { it.strategy != "email_link" } ?: return null
+    val availableFirstFactors = supportedFirstFactors ?: return null
+
+    availableFirstFactors.emailLinkFactorForIdentifier(identifier)?.let {
+      return it
+    }
 
     // Prefer passkey
     availableFirstFactors
@@ -128,9 +135,11 @@ private val SignIn.factorWhenPasswordIsPreferred: Factor?
 
 private val SignIn.factorWhenOtpIsPreferred: Factor?
   get() {
-    // email links are not supported on iOS (keeping the same exclusion here)
-    val availableFirstFactors =
-      supportedFirstFactors?.filter { it.strategy != "email_link" } ?: return null
+    val availableFirstFactors = supportedFirstFactors ?: return null
+
+    availableFirstFactors.emailLinkFactorForIdentifier(identifier)?.let {
+      return it
+    }
 
     // Prefer passkey
     availableFirstFactors
@@ -143,6 +152,43 @@ private val SignIn.factorWhenOtpIsPreferred: Factor?
     val sorted = availableFirstFactors.sortedWith(FactorComparators.otpPrefComparator)
     return sorted.firstOrNull { it.safeIdentifier == identifier } ?: sorted.firstOrNull()
   }
+
+private val SignIn.preparedFirstFactor: Factor?
+  get() {
+    val preparedStrategy = firstFactorVerification?.strategy ?: return null
+    val availableFirstFactors = supportedFirstFactors ?: return null
+
+    return availableFirstFactors.firstOrNull {
+      it.strategy == preparedStrategy && it.safeIdentifier == identifier
+    } ?: availableFirstFactors.singleOrNull { it.strategy == preparedStrategy }
+  }
+
+private fun List<Factor>.emailLinkFactorForIdentifier(identifier: String?): Factor? {
+  val isEmailIdentifier = !identifier.isNullOrBlank() && identifier.contains("@")
+  val matchingEmailFactor =
+    if (isEmailIdentifier) {
+      firstOrNull { it.isEmailFactor && it.safeIdentifier == identifier }
+    } else {
+      null
+    }
+
+  return when {
+    !isEmailIdentifier -> null
+    matchingEmailFactor == null -> filter { it.strategy == EMAIL_LINK }.singleOrNull()
+    else ->
+      firstOrNull { it.strategy == EMAIL_LINK && it.hasSameIdentityAs(matchingEmailFactor) }
+        ?: matchingEmailFactor.takeIf { it.strategy == EMAIL_LINK }
+  }
+}
+
+private val Factor.isEmailFactor: Boolean
+  get() = strategy == EMAIL_LINK || strategy == EMAIL_CODE
+
+private fun Factor.hasSameIdentityAs(other: Factor): Boolean {
+  return (!emailAddressId.isNullOrBlank() && emailAddressId == other.emailAddressId) ||
+    (!phoneNumberId.isNullOrBlank() && phoneNumberId == other.phoneNumberId) ||
+    (!safeIdentifier.isNullOrBlank() && safeIdentifier == other.safeIdentifier)
+}
 
 // endregion
 

--- a/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
@@ -5,6 +5,9 @@ package com.clerk.api.signup
 import com.clerk.api.Clerk
 import com.clerk.api.Constants.Strategy as AuthStrategy
 import com.clerk.api.extensions.sortedByPriority
+import com.clerk.api.magiclink.NativeMagicLinkService
+import com.clerk.api.magiclink.PkceUtil
+import com.clerk.api.network.ApiParams
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.verification.Verification
@@ -340,6 +343,23 @@ data class SignUp(
        */
       data class EmailCode(override val strategy: String = AuthStrategy.EMAIL_CODE) :
         PrepareVerificationParams.Strategy
+
+      /**
+       * Send an email with a verification link.
+       *
+       * @property redirectUrl Legacy callback URL field. When [redirectUri] is not provided this
+       *   value is used as the native callback URI.
+       * @property redirectUri Callback URI used for native email-link completion.
+       * @property codeChallenge PKCE code challenge for native email-link verification.
+       * @property codeChallengeMethod PKCE method. Native flows require `S256`.
+       */
+      data class EmailLink(
+        override val strategy: String = AuthStrategy.EMAIL_LINK,
+        @SerialName("redirect_url") val redirectUrl: String? = null,
+        @SerialName("redirect_uri") val redirectUri: String? = null,
+        @SerialName("code_challenge") val codeChallenge: String? = null,
+        @SerialName("code_challenge_method") val codeChallengeMethod: String = PKCE_METHOD_S256,
+      ) : PrepareVerificationParams.Strategy
     }
   }
 
@@ -576,7 +596,10 @@ suspend fun SignUp.get(
 suspend fun SignUp.prepareVerification(
   prepareVerification: SignUp.PrepareVerificationParams.Strategy
 ): ClerkResult<SignUp, ClerkErrorResponse> {
-  return ClerkApi.signUp.prepareSignUpVerification(this.id, prepareVerification.strategy)
+  if (prepareVerification is SignUp.PrepareVerificationParams.Strategy.EmailLink) {
+    return NativeMagicLinkService.prepareSignUpEmailLink(this.id, prepareVerification)
+  }
+  return ClerkApi.signUp.prepareSignUpVerification(this.id, fields = prepareVerification.toFields())
 }
 
 /**
@@ -603,6 +626,16 @@ suspend fun SignUp.sendPhoneCode(): ClerkResult<SignUp, ClerkErrorResponse> {
  */
 suspend fun SignUp.sendEmailCode(): ClerkResult<SignUp, ClerkErrorResponse> {
   return prepareVerification(SignUp.PrepareVerificationParams.Strategy.EmailCode())
+}
+
+/**
+ * Sends a verification link to the email address associated with this sign-up.
+ *
+ * @return A [ClerkResult] containing the updated [SignUp] object on success, or a
+ *   [ClerkErrorResponse] on failure.
+ */
+suspend fun SignUp.sendEmailLink(): ClerkResult<SignUp, ClerkErrorResponse> {
+  return prepareVerification(SignUp.PrepareVerificationParams.Strategy.EmailLink())
 }
 
 /**
@@ -633,3 +666,59 @@ suspend fun SignUp.attemptVerification(
  * @return An [OAuthResult] containing this [SignUp] object.
  */
 internal fun SignUp.toOAuthResult() = OAuthResult(signUp = this)
+
+private const val EMAIL_ADDRESS = "email_address"
+
+val SignUp.emailVerificationStrategy: String
+  get() {
+    val activeStrategy = verifications[EMAIL_ADDRESS]?.strategy
+    if (!activeStrategy.isNullOrBlank()) return activeStrategy
+
+    val configuredStrategies =
+      runCatching {
+          Clerk.environment?.userSettings?.attributes?.get(EMAIL_ADDRESS)?.verifications.orEmpty()
+        }
+        .getOrDefault(emptyList())
+
+    return when {
+      configuredStrategies.contains(AuthStrategy.EMAIL_LINK) -> AuthStrategy.EMAIL_LINK
+      configuredStrategies.contains(AuthStrategy.EMAIL_CODE) -> AuthStrategy.EMAIL_CODE
+      else -> AuthStrategy.EMAIL_CODE
+    }
+  }
+
+val SignUp.isEmailLinkVerificationSupported: Boolean
+  get() = emailVerificationStrategy == AuthStrategy.EMAIL_LINK
+
+private fun SignUp.PrepareVerificationParams.Strategy.toFields(): Map<String, String> {
+  val strategyFields = mutableMapOf(ApiParams.STRATEGY to strategy)
+
+  if (this is SignUp.PrepareVerificationParams.Strategy.EmailLink) {
+    val resolvedRedirectUri =
+      redirectUri
+        ?: redirectUrl
+        ?: runCatching {
+            val applicationId = Clerk.applicationId
+            if (applicationId.isNullOrBlank()) {
+              null
+            } else {
+              RedirectConfiguration.emailLinkRedirectUrl(
+                applicationId = applicationId,
+                proxyUrl = Clerk.proxyUrl,
+              )
+            }
+          }
+          .getOrNull()
+    if (!resolvedRedirectUri.isNullOrBlank()) {
+      strategyFields[ApiParams.REDIRECT_URI] = resolvedRedirectUri
+    }
+
+    strategyFields[ApiParams.CODE_CHALLENGE] = codeChallenge ?: PkceUtil.generatePair().challenge
+    strategyFields[ApiParams.CODE_CHALLENGE_METHOD] =
+      if (codeChallengeMethod == PKCE_METHOD_S256) codeChallengeMethod else PKCE_METHOD_S256
+  }
+
+  return strategyFields
+}
+
+private const val PKCE_METHOD_S256 = "S256"

--- a/source/api/src/main/kotlin/com/clerk/api/signup/SignUpExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signup/SignUpExtensions.kt
@@ -32,12 +32,16 @@ suspend fun SignUp.sendCode(
 
   val strategy =
     if (builder.email != null) {
-      SignUp.PrepareVerificationParams.Strategy.EmailCode()
+      if (isEmailLinkVerificationSupported) {
+        SignUp.PrepareVerificationParams.Strategy.EmailLink()
+      } else {
+        SignUp.PrepareVerificationParams.Strategy.EmailCode()
+      }
     } else {
       SignUp.PrepareVerificationParams.Strategy.PhoneCode()
     }
 
-  return ClerkApi.signUp.prepareSignUpVerification(this.id, strategy.strategy)
+  return prepareVerification(strategy)
 }
 
 /**

--- a/source/api/src/main/kotlin/com/clerk/api/sso/RedirectConfiguration.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/RedirectConfiguration.kt
@@ -1,6 +1,7 @@
 package com.clerk.api.sso
 
 import com.clerk.api.Clerk
+import java.net.URL
 
 /**
  * Internal configuration object for OAuth redirect URLs.
@@ -15,6 +16,7 @@ internal object RedirectConfiguration {
   private const val SCHEME = "clerk"
   private const val DEFAULT_HOST_SUFFIX = "callback"
   private const val LEGACY_HOST_SUFFIX = "oauth"
+  private const val DEFAULT_HTTPS_PORT = 443
 
   /**
    * The default redirect URL used for OAuth authentication flows.
@@ -35,7 +37,22 @@ internal object RedirectConfiguration {
   val LEGACY_REDIRECT_URL: String
     get() = buildRedirectUrl(LEGACY_HOST_SUFFIX)
 
+  internal fun emailLinkRedirectUrl(
+    applicationId: String,
+    proxyUrl: String? = Clerk.proxyUrl,
+  ): String {
+    val portSuffix = resolveNonDefaultHttpsPort(proxyUrl)
+    return "$SCHEME://$applicationId.$DEFAULT_HOST_SUFFIX$portSuffix"
+  }
+
   private fun buildRedirectUrl(hostSuffix: String): String {
     return "$SCHEME://${Clerk.applicationId}.$hostSuffix"
+  }
+
+  private fun resolveNonDefaultHttpsPort(proxyUrl: String?): String {
+    val parsedPort =
+      proxyUrl?.takeUnless { it.isBlank() }?.let { runCatching { URL(it) }.getOrNull() }?.port
+    val nonDefaultPort = parsedPort?.takeIf { it > 0 && it != DEFAULT_HTTPS_PORT }
+    return nonDefaultPort?.let { ":$it" }.orEmpty()
   }
 }

--- a/source/api/src/main/kotlin/com/clerk/api/sso/SSOManagerActivity.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/SSOManagerActivity.kt
@@ -11,6 +11,8 @@ import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import com.clerk.api.Constants.Storage.KEY_AUTHORIZATION_STARTED
 import com.clerk.api.log.ClerkLog
+import com.clerk.api.magiclink.NativeMagicLinkService
+import com.clerk.api.magiclink.canHandleNativeMagicLink
 import kotlinx.coroutines.launch
 
 /**
@@ -30,6 +32,7 @@ internal class SSOManagerActivity : AppCompatActivity() {
   private var authorizationStarted = false
   private var completionStarted = false
   private lateinit var desiredUri: Uri
+  private var pendingCallbackUri: Uri? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -42,6 +45,18 @@ internal class SSOManagerActivity : AppCompatActivity() {
 
   override fun onResume() {
     super.onResume()
+    val callbackUri = pendingCallbackUri ?: intent.data?.takeIf(::isCallbackUri)
+    if (callbackUri != null) {
+      if (!completionStarted) {
+        completionStarted = true
+        authorizationStarted = true
+        pendingCallbackUri = callbackUri
+        intent = Intent(intent).apply { data = null }
+        authorizationComplete(callbackUri)
+      }
+      return
+    }
+
     // on first run, launch the intent to start the OAuth/SSO flow in the browser
     if (!authorizationStarted) {
       try {
@@ -63,7 +78,7 @@ internal class SSOManagerActivity : AppCompatActivity() {
     intent.data?.let {
       if (!completionStarted) {
         completionStarted = true
-        // Clear the intent's data to avoid re-triggering completion on subsequent resumes
+        pendingCallbackUri = it
         intent = Intent(intent).apply { data = null }
         authorizationComplete(it)
       }
@@ -84,6 +99,10 @@ internal class SSOManagerActivity : AppCompatActivity() {
     super.onSaveInstanceState(outState)
     outState.putBoolean(KEY_AUTHORIZATION_STARTED, authorizationStarted)
     outState.putBoolean(KEY_COMPLETION_STARTED, completionStarted)
+    outState.putString(KEY_PENDING_CALLBACK_URI, pendingCallbackUri?.toString())
+    if (::desiredUri.isInitialized) {
+      outState.putString(URI_KEY, desiredUri.toString())
+    }
   }
 
   /**
@@ -97,6 +116,7 @@ internal class SSOManagerActivity : AppCompatActivity() {
     authorizationStarted = state.getBoolean(KEY_AUTHORIZATION_STARTED, false)
     completionStarted = state.getBoolean(KEY_COMPLETION_STARTED, false)
     state.getString(URI_KEY)?.let { desiredUri = it.toUri() }
+    pendingCallbackUri = state.getString(KEY_PENDING_CALLBACK_URI)?.toUri()
   }
 
   /**
@@ -107,8 +127,21 @@ internal class SSOManagerActivity : AppCompatActivity() {
   private fun authorizationComplete(uri: Uri) {
     lifecycleScope.launch {
       try {
-        // Mark the Activity result as success so callers don't observe RESULT_CANCELED
-        setResult(RESULT_OK, Intent())
+        if (canHandleNativeMagicLink(uri)) {
+          ClerkLog.d("authorizationComplete called with native magic link redirect: $uri")
+          when (NativeMagicLinkService.handleMagicLinkDeepLink(uri)) {
+            is com.clerk.api.network.serialization.ClerkResult.Success -> {
+              ClerkLog.i("event=native_magic_link_activity_completion_success")
+              pendingCallbackUri = null
+              setResult(RESULT_OK, Intent())
+            }
+            is com.clerk.api.network.serialization.ClerkResult.Failure -> {
+              ClerkLog.w("event=native_magic_link_activity_completion_failure")
+              setResult(RESULT_CANCELED, Intent())
+            }
+          }
+          return@launch
+        }
         if (SSOService.hasPendingExternalAccountConnection()) {
           ClerkLog.d("authorizationComplete called with external connection")
           SSOService.completeExternalConnection()
@@ -116,11 +149,21 @@ internal class SSOManagerActivity : AppCompatActivity() {
           ClerkLog.d("authorizationComplete called with redirect: $uri")
           SSOService.completeAuthenticateWithRedirect(uri)
         }
+        pendingCallbackUri = null
+        setResult(RESULT_OK, Intent())
+      } catch (t: Throwable) {
+        ClerkLog.e("authorizationComplete failed: ${t.message}")
+        setResult(RESULT_CANCELED, Intent())
       } finally {
-        // Finish only after the completion call returns so coroutines aren't cancelled early
         finish()
       }
     }
+  }
+
+  private fun isCallbackUri(uri: Uri): Boolean {
+    return uri.scheme?.startsWith("clerk") == true ||
+      canHandleNativeMagicLink(uri) ||
+      uri.getQueryParameter("rotating_token_nonce") != null
   }
 
   /** Handles authentication cancellation by the user. */
@@ -168,5 +211,6 @@ internal class SSOManagerActivity : AppCompatActivity() {
 
     internal const val URI_KEY = "uri"
     internal const val KEY_COMPLETION_STARTED = "completion_started"
+    internal const val KEY_PENDING_CALLBACK_URI = "pending_callback_uri"
   }
 }

--- a/source/api/src/main/kotlin/com/clerk/api/storage/StorageHelper.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/storage/StorageHelper.kt
@@ -111,7 +111,7 @@ internal object StorageHelper {
       )
       return
     }
-    prefs.edit { remove(key.name) }
+    prefs.edit(commit = true) { remove(key.name) }
   }
 
   /**
@@ -154,4 +154,5 @@ internal object StorageHelper {
 internal enum class StorageKey {
   DEVICE_TOKEN,
   DEVICE_ID,
+  PENDING_NATIVE_MAGIC_LINK_FLOW,
 }

--- a/source/api/src/main/res/values/themes.xml
+++ b/source/api/src/main/res/values/themes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Clerk.AuthBridge" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+</resources>

--- a/source/api/src/test/java/com/clerk/api/auth/AuthHandleTest.kt
+++ b/source/api/src/test/java/com/clerk/api/auth/AuthHandleTest.kt
@@ -1,0 +1,91 @@
+package com.clerk.api.auth
+
+import android.net.Uri
+import com.clerk.api.magiclink.NativeMagicLinkAuthResult
+import com.clerk.api.magiclink.NativeMagicLinkService
+import com.clerk.api.magiclink.canHandleNativeMagicLink
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.api.sso.SSOService
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AuthHandleTest {
+  private lateinit var auth: Auth
+
+  @Before
+  fun setup() {
+    auth = Auth()
+    mockkObject(NativeMagicLinkService)
+    mockkStatic(::canHandleNativeMagicLink)
+    mockkObject(SSOService)
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `handle completes native magic link callback without SSO fallback`() = runTest {
+    val callbackUri = mockk<Uri>(relaxed = true)
+
+    every { canHandleNativeMagicLink(callbackUri) } returns true
+    coEvery { NativeMagicLinkService.handleMagicLinkDeepLink(callbackUri) } returns
+      ClerkResult.success(NativeMagicLinkAuthResult.SignIn(mockk<SignIn>(relaxed = true)))
+
+    val handled = auth.handle(callbackUri)
+
+    assertTrue(handled)
+    coVerify(exactly = 1) { NativeMagicLinkService.handleMagicLinkDeepLink(callbackUri) }
+    coVerify(exactly = 0) { SSOService.completeAuthenticateWithRedirect(any()) }
+  }
+
+  @Test
+  fun `handle completes SSO callback when URI is Clerk scheme and not magic link`() = runTest {
+    val callbackUri = mockk<Uri>(relaxed = true)
+
+    every { canHandleNativeMagicLink(callbackUri) } returns false
+    every { callbackUri.scheme } returns "clerk"
+    coJustRun { SSOService.completeAuthenticateWithRedirect(callbackUri) }
+
+    val handled = auth.handle(callbackUri)
+
+    assertTrue(handled)
+    coVerify(exactly = 0) { NativeMagicLinkService.handleMagicLinkDeepLink(any()) }
+    coVerify(exactly = 1) { SSOService.completeAuthenticateWithRedirect(callbackUri) }
+  }
+
+  @Test
+  fun `handle returns false for non Clerk URIs`() = runTest {
+    val callbackUri = mockk<Uri>(relaxed = true)
+
+    every { canHandleNativeMagicLink(callbackUri) } returns false
+    every { callbackUri.scheme } returns "https"
+
+    val handled = auth.handle(callbackUri)
+
+    assertFalse(handled)
+    coVerify(exactly = 0) { NativeMagicLinkService.handleMagicLinkDeepLink(any()) }
+    coVerify(exactly = 0) { SSOService.completeAuthenticateWithRedirect(any()) }
+  }
+
+  @Test
+  fun `handle returns false for null URI`() = runTest {
+    assertFalse(auth.handle(null))
+    coVerify(exactly = 0) { NativeMagicLinkService.handleMagicLinkDeepLink(any()) }
+    coVerify(exactly = 0) { SSOService.completeAuthenticateWithRedirect(any()) }
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/auth/AuthOtpTest.kt
+++ b/source/api/src/test/java/com/clerk/api/auth/AuthOtpTest.kt
@@ -1,0 +1,62 @@
+package com.clerk.api.auth
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.api.SignInApi
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AuthOtpTest {
+  private lateinit var auth: Auth
+  private lateinit var signInApi: SignInApi
+
+  @Before
+  fun setup() {
+    auth = Auth()
+    signInApi = mockk(relaxed = true)
+
+    mockkObject(ClerkApi)
+    mockkObject(Clerk)
+
+    every { ClerkApi.signIn } returns signInApi
+    every { Clerk.locale } returns MutableStateFlow("en")
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `signInWithOtp for email creates email code flow instead of native email link`() = runTest {
+    val createdSignIn = SignIn(id = "sign_in_123")
+    val createParams = slot<Map<String, String>>()
+
+    coEvery { signInApi.createSignIn(capture(createParams)) } returns
+      ClerkResult.success(createdSignIn)
+
+    val result = auth.signInWithOtp { email = "user@example.com" }
+
+    assertTrue(result is ClerkResult.Success)
+    assertTrue(createParams.captured["identifier"] == "user@example.com")
+    assertTrue(createParams.captured["locale"] == "en")
+    assertTrue(createParams.captured["strategy"] == "email_code")
+    assertTrue(!createParams.captured.containsKey("redirect_uri"))
+    assertTrue(!createParams.captured.containsKey("code_challenge"))
+    coVerify(exactly = 1) { signInApi.createSignIn(any()) }
+    coVerify(exactly = 0) { signInApi.prepareSignInFirstFactor(any(), any()) }
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/integration/AuthIntegrationTests.kt
+++ b/source/api/src/test/java/com/clerk/api/integration/AuthIntegrationTests.kt
@@ -29,7 +29,6 @@ import org.robolectric.RobolectricTestRunner
  */
 @RunWith(RobolectricTestRunner::class)
 class AuthIntegrationTests {
-
   @Test
   fun `sign up and sign in with email codes`(): Unit = runBlocking {
     val pk = requirePublishableKey()

--- a/source/api/src/test/java/com/clerk/api/integration/IntegrationTestHelpers.kt
+++ b/source/api/src/test/java/com/clerk/api/integration/IntegrationTestHelpers.kt
@@ -3,7 +3,6 @@ package com.clerk.api.integration
 import com.clerk.api.Clerk
 import java.io.File
 import java.util.UUID
-import kotlin.random.Random
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
@@ -63,11 +62,11 @@ suspend fun initializeClerkAndWait(publishableKey: String, timeoutMs: Long = INI
 fun generateTestEmail(): String = "test+clerk_test_${UUID.randomUUID()}@example.com"
 
 fun generateTestPhone(): String {
-  val areaCode = buildString {
-    append(Random.nextInt(from = 2, until = 10))
-    append(Random.nextInt(from = 0, until = 10))
-    append(Random.nextInt(from = 0, until = 10))
-  }
-  val suffix = Random.nextInt(from = 0, until = 100).toString().padStart(length = 2, padChar = '0')
-  return "+1${areaCode}55501${suffix}"
+  val seed = UUID.randomUUID()
+  val areaSeed = seed.mostSignificantBits and Long.MAX_VALUE
+  val firstDigit = 2 + (areaSeed % 8L).toInt()
+  val secondDigit = ((areaSeed / 8L) % 10L).toInt()
+  val thirdDigit = ((areaSeed / 80L) % 10L).toInt()
+  val suffix = ((seed.leastSignificantBits and 0x7FFF).toInt()) % 100
+  return "+1${firstDigit}${secondDigit}${thirdDigit}55501%02d".format(suffix)
 }

--- a/source/api/src/test/java/com/clerk/api/log/SafeUriLogTest.kt
+++ b/source/api/src/test/java/com/clerk/api/log/SafeUriLogTest.kt
@@ -1,0 +1,39 @@
+package com.clerk.api.log
+
+import android.net.Uri
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SafeUriLogTest {
+
+  @Test
+  fun `describe includes URI shape but redacts parameter values`() {
+    val uri =
+      Uri.parse(
+        "https://example.com/v1/verify?token=secret-token&flow_id=flow_123&approval_token=approval_123"
+      )
+
+    val description = SafeUriLog.describe(uri)
+
+    assertTrue(description.contains("scheme=https"))
+    assertTrue(description.contains("host=example.com"))
+    assertTrue(description.contains("query_keys=[approval_token, flow_id, token]"))
+    assertFalse(description.contains("secret-token"))
+    assertFalse(description.contains("approval_123"))
+  }
+
+  @Test
+  fun `describe parses fragment keys`() {
+    val uri = Uri.parse("clerk://callback#flow_id=flow_123&approval_token=approval_123")
+
+    val description = SafeUriLog.describe(uri)
+
+    assertTrue(description.contains("fragment_keys=[approval_token, flow_id]"))
+    assertFalse(description.contains("flow_123"))
+    assertFalse(description.contains("approval_123"))
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/magiclink/MagicLinkDeepLinkParserTest.kt
+++ b/source/api/src/test/java/com/clerk/api/magiclink/MagicLinkDeepLinkParserTest.kt
@@ -1,0 +1,47 @@
+package com.clerk.api.magiclink
+
+import android.net.Uri
+import com.clerk.api.network.serialization.ClerkResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MagicLinkDeepLinkParserTest {
+  @Test
+  fun `parses flow_id and approval_token from query`() {
+    val uri = Uri.parse("clerk://callback?flow_id=flow_123&approval_token=approval_123")
+
+    val result = parseMagicLinkCallback(uri)
+
+    assertTrue(result is ClerkResult.Success)
+    val value = (result as ClerkResult.Success).value
+    assertEquals("flow_123", value.flowId)
+    assertEquals("approval_123", value.approvalToken)
+  }
+
+  @Test
+  fun `parses flow_id and approval_token from fragment`() {
+    val uri = Uri.parse("clerk://callback#flow_id=flow_123&approval_token=approval_123")
+
+    val result = parseMagicLinkCallback(uri)
+
+    assertTrue(result is ClerkResult.Success)
+    val value = (result as ClerkResult.Success).value
+    assertEquals("flow_123", value.flowId)
+    assertEquals("approval_123", value.approvalToken)
+  }
+
+  @Test
+  fun `missing flow_id returns deterministic reason code`() {
+    val uri = Uri.parse("clerk://callback?approval_token=approval_123")
+
+    val result = parseMagicLinkCallback(uri)
+
+    assertTrue(result is ClerkResult.Failure)
+    val reason = (result as ClerkResult.Failure).error?.reasonCode
+    assertEquals(NativeMagicLinkReason.MISSING_FLOW_ID.code, reason)
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/magiclink/NativeMagicLinkErrorMappingTest.kt
+++ b/source/api/src/test/java/com/clerk/api/magiclink/NativeMagicLinkErrorMappingTest.kt
@@ -1,0 +1,45 @@
+package com.clerk.api.magiclink
+
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.model.error.Error
+import com.clerk.api.network.serialization.ClerkResult
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NativeMagicLinkErrorMappingTest {
+  @Test
+  fun `maps known backend error codes deterministically`() {
+    assertMapped("approval_token_consumed", NativeMagicLinkReason.APPROVAL_TOKEN_CONSUMED)
+    assertMapped("approval_token_expired", NativeMagicLinkReason.APPROVAL_TOKEN_EXPIRED)
+    assertMapped("approval_token_invalid", NativeMagicLinkReason.APPROVAL_TOKEN_INVALID)
+    assertMapped("pkce_verification_failed", NativeMagicLinkReason.PKCE_VERIFICATION_FAILED)
+    assertMapped("flow_not_approved", NativeMagicLinkReason.FLOW_NOT_APPROVED)
+  }
+
+  @Test
+  fun `unknown backend errors preserve backend error code`() {
+    val mapped =
+      failure(code = "too_many_requests", longMessage = "Too many requests, retry later")
+        .toNativeMagicLinkError(NativeMagicLinkReason.COMPLETE_FAILED)
+
+    assertEquals("too_many_requests", mapped.reasonCode)
+    assertEquals("Too many requests, retry later", mapped.message)
+  }
+
+  private fun assertMapped(apiCode: String, expected: NativeMagicLinkReason) {
+    val mapped = failure(apiCode).toNativeMagicLinkError(NativeMagicLinkReason.COMPLETE_FAILED)
+    assertEquals(expected.code, mapped.reasonCode)
+  }
+
+  private fun failure(
+    code: String,
+    longMessage: String? = null,
+  ): ClerkResult.Failure<ClerkErrorResponse> {
+    val errorResponse =
+      ClerkErrorResponse(errors = listOf(Error(code = code, longMessage = longMessage)))
+    return ClerkResult.apiFailure(errorResponse)
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/magiclink/NativeMagicLinkServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/magiclink/NativeMagicLinkServiceTest.kt
@@ -1,0 +1,402 @@
+package com.clerk.api.magiclink
+
+import android.net.Uri
+import com.clerk.api.Clerk
+import com.clerk.api.auth.Auth
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.api.ClientApi
+import com.clerk.api.network.api.MagicLinkApi
+import com.clerk.api.network.api.SignInApi
+import com.clerk.api.network.api.SignUpApi
+import com.clerk.api.network.model.client.Client
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.model.error.Error
+import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.network.model.magiclink.NativeMagicLinkCompleteResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signup.SignUp
+import com.clerk.api.storage.StorageHelper
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class NativeMagicLinkServiceTest {
+  private lateinit var signInApi: SignInApi
+  private lateinit var signUpApi: SignUpApi
+  private lateinit var magicLinkApi: MagicLinkApi
+  private lateinit var clientApi: ClientApi
+  private lateinit var auth: Auth
+
+  @Before
+  fun setup() {
+    StorageHelper.initialize(RuntimeEnvironment.getApplication())
+    StorageHelper.reset(RuntimeEnvironment.getApplication())
+
+    signInApi = mockk(relaxed = true)
+    signUpApi = mockk(relaxed = true)
+    magicLinkApi = mockk(relaxed = true)
+    clientApi = mockk(relaxed = true)
+    auth = mockk(relaxed = true)
+
+    mockkObject(ClerkApi)
+    mockkObject(Clerk)
+
+    every { ClerkApi.signIn } returns signInApi
+    every { ClerkApi.signUp } returns signUpApi
+    every { ClerkApi.magicLink } returns magicLinkApi
+    every { ClerkApi.client } returns clientApi
+    every { Clerk.auth } returns auth
+    every { Clerk.locale } returns MutableStateFlow("en")
+    every { Clerk.applicationId } returns "com.clerk.test"
+    every { Clerk.proxyUrl } returns null
+    every { Clerk.updateClient(any()) } just runs
+
+    NativeMagicLinkService.resetForTests()
+  }
+
+  @After
+  fun tearDown() {
+    NativeMagicLinkService.resetForTests()
+    StorageHelper.reset(RuntimeEnvironment.getApplication())
+    unmockkAll()
+  }
+
+  @Test
+  fun `end-to-end native magic link flow completes with ticket sign-in`() = runTest {
+    val initialSignIn = emailLinkSignIn()
+    val preparedSignIn = initialSignIn.copy(status = SignIn.Status.NEEDS_FIRST_FACTOR)
+    val completedSignIn =
+      initialSignIn.copy(status = SignIn.Status.COMPLETE, createdSessionId = "sess_123")
+    val refreshedClient = mockk<Client>(relaxed = true)
+    val activatedSession = mockk<Session>(relaxed = true)
+
+    mockEmailLinkPrepare(initialSignIn, preparedSignIn)
+    coEvery { magicLinkApi.complete(any()) } returns
+      ClerkResult.success(NativeMagicLinkCompleteResponse(ticket = "ticket_123"))
+    coEvery { auth.signInWithTicket("ticket_123") } returns ClerkResult.success(completedSignIn)
+    coEvery { auth.setActive("sess_123", null) } returns ClerkResult.success(activatedSession)
+    coEvery { clientApi.get() } returns ClerkResult.success(refreshedClient)
+
+    val startResult = NativeMagicLinkService.startEmailLinkSignIn("user@example.com")
+    assertTrue(startResult is ClerkResult.Success)
+
+    val callbackUri =
+      Uri.parse("clerk://com.clerk.test.oauth?flow_id=sign_in_123&approval_token=approval_123")
+    val completeResult = NativeMagicLinkService.handleMagicLinkDeepLink(callbackUri)
+    assertTrue(completeResult is ClerkResult.Success)
+    assertEquals(
+      SignIn.Status.COMPLETE,
+      ((completeResult as ClerkResult.Success).value as NativeMagicLinkAuthResult.SignIn)
+        .signIn
+        .status,
+    )
+
+    verifyEndToEndRequests()
+  }
+
+  private fun verifyEndToEndRequests() {
+    coVerify(exactly = 1) {
+      signInApi.createSignIn(
+        match {
+          it["identifier"] == "user@example.com" &&
+            it["locale"] == "en" &&
+            it.keys == setOf("identifier", "locale")
+        }
+      )
+    }
+    coVerify(exactly = 1) {
+      signInApi.prepareSignInFirstFactor(
+        "sign_in_123",
+        match {
+          it["strategy"] == "email_link" &&
+            it["email_address_id"] == "email_123" &&
+            it["redirect_uri"] == "clerk://com.clerk.test.callback" &&
+            it["code_challenge_method"] == "S256" &&
+            it["code_challenge"]?.isNotBlank() == true &&
+            !it.containsKey("code_verifier")
+        },
+      )
+    }
+    coVerify(exactly = 1) {
+      magicLinkApi.complete(
+        match {
+          it["flow_id"] == "sign_in_123" &&
+            it["approval_token"] == "approval_123" &&
+            it["code_verifier"]?.isNotBlank() == true
+        }
+      )
+    }
+    coVerify(exactly = 1) { auth.signInWithTicket("ticket_123") }
+    coVerify(exactly = 1) { auth.setActive("sess_123", null) }
+    coVerify(exactly = 0) { signInApi.fetchSignIn(any(), any()) }
+  }
+
+  @Test
+  fun `native magic link sign-in with mfa returns in-progress sign in without activating session`() =
+    runTest {
+      val initialSignIn = emailLinkSignIn()
+      val preparedSignIn = initialSignIn.copy(status = SignIn.Status.NEEDS_FIRST_FACTOR)
+      val mfaSignIn =
+        initialSignIn.copy(
+          status = SignIn.Status.NEEDS_SECOND_FACTOR,
+          supportedSecondFactors = listOf(Factor(strategy = "totp")),
+          createdSessionId = null,
+        )
+      val refreshedClient = mockk<Client>(relaxed = true)
+
+      mockEmailLinkPrepare(initialSignIn, preparedSignIn)
+      coEvery { magicLinkApi.complete(any()) } returns
+        ClerkResult.success(NativeMagicLinkCompleteResponse(ticket = "ticket_123"))
+      coEvery { auth.signInWithTicket("ticket_123") } returns ClerkResult.success(mfaSignIn)
+      coEvery { clientApi.get() } returns ClerkResult.success(refreshedClient)
+
+      val startResult = NativeMagicLinkService.startEmailLinkSignIn("user@example.com")
+      assertTrue(startResult is ClerkResult.Success)
+
+      val callbackUri =
+        Uri.parse("clerk://com.clerk.test.oauth?flow_id=sign_in_123&approval_token=approval_123")
+      val completeResult = NativeMagicLinkService.handleMagicLinkDeepLink(callbackUri)
+      assertTrue(completeResult is ClerkResult.Success)
+      assertEquals(
+        SignIn.Status.NEEDS_SECOND_FACTOR,
+        ((completeResult as ClerkResult.Success).value as NativeMagicLinkAuthResult.SignIn)
+          .signIn
+          .status,
+      )
+
+      coVerify(exactly = 1) { auth.signInWithTicket("ticket_123") }
+      coVerify(exactly = 0) { auth.setActive(any(), any()) }
+      coVerify(exactly = 0) { clientApi.get() }
+    }
+
+  @Test
+  fun `sign-up native email-link prepare stores PKCE verifier for callback completion`() = runTest {
+    val preparedSignUp = mockk<SignUp>(relaxed = true)
+    val completedSignUp = completedSignUp()
+    val refreshedClient = mockk<Client>(relaxed = true)
+    val activatedSession = mockk<Session>(relaxed = true)
+    val strategy =
+      SignUp.PrepareVerificationParams.Strategy.EmailLink(
+        redirectUri = "clerk://com.clerk.test.oauth"
+      )
+
+    coEvery { signUpApi.prepareSignUpVerification("sign_up_123", any()) } returns
+      ClerkResult.success(preparedSignUp)
+    coEvery { magicLinkApi.complete(any()) } returns
+      ClerkResult.success(NativeMagicLinkCompleteResponse(ticket = "ticket_signup"))
+    coEvery { auth.signUpWithTicket("ticket_signup") } returns ClerkResult.success(completedSignUp)
+    coEvery { auth.setActive("sess_456", null) } returns ClerkResult.success(activatedSession)
+    coEvery { clientApi.get() } returns ClerkResult.success(refreshedClient)
+
+    val prepareResult =
+      NativeMagicLinkService.prepareSignUpEmailLink(signUpId = "sign_up_123", strategy = strategy)
+    assertTrue(prepareResult is ClerkResult.Success)
+
+    val completeResult = NativeMagicLinkService.handleMagicLinkDeepLink(callbackUri("sign_up_123"))
+    assertSuccessfulSignUpCompletion(completeResult)
+
+    coVerify(exactly = 1) {
+      signUpApi.prepareSignUpVerification(
+        "sign_up_123",
+        match {
+          it["strategy"] == "email_link" &&
+            it["redirect_uri"] == "clerk://com.clerk.test.oauth" &&
+            it["code_challenge_method"] == "S256" &&
+            it["code_challenge"]?.isNotBlank() == true
+        },
+      )
+    }
+    coVerify(exactly = 1) {
+      magicLinkApi.complete(
+        match {
+          it["flow_id"] == "sign_up_123" &&
+            it["approval_token"] == "approval_123" &&
+            it["code_verifier"]?.isNotBlank() == true
+        }
+      )
+    }
+    coVerify(exactly = 1) { auth.signUpWithTicket("ticket_signup") }
+    coVerify(exactly = 0) { auth.signInWithTicket(any()) }
+    coVerify(exactly = 1) { auth.setActive("sess_456", null) }
+  }
+
+  private fun completedSignUp(): SignUp {
+    return SignUp(
+      id = "sign_up_123",
+      status = SignUp.Status.COMPLETE,
+      requiredFields = emptyList(),
+      optionalFields = emptyList(),
+      missingFields = emptyList(),
+      unverifiedFields = emptyList(),
+      verifications = emptyMap(),
+      passwordEnabled = false,
+      createdSessionId = "sess_456",
+      createdUserId = "user_456",
+    )
+  }
+
+  private fun callbackUri(flowId: String): Uri {
+    return Uri.parse("clerk://com.clerk.test.oauth?flow_id=$flowId&approval_token=approval_123")
+  }
+
+  private fun assertSuccessfulSignUpCompletion(
+    result: ClerkResult<NativeMagicLinkAuthResult, NativeMagicLinkError>
+  ) {
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(
+      SignUp.Status.COMPLETE,
+      ((result as ClerkResult.Success).value as NativeMagicLinkAuthResult.SignUp).signUp.status,
+    )
+  }
+
+  private fun emailLinkSignIn(
+    id: String = "sign_in_123",
+    emailAddressId: String = "email_123",
+  ): SignIn {
+    return SignIn(
+      id = id,
+      supportedFirstFactors =
+        listOf(Factor(strategy = "email_link", emailAddressId = emailAddressId)),
+    )
+  }
+
+  private fun mockEmailLinkPrepare(initialSignIn: SignIn, preparedSignIn: SignIn) {
+    coEvery { signInApi.createSignIn(any()) } returns ClerkResult.success(initialSignIn)
+    coEvery { signInApi.prepareSignInFirstFactor(any(), any()) } returns
+      ClerkResult.success(preparedSignIn)
+  }
+
+  @Test
+  fun `complete rejects callback for different pending flow id`() = runTest {
+    val initialSignIn = emailLinkSignIn()
+
+    mockEmailLinkPrepare(
+      initialSignIn,
+      initialSignIn.copy(status = SignIn.Status.NEEDS_FIRST_FACTOR),
+    )
+
+    val startResult = NativeMagicLinkService.startEmailLinkSignIn("user@example.com")
+    assertTrue(startResult is ClerkResult.Success)
+
+    val completeResult = NativeMagicLinkService.complete("sign_in_other", "approval_123")
+
+    assertTrue(completeResult is ClerkResult.Failure)
+    assertEquals(
+      NativeMagicLinkReason.FLOW_ID_MISMATCH.code,
+      (completeResult as ClerkResult.Failure).error?.reasonCode,
+    )
+    coVerify(exactly = 0) { magicLinkApi.complete(any()) }
+  }
+
+  @Test
+  fun `complete keeps pending flow when callback flow id does not match`() = runTest {
+    val initialSignIn = emailLinkSignIn()
+
+    mockEmailLinkPrepare(
+      initialSignIn,
+      initialSignIn.copy(status = SignIn.Status.NEEDS_FIRST_FACTOR),
+    )
+
+    NativeMagicLinkService.startEmailLinkSignIn("user@example.com")
+
+    NativeMagicLinkService.complete("sign_in_other", "approval_123")
+
+    val persisted = PersistentPendingNativeMagicLinkStore().load()
+    assertEquals("sign_in_123", persisted?.flowId)
+    assertTrue(persisted?.codeVerifier?.isNotBlank() == true)
+  }
+
+  @Test
+  fun `complete does not clear a newer pending flow saved before old completion finishes`() =
+    runTest {
+      val originalSignIn = emailLinkSignIn()
+      val newerSignIn = emailLinkSignIn(id = "sign_in_new", emailAddressId = "email_new")
+
+      coEvery { signInApi.createSignIn(match { it["identifier"] == "user@example.com" }) } returns
+        ClerkResult.success(originalSignIn)
+      coEvery { signInApi.createSignIn(match { it["identifier"] == "new@example.com" }) } returns
+        ClerkResult.success(newerSignIn)
+      coEvery { signInApi.prepareSignInFirstFactor("sign_in_123", any()) } returns
+        ClerkResult.success(originalSignIn.copy(status = SignIn.Status.NEEDS_FIRST_FACTOR))
+      coEvery { signInApi.prepareSignInFirstFactor("sign_in_new", any()) } returns
+        ClerkResult.success(newerSignIn.copy(status = SignIn.Status.NEEDS_FIRST_FACTOR))
+      coEvery { magicLinkApi.complete(any()) } returns
+        ClerkResult.success(NativeMagicLinkCompleteResponse(ticket = "ticket_123"))
+      coEvery { auth.signInWithTicket("ticket_123") } coAnswers
+        {
+          val newerStartResult = NativeMagicLinkService.startEmailLinkSignIn("new@example.com")
+          assertTrue(newerStartResult is ClerkResult.Success)
+          ClerkResult.success(originalSignIn.copy(status = SignIn.Status.NEEDS_SECOND_FACTOR))
+        }
+
+      val originalStartResult = NativeMagicLinkService.startEmailLinkSignIn("user@example.com")
+      assertTrue(originalStartResult is ClerkResult.Success)
+
+      val completeResult = NativeMagicLinkService.complete("sign_in_123", "approval_123")
+
+      assertTrue(completeResult is ClerkResult.Success)
+      val persisted = PersistentPendingNativeMagicLinkStore().load()
+      assertEquals("sign_in_new", persisted?.flowId)
+      assertTrue(persisted?.codeVerifier?.isNotBlank() == true)
+    }
+
+  @Test
+  fun `complete returns activation failure when created session cannot be activated`() = runTest {
+    val initialSignIn = emailLinkSignIn()
+    val preparedSignIn = initialSignIn.copy(status = SignIn.Status.NEEDS_FIRST_FACTOR)
+    val completedSignIn =
+      initialSignIn.copy(status = SignIn.Status.COMPLETE, createdSessionId = "sess_unactivated")
+    val refreshedClient = mockk<Client>(relaxed = true)
+    val apiError =
+      ClerkErrorResponse(
+        errors =
+          listOf(
+            Error(
+              message = "is invalid",
+              longMessage = "Could not activate session",
+              code = "session_cannot_be_activated",
+            )
+          )
+      )
+
+    mockEmailLinkPrepare(initialSignIn, preparedSignIn)
+    coEvery { magicLinkApi.complete(any()) } returns
+      ClerkResult.success(NativeMagicLinkCompleteResponse(ticket = "ticket_123"))
+    coEvery { auth.signInWithTicket("ticket_123") } returns ClerkResult.success(completedSignIn)
+    coEvery { auth.setActive("sess_unactivated", null) } returns ClerkResult.apiFailure(apiError)
+    coEvery { clientApi.get() } returns ClerkResult.success(refreshedClient)
+
+    val startResult = NativeMagicLinkService.startEmailLinkSignIn("user@example.com")
+    assertTrue(startResult is ClerkResult.Success)
+
+    val callbackUri =
+      Uri.parse("clerk://com.clerk.test.oauth?flow_id=sign_in_123&approval_token=approval_123")
+    val completeResult = NativeMagicLinkService.handleMagicLinkDeepLink(callbackUri)
+
+    assertTrue(completeResult is ClerkResult.Failure)
+    assertEquals(
+      "session_cannot_be_activated",
+      (completeResult as ClerkResult.Failure).error?.reasonCode,
+    )
+    assertEquals("Could not activate session", completeResult.error?.message)
+    coVerify(exactly = 1) { auth.setActive("sess_unactivated", null) }
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/magiclink/PersistentPendingNativeMagicLinkStoreTest.kt
+++ b/source/api/src/test/java/com/clerk/api/magiclink/PersistentPendingNativeMagicLinkStoreTest.kt
@@ -1,0 +1,54 @@
+package com.clerk.api.magiclink
+
+import com.clerk.api.storage.StorageHelper
+import com.clerk.api.storage.StorageKey
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class PersistentPendingNativeMagicLinkStoreTest {
+  @Before
+  fun setup() {
+    StorageHelper.initialize(RuntimeEnvironment.getApplication())
+    StorageHelper.reset(RuntimeEnvironment.getApplication())
+  }
+
+  @After
+  fun tearDown() {
+    StorageHelper.reset(RuntimeEnvironment.getApplication())
+  }
+
+  @Test
+  fun `save persists flow across store instances`() {
+    val flow =
+      PendingNativeMagicLinkFlow(
+        codeVerifier = "verifier_123",
+        state = PendingNativeMagicLinkState.SIGN_IN,
+        createdAtEpochMs = 100L,
+        expiresAtEpochMs = 200L,
+        flowId = "flow_123",
+      )
+
+    PersistentPendingNativeMagicLinkStore().save(flow)
+
+    val restored = PersistentPendingNativeMagicLinkStore().load()
+
+    assertEquals(flow, restored)
+  }
+
+  @Test
+  fun `load clears corrupted payload`() {
+    StorageHelper.saveValue(StorageKey.PENDING_NATIVE_MAGIC_LINK_FLOW, "{bad json")
+
+    val restored = PersistentPendingNativeMagicLinkStore().load()
+
+    assertNull(restored)
+    assertNull(StorageHelper.loadValue(StorageKey.PENDING_NATIVE_MAGIC_LINK_FLOW))
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/magiclink/PkceUtilTest.kt
+++ b/source/api/src/test/java/com/clerk/api/magiclink/PkceUtilTest.kt
@@ -1,0 +1,37 @@
+package com.clerk.api.magiclink
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PkceUtilTest {
+  @Test
+  fun `generatePair returns verifier and challenge in base64url format`() {
+    val pair = PkceUtil.generatePair()
+
+    assertTrue(pair.verifier.length in 43..128)
+    assertFalse(pair.verifier.contains("="))
+    assertTrue(BASE64_URL_REGEX.matches(pair.verifier))
+
+    assertFalse(pair.challenge.contains("="))
+    assertTrue(BASE64_URL_REGEX.matches(pair.challenge))
+  }
+
+  @Test
+  fun `challenge matches verifier using S256`() {
+    val verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    val expectedChallenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+    val challenge = PkceUtil.createS256CodeChallenge(verifier)
+
+    assertEquals(expectedChallenge, challenge)
+  }
+
+  private companion object {
+    private val BASE64_URL_REGEX = Regex("^[A-Za-z0-9_-]+$")
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/network/model/environment/UserSettingsSerializationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/model/environment/UserSettingsSerializationTest.kt
@@ -77,7 +77,8 @@ class UserSettingsSerializationTest {
         },
         "passkey_settings": null
       }
-      """.trimIndent()
+      """
+        .trimIndent()
     return ClerkApi.json.decodeFromString<UserSettings>(json)
   }
 }

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyCreationServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyCreationServiceTest.kt
@@ -76,14 +76,14 @@ class PasskeyCreationServiceTest {
       """
       {
         "id": "credential-id",
-        "rawId": "raw-credential-id", 
+        "rawId": "raw-credential-id",
         "type": "public-key",
         "response": {
           "attestationObject": "test-attestation",
           "clientDataJSON": "test-client-data"
         }
       }
-    """
+      """
         .trimIndent()
 
     every { mockVerification.nonce } returns nonce
@@ -159,7 +159,7 @@ class PasskeyCreationServiceTest {
           "extraField": "should-be-ignored"
         }
       }
-    """
+      """
         .trimIndent()
     every { mockCreateCredentialResponse.data } returns mockBundle
 
@@ -199,7 +199,7 @@ class PasskeyCreationServiceTest {
           "extraField": "should-be-ignored"
         }
       }
-    """
+      """
         .trimIndent()
 
     val publicKeyCredentialSlot = slot<String>()
@@ -288,14 +288,14 @@ class PasskeyCreationServiceTest {
       """
       {
         "id": "test-id",
-        "rawId": "test-raw-id", 
+        "rawId": "test-raw-id",
         "type": "public-key",
         "response": {
           "attestationObject": "test-attestation",
           "clientDataJSON": "test-client-data"
         }
       }
-    """
+      """
         .trimIndent()
     every { mockCreateCredentialResponse.data } returns mockBundle
 

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkAttachActivityTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkAttachActivityTest.kt
@@ -15,12 +15,10 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 /**
- * Verifies the activity-tracking guarantees that callers rely on for
- * Credential Manager flows (Google sign-in, passkeys). Without these,
- * `Clerk.credentialActivity()` returns null on cold start in any host that
- * calls [Clerk.initialize] after the host Activity has already passed
- * onResume — e.g. React Native bridges, late-init flows behind a permission
- * gate.
+ * Verifies the activity-tracking guarantees that callers rely on for Credential Manager flows
+ * (Google sign-in, passkeys). Without these, `Clerk.credentialActivity()` returns null on cold
+ * start in any host that calls [Clerk.initialize] after the host Activity has already passed
+ * onResume — e.g. React Native bridges, late-init flows behind a permission gate.
  */
 @RunWith(RobolectricTestRunner::class)
 class ClerkAttachActivityTest {
@@ -49,9 +47,9 @@ class ClerkAttachActivityTest {
     var activity: Activity? = mockk<Activity>(relaxed = true)
     Clerk.attachActivity(activity!!)
 
-    val ref = Clerk::class.java.getDeclaredField("currentActivity")
-      .apply { isAccessible = true }
-      .get(Clerk) as java.lang.ref.WeakReference<*>?
+    val ref =
+      Clerk::class.java.getDeclaredField("currentActivity").apply { isAccessible = true }.get(Clerk)
+        as java.lang.ref.WeakReference<*>?
 
     // Same instance through the WeakReference while it's alive.
     assertSame(activity, ref?.get())
@@ -70,33 +68,34 @@ class ClerkAttachActivityTest {
   }
 
   /**
-   * `credentialActivity` is a Kotlin `internal` function on the Clerk
-   * singleton. Kotlin mangles its JVM name with a build-flavor suffix
-   * (`$api_debug` in tests, `$api_release` in published artifacts), so we
-   * locate it dynamically by base name rather than hardcoding the suffix.
+   * `credentialActivity` is a Kotlin `internal` function on the Clerk singleton. Kotlin mangles its
+   * JVM name with a build-flavor suffix (`$api_debug` in tests, `$api_release` in published
+   * artifacts), so we locate it dynamically by base name rather than hardcoding the suffix.
    */
   private fun readCredentialActivity(): Activity? {
-    val method = Clerk::class.java.declaredMethods
-      .first { it.name == "credentialActivity" || it.name.startsWith("credentialActivity\$") }
-      .apply { isAccessible = true }
+    val method =
+      Clerk::class
+        .java
+        .declaredMethods
+        .first { it.name == "credentialActivity" || it.name.startsWith("credentialActivity\$") }
+        .apply { isAccessible = true }
     return method.invoke(Clerk) as Activity?
   }
 
   /**
-   * Smoke test for the [Context]-walk inside [Clerk.initialize]. We exercise
-   * the helper directly rather than going through `initialize()` (which would
-   * spin up the configuration manager); the helper's contract is the
-   * load-bearing piece for the seeding guarantee.
+   * Smoke test for the [Context]-walk inside [Clerk.initialize]. We exercise the helper directly
+   * rather than going through `initialize()` (which would spin up the configuration manager); the
+   * helper's contract is the load-bearing piece for the seeding guarantee.
    */
   @Test
   fun `Context findActivityOrNull walks ContextWrapper chain`() {
     val activity = mockk<Activity>(relaxed = true)
     val outer: Context = object : ContextWrapper(activity) {}
 
-    val helper = Clerk::class.java.getDeclaredMethod(
-      "findActivityOrNull",
-      Context::class.java,
-    ).apply { isAccessible = true }
+    val helper =
+      Clerk::class.java.getDeclaredMethod("findActivityOrNull", Context::class.java).apply {
+        isAccessible = true
+      }
 
     val found = helper.invoke(Clerk, outer) as Activity?
     assertSame(activity, found)
@@ -107,10 +106,10 @@ class ClerkAttachActivityTest {
     val plain = mockk<Context>(relaxed = true)
     every { plain.applicationContext } returns plain
 
-    val helper = Clerk::class.java.getDeclaredMethod(
-      "findActivityOrNull",
-      Context::class.java,
-    ).apply { isAccessible = true }
+    val helper =
+      Clerk::class.java.getDeclaredMethod("findActivityOrNull", Context::class.java).apply {
+        isAccessible = true
+      }
 
     val found = helper.invoke(Clerk, plain) as Activity?
     assertNull(found)

--- a/source/api/src/test/java/com/clerk/api/signin/SignInExtensionsTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signin/SignInExtensionsTest.kt
@@ -1,0 +1,189 @@
+package com.clerk.api.signin
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.environment.DisplayConfig
+import com.clerk.api.network.model.environment.Environment
+import com.clerk.api.network.model.environment.PreferredSignInStrategy
+import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.network.model.verification.Verification
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SignInExtensionsTest {
+  private lateinit var environment: Environment
+  private lateinit var displayConfig: DisplayConfig
+
+  @Before
+  fun setup() {
+    environment = mockk(relaxed = true)
+    displayConfig = mockk(relaxed = true)
+    every { environment.displayConfig } returns displayConfig
+    Clerk.environment = environment
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `startingFirstFactor prefers email_link for email identifier when password is preferred`() {
+    every { displayConfig.preferredSignInStrategy } returns PreferredSignInStrategy.PASSWORD
+    val signIn =
+      SignIn(
+        id = "sign_in_123",
+        identifier = "user@example.com",
+        supportedFirstFactors =
+          listOf(
+            Factor(strategy = "password", safeIdentifier = "user@example.com"),
+            Factor(strategy = "email_code", emailAddressId = "email_123"),
+            Factor(strategy = "email_link", emailAddressId = "email_123"),
+          ),
+      )
+
+    val factor = signIn.startingFirstFactor
+
+    assertEquals("email_link", factor?.strategy)
+  }
+
+  @Test
+  fun `startingFirstFactor prefers email_link for email identifier when otp is preferred`() {
+    every { displayConfig.preferredSignInStrategy } returns PreferredSignInStrategy.OTP
+    val signIn =
+      SignIn(
+        id = "sign_in_123",
+        identifier = "user@example.com",
+        supportedFirstFactors =
+          listOf(
+            Factor(strategy = "email_code", emailAddressId = "email_123"),
+            Factor(strategy = "email_link", emailAddressId = "email_123"),
+          ),
+      )
+
+    val factor = signIn.startingFirstFactor
+
+    assertEquals("email_link", factor?.strategy)
+  }
+
+  @Test
+  fun `startingFirstFactor does not force email_link for non-email identifiers`() {
+    every { displayConfig.preferredSignInStrategy } returns PreferredSignInStrategy.OTP
+    val signIn =
+      SignIn(
+        id = "sign_in_123",
+        identifier = "username_123",
+        supportedFirstFactors =
+          listOf(
+            Factor(strategy = "passkey"),
+            Factor(strategy = "email_link", emailAddressId = "email_123"),
+          ),
+      )
+
+    val factor = signIn.startingFirstFactor
+
+    assertEquals("passkey", factor?.strategy)
+  }
+
+  @Test
+  fun `startingFirstFactor chooses email_link matching the email factor identity`() {
+    every { displayConfig.preferredSignInStrategy } returns PreferredSignInStrategy.PASSWORD
+    val signIn =
+      SignIn(
+        id = "sign_in_123",
+        identifier = "user@example.com",
+        supportedFirstFactors =
+          listOf(
+            Factor(strategy = "email_link", emailAddressId = "email_other"),
+            Factor(
+              strategy = "email_code",
+              emailAddressId = "email_123",
+              safeIdentifier = "user@example.com",
+            ),
+            Factor(strategy = "email_link", emailAddressId = "email_123"),
+            Factor(strategy = "password", safeIdentifier = "user@example.com"),
+          ),
+      )
+
+    val factor = signIn.startingFirstFactor
+
+    assertEquals("email_link", factor?.strategy)
+    assertEquals("email_123", factor?.emailAddressId)
+  }
+
+  @Test
+  fun `startingFirstFactor does not use unrelated email_link for username sign-ins`() {
+    every { displayConfig.preferredSignInStrategy } returns PreferredSignInStrategy.PASSWORD
+    val signIn =
+      SignIn(
+        id = "sign_in_123",
+        identifier = "username_123",
+        supportedFirstFactors =
+          listOf(
+            Factor(strategy = "email_link", emailAddressId = "email_123"),
+            Factor(strategy = "password", safeIdentifier = "username_123"),
+          ),
+      )
+
+    val factor = signIn.startingFirstFactor
+
+    assertEquals("password", factor?.strategy)
+  }
+
+  @Test
+  fun `startingFirstFactor matches prepared factor by identifier when strategies repeat`() {
+    every { displayConfig.preferredSignInStrategy } returns PreferredSignInStrategy.OTP
+    val signIn =
+      SignIn(
+        id = "sign_in_123",
+        identifier = "second@example.com",
+        supportedFirstFactors =
+          listOf(
+            Factor(
+              strategy = "email_code",
+              emailAddressId = "email_first",
+              safeIdentifier = "first@example.com",
+            ),
+            Factor(
+              strategy = "email_code",
+              emailAddressId = "email_second",
+              safeIdentifier = "second@example.com",
+            ),
+          ),
+        firstFactorVerification =
+          Verification(status = Verification.Status.UNVERIFIED, strategy = "email_code"),
+      )
+
+    val factor = signIn.startingFirstFactor
+
+    assertEquals("email_second", factor?.emailAddressId)
+  }
+
+  @Test
+  fun `startingFirstFactor returns prepared email_code when verification is already prepared`() {
+    every { displayConfig.preferredSignInStrategy } returns PreferredSignInStrategy.OTP
+    val signIn =
+      SignIn(
+        id = "sign_in_123",
+        identifier = "user@example.com",
+        supportedFirstFactors =
+          listOf(
+            Factor(strategy = "email_code", emailAddressId = "email_123"),
+            Factor(strategy = "email_link", emailAddressId = "email_123"),
+          ),
+        firstFactorVerification =
+          Verification(status = Verification.Status.UNVERIFIED, strategy = "email_code"),
+      )
+
+    val factor = signIn.startingFirstFactor
+
+    assertEquals("email_code", factor?.strategy)
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/signup/SignUpEmailVerificationStrategyTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signup/SignUpEmailVerificationStrategyTest.kt
@@ -1,0 +1,198 @@
+package com.clerk.api.signup
+
+import com.clerk.api.Clerk
+import com.clerk.api.Constants
+import com.clerk.api.magiclink.NativeMagicLinkService
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.api.SignUpApi
+import com.clerk.api.network.model.environment.Environment
+import com.clerk.api.network.model.environment.UserSettings
+import com.clerk.api.network.model.verification.Verification
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.storage.StorageHelper
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class SignUpEmailVerificationStrategyTest {
+  private val mockSignUpApi = mockk<SignUpApi>(relaxed = true)
+  private val environment = mockk<Environment>(relaxed = true)
+  private val userSettings = mockk<UserSettings>(relaxed = true)
+  private var previousEnvironment: Environment? = null
+  private var previousApplicationId: String? = null
+
+  @Before
+  fun setUp() {
+    StorageHelper.initialize(RuntimeEnvironment.getApplication())
+    StorageHelper.reset(RuntimeEnvironment.getApplication())
+    mockkObject(ClerkApi)
+    every { ClerkApi.signUp } returns mockSignUpApi
+    every { environment.userSettings } returns userSettings
+    previousEnvironment = runCatching { Clerk.environment }.getOrNull()
+    previousApplicationId = Clerk.applicationId
+    Clerk.environment = environment
+    NativeMagicLinkService.resetForTests()
+  }
+
+  @After
+  fun tearDown() {
+    previousEnvironment?.let { Clerk.environment = it }
+    Clerk.applicationId = previousApplicationId
+    NativeMagicLinkService.resetForTests()
+    StorageHelper.reset(RuntimeEnvironment.getApplication())
+    unmockkAll()
+  }
+
+  @Test
+  fun emailVerificationStrategyUsesActiveVerificationStrategyWhenPresent() {
+    every { userSettings.attributes } returns emptyMap()
+    val signUp =
+      signUp(
+        verifications =
+          mapOf(
+            "email_address" to
+              Verification(
+                status = Verification.Status.UNVERIFIED,
+                strategy = Constants.Strategy.EMAIL_LINK,
+              )
+          )
+      )
+
+    assertEquals(Constants.Strategy.EMAIL_LINK, signUp.emailVerificationStrategy)
+  }
+
+  @Test
+  fun emailVerificationStrategyFallsBackToEnvironmentStrategiesWhenNoActiveStrategyExists() {
+    every { userSettings.attributes } returns
+      mapOf(
+        "email_address" to
+          UserSettings.AttributesConfig(
+            enabled = true,
+            required = true,
+            usedForFirstFactor = true,
+            firstFactors = listOf(Constants.Strategy.EMAIL_CODE, Constants.Strategy.EMAIL_LINK),
+            usedForSecondFactor = false,
+            secondFactors = emptyList(),
+            verifications = listOf(Constants.Strategy.EMAIL_LINK),
+            verifyAtSignUp = true,
+          )
+      )
+    val signUp = signUp()
+
+    assertEquals(Constants.Strategy.EMAIL_LINK, signUp.emailVerificationStrategy)
+    assertTrue(signUp.isEmailLinkVerificationSupported)
+  }
+
+  @Test
+  fun prepareVerificationMapsNativeEmailLinkPkceFields() {
+    val fieldsSlot = slot<Map<String, String>>()
+    val signUp = signUp()
+
+    coEvery { mockSignUpApi.prepareSignUpVerification(signUp.id, capture(fieldsSlot)) } returns
+      ClerkResult.success(signUp)
+
+    runBlocking {
+      signUp.prepareVerification(
+        SignUp.PrepareVerificationParams.Strategy.EmailLink(redirectUrl = "app://clerk-callback")
+      )
+    }
+
+    coVerify(exactly = 1) { mockSignUpApi.prepareSignUpVerification(signUp.id, any()) }
+    assertEquals(Constants.Strategy.EMAIL_LINK, fieldsSlot.captured["strategy"])
+    assertEquals("app://clerk-callback", fieldsSlot.captured["redirect_uri"])
+    assertEquals("S256", fieldsSlot.captured["code_challenge_method"])
+    assertTrue(fieldsSlot.captured["code_challenge"]?.isNotBlank() == true)
+  }
+
+  @Test
+  fun sendCodeUsesEmailLinkWhenEmailLinkVerificationIsSupported() {
+    every { userSettings.attributes } returns
+      mapOf("email_address" to emailAttributeConfig(listOf(Constants.Strategy.EMAIL_LINK)))
+    Clerk.applicationId = "com.clerk.test"
+    val fieldsSlot = slot<Map<String, String>>()
+    val signUp = signUp()
+
+    coEvery { mockSignUpApi.prepareSignUpVerification(signUp.id, capture(fieldsSlot)) } returns
+      ClerkResult.success(signUp)
+
+    runBlocking { signUp.sendCode { email = "sam@clerk.dev" } }
+
+    coVerify(exactly = 1) { mockSignUpApi.prepareSignUpVerification(signUp.id, any()) }
+    assertEquals(Constants.Strategy.EMAIL_LINK, fieldsSlot.captured["strategy"])
+    assertTrue(fieldsSlot.captured["redirect_uri"]?.isNotBlank() == true)
+    assertEquals("S256", fieldsSlot.captured["code_challenge_method"])
+    assertTrue(fieldsSlot.captured["code_challenge"]?.isNotBlank() == true)
+  }
+
+  @Test
+  fun sendCodeFallsBackToEmailCodeWhenEmailLinkVerificationIsNotSupported() {
+    every { userSettings.attributes } returns
+      mapOf("email_address" to emailAttributeConfig(listOf(Constants.Strategy.EMAIL_CODE)))
+    val fieldsSlot = slot<Map<String, String>>()
+    val signUp = signUp()
+
+    coEvery { mockSignUpApi.prepareSignUpVerification(signUp.id, capture(fieldsSlot)) } returns
+      ClerkResult.success(signUp)
+
+    runBlocking { signUp.sendCode { email = "sam@clerk.dev" } }
+
+    coVerify(exactly = 1) { mockSignUpApi.prepareSignUpVerification(signUp.id, any()) }
+    assertEquals(Constants.Strategy.EMAIL_CODE, fieldsSlot.captured["strategy"])
+  }
+
+  @Test
+  fun sendCodeUsesPhoneCodeForPhoneVerification() {
+    every { userSettings.attributes } returns emptyMap()
+    val fieldsSlot = slot<Map<String, String>>()
+    val signUp = signUp()
+
+    coEvery { mockSignUpApi.prepareSignUpVerification(signUp.id, capture(fieldsSlot)) } returns
+      ClerkResult.success(signUp)
+
+    runBlocking { signUp.sendCode { phone = "+15555550123" } }
+
+    coVerify(exactly = 1) { mockSignUpApi.prepareSignUpVerification(signUp.id, any()) }
+    assertEquals(Constants.Strategy.PHONE_CODE, fieldsSlot.captured["strategy"])
+  }
+
+  private fun emailAttributeConfig(verifications: List<String>): UserSettings.AttributesConfig {
+    return UserSettings.AttributesConfig(
+      enabled = true,
+      required = true,
+      usedForFirstFactor = true,
+      firstFactors = verifications,
+      usedForSecondFactor = false,
+      secondFactors = emptyList(),
+      verifications = verifications,
+      verifyAtSignUp = true,
+    )
+  }
+
+  private fun signUp(verifications: Map<String, Verification?> = emptyMap()): SignUp {
+    return SignUp(
+      id = "sign_up_123",
+      status = SignUp.Status.MISSING_REQUIREMENTS,
+      requiredFields = listOf("email_address"),
+      optionalFields = emptyList(),
+      missingFields = emptyList(),
+      unverifiedFields = listOf("email_address"),
+      verifications = verifications,
+      emailAddress = "sam@clerk.dev",
+      passwordEnabled = false,
+    )
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/sso/ExternalAccountServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/ExternalAccountServiceTest.kt
@@ -52,6 +52,7 @@ class ExternalAccountServiceTest {
   @Before
   fun setup() {
     Dispatchers.setMain(testDispatcher)
+    ExternalAccountService.cancelPendingExternalAccountConnection()
 
     // Mock objects
     mockContext = mockk(relaxed = true)
@@ -90,6 +91,7 @@ class ExternalAccountServiceTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   @After
   fun tearDown() {
+    ExternalAccountService.cancelPendingExternalAccountConnection()
     Dispatchers.resetMain()
     unmockkAll()
   }

--- a/source/api/src/test/java/com/clerk/api/sso/RedirectConfigurationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/RedirectConfigurationTest.kt
@@ -42,4 +42,26 @@ class RedirectConfigurationTest {
 
     assertEquals("clerk://null.callback", RedirectConfiguration.DEFAULT_REDIRECT_URL)
   }
+
+  @Test
+  fun emailLinkRedirectUrl_usesProxyPortWhenConfigured() {
+    assertEquals(
+      "clerk://com.clerk.workbench.callback:8443",
+      RedirectConfiguration.emailLinkRedirectUrl(
+        applicationId = "com.clerk.workbench",
+        proxyUrl = "https://rapid-earwig-10.clerk.accounts.lclclerk.com:8443",
+      ),
+    )
+  }
+
+  @Test
+  fun emailLinkRedirectUrl_omitsStandardHttpsPort() {
+    assertEquals(
+      "clerk://com.clerk.workbench.callback",
+      RedirectConfiguration.emailLinkRedirectUrl(
+        applicationId = "com.clerk.workbench",
+        proxyUrl = "https://rapid-earwig-10.clerk.accounts.lclclerk.com:443",
+      ),
+    )
+  }
 }

--- a/source/api/src/test/java/com/clerk/api/sso/SSOManagerActivityTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/SSOManagerActivityTest.kt
@@ -4,12 +4,15 @@ import android.app.Activity
 import android.app.Application
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
+import com.clerk.api.magiclink.NativeMagicLinkService
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockkObject
+import io.mockk.unmockkAll
 import kotlinx.coroutines.CompletableDeferred
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -20,6 +23,11 @@ import org.robolectric.Shadows
 
 @RunWith(RobolectricTestRunner::class)
 class SSOManagerActivityTest {
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
 
   @Before
   fun setup() {
@@ -44,6 +52,24 @@ class SSOManagerActivityTest {
     val controller = Robolectric.buildActivity(SSOManagerActivity::class.java, intent)
     val activity = controller.create().resume().get()
 
+    val shadow = Shadows.shadowOf(activity)
+    assertEquals(Activity.RESULT_OK, shadow.resultCode)
+  }
+
+  @Test
+  fun callbackIntent_completesWithoutAuthorizationStarted() {
+    mockkObject(SSOService)
+    every { SSOService.hasPendingExternalAccountConnection() } returns false
+    coJustRun { SSOService.completeAuthenticateWithRedirect(any()) }
+
+    val app = ApplicationProvider.getApplicationContext<Application>()
+    val responseUri = Uri.parse("clerk://callback?rotating_token_nonce=abc")
+    val intent = SSOManagerActivity.createResponseHandlingIntent(app, responseUri)
+
+    val controller = Robolectric.buildActivity(SSOManagerActivity::class.java, intent)
+    val activity = controller.create().resume().get()
+
+    coVerify(exactly = 1) { SSOService.completeAuthenticateWithRedirect(any()) }
     val shadow = Shadows.shadowOf(activity)
     assertEquals(Activity.RESULT_OK, shadow.resultCode)
   }
@@ -104,8 +130,7 @@ class SSOManagerActivityTest {
       val activity = controller.create().resume().get()
 
       val shadow = Shadows.shadowOf(activity)
-      // Result is set to OK before the service call
-      assertEquals(Activity.RESULT_OK, shadow.resultCode)
+      assertEquals(Activity.RESULT_CANCELED, shadow.resultCode)
     } finally {
       Thread.setDefaultUncaughtExceptionHandler(originalHandler)
     }
@@ -164,5 +189,30 @@ class SSOManagerActivityTest {
 
     // Release the gate so activity can finish
     gate.complete(Unit)
+  }
+
+  @Test
+  fun nativeMagicLinkFailure_setsResultCanceled() {
+    mockkObject(NativeMagicLinkService)
+    coEvery { NativeMagicLinkService.handleMagicLinkDeepLink(any()) } returns
+      com.clerk.api.network.serialization.ClerkResult.apiFailure(
+        com.clerk.api.magiclink.NativeMagicLinkError(
+          reasonCode = "native_magic_link_complete_failed"
+        )
+      )
+
+    val app = ApplicationProvider.getApplicationContext<Application>()
+    val responseUri =
+      Uri.parse("clerk://com.clerk.test.oauth?flow_id=flow_123&approval_token=approval_123")
+    val intent =
+      SSOManagerActivity.createResponseHandlingIntent(app, responseUri).apply {
+        putExtra(com.clerk.api.Constants.Storage.KEY_AUTHORIZATION_STARTED, true)
+      }
+
+    val controller = Robolectric.buildActivity(SSOManagerActivity::class.java, intent)
+    val activity = controller.create().resume().get()
+
+    val shadow = Shadows.shadowOf(activity)
+    assertEquals(Activity.RESULT_CANCELED, shadow.resultCode)
   }
 }

--- a/source/api/src/test/java/com/clerk/api/sso/SSOServiceAuthenticateWithRedirectTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/SSOServiceAuthenticateWithRedirectTest.kt
@@ -2,6 +2,7 @@ package com.clerk.api.sso
 
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.api.SignInApi
+import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.signin.SignIn
@@ -34,7 +35,12 @@ class SSOServiceAuthenticateWithRedirectTest {
     val signInApi = mockk<SignInApi>()
     val redirectUrl = "clerk://example.callback"
     val externalVerificationRedirectUrl = "https://oauth.example.com/start"
-    val createdSignIn = SignIn(id = "sign_in_123")
+    val createdSignIn =
+      SignIn(
+        id = "sign_in_123",
+        status = SignIn.Status.NEEDS_FIRST_FACTOR,
+        supportedFirstFactors = listOf(Factor(strategy = "oauth_google")),
+      )
     val preparedSignIn =
       SignIn(
         id = createdSignIn.id,

--- a/source/telemetry/src/androidMain/kotlin/com/clerk/telemetry/ClerkTelemetryEnvironment.kt
+++ b/source/telemetry/src/androidMain/kotlin/com/clerk/telemetry/ClerkTelemetryEnvironment.kt
@@ -1,33 +1,32 @@
 package com.clerk.telemetry
 
-import com.clerk.api.Clerk
-
 private const val CLERK_ANDROID = "clerk-android"
 
-/**
- * An implementation of [TelemetryEnvironment] that retrieves configuration and state directly from
- * the main [Clerk] singleton. This class acts as a bridge between the telemetry system and the core
- * Clerk SDK's settings.
- */
-class ClerkTelemetryEnvironment : TelemetryEnvironment {
+/** A [TelemetryEnvironment] implementation that reads values from injected providers. */
+class ClerkTelemetryEnvironment(
+  override val sdkVersion: String,
+  private val instanceTypeProvider: suspend () -> String,
+  private val telemetryEnabledProvider: suspend () -> Boolean,
+  private val debugModeEnabledProvider: suspend () -> Boolean,
+  private val publishableKeyProvider: suspend () -> String?,
+) : TelemetryEnvironment {
 
   override val sdkName: String = CLERK_ANDROID
-  override val sdkVersion: String = Clerk.version
 
   override suspend fun instanceTypeString(): String {
-    return Clerk.instanceEnvironmentType.name
+    return instanceTypeProvider()
   }
 
   override suspend fun isTelemetryEnabled(): Boolean {
-    return Clerk.telemetryEnabled
+    return telemetryEnabledProvider()
   }
 
   override suspend fun isDebugModeEnabled(): Boolean {
-    return Clerk.debugMode
+    return debugModeEnabledProvider()
   }
 
   override suspend fun publishableKey(): String? {
-    val key = Clerk.publishableKey
+    val key = publishableKeyProvider()
     return key.takeIf { !it.isNullOrEmpty() }
   }
 }

--- a/source/telemetry/src/commonMain/kotlin/com/clerk/telemetry/TelemetryCollector.kt
+++ b/source/telemetry/src/commonMain/kotlin/com/clerk/telemetry/TelemetryCollector.kt
@@ -1,6 +1,5 @@
 package com.clerk.telemetry
 
-import com.clerk.api.log.ClerkLog
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.post
@@ -172,9 +171,7 @@ class TelemetryCollector(
           setBody(envelope)
         }
         .body<Unit>()
-    } catch (e: Exception) {
-      ClerkLog.e("${e.message}")
-    }
+    } catch (_: Exception) {}
   }
 
   private companion object {

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -184,6 +183,12 @@ internal fun AuthStartViewImpl(
                   authStartIdentifier = authState.authStartIdentifier,
                 )
               }
+              authState.lastSubmittedIdentifier =
+                if (phoneActive && authViewHelper.phoneNumberIsEnabled) {
+                  authState.authStartPhoneNumber
+                } else {
+                  authState.authStartIdentifier
+                }
               authStartViewModel.startAuth(
                 authMode = authState.mode,
                 isPhoneNumberFieldActive = phoneActive,
@@ -265,7 +270,7 @@ private fun AuthInputField(
   } else {
     LastUsedAuthBadgeOverlay(isVisible = showEmailUsernameBadge) {
       ClerkTextField(
-        inputContentType = ContentType.EmailAddress,
+        inputContentType = authViewHelper.identifierContentType(),
         value = authStartIdentifier,
         onValueChange = onIdentifierChange,
         label = authViewHelper.emailOrUsernamePlaceholder(),

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewHelper.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewHelper.kt
@@ -3,6 +3,7 @@ package com.clerk.ui.auth
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import com.clerk.api.Clerk
@@ -79,6 +80,14 @@ internal class AuthStartViewHelper {
       } else {
         KeyboardType.Text
       }
+    }
+  }
+
+  fun identifierContentType(): ContentType {
+    return when {
+      emailIsEnabled && usernameIsEnabled -> ContentType.EmailAddress + ContentType.Username
+      emailIsEnabled -> ContentType.EmailAddress
+      else -> ContentType.Username
     }
   }
 

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
@@ -18,6 +18,7 @@ import com.clerk.api.signin.SignIn
 import com.clerk.api.signin.startingFirstFactor
 import com.clerk.api.signin.startingSecondFactor
 import com.clerk.api.signup.SignUp
+import com.clerk.api.signup.emailVerificationStrategy
 import com.clerk.api.signup.firstFieldToCollect
 import com.clerk.api.signup.firstFieldToVerify
 import com.clerk.ui.core.common.NavigableState
@@ -44,6 +45,7 @@ internal class AuthState(
   val backStack: NavBackStack<NavKey>,
   private val sharedPreferences: SharedPreferences,
   identifierConfig: AuthIdentifierConfig = AuthIdentifierConfig(),
+  organizationLogoUrl: String? = null,
 ) : NavigableState<AuthDestination> {
 
   private var appliedIdentifierConfig: AuthIdentifierConfig? = null
@@ -73,6 +75,11 @@ internal class AuthState(
       authStartPhoneNumberState = value
       persistStoredValue(AUTH_START_PHONE_NUMBER_STORAGE_KEY, value)
     }
+
+  var lastSubmittedIdentifier by mutableStateOf<String?>(null)
+
+  var organizationLogoUrl by mutableStateOf(organizationLogoUrl)
+    private set
 
   // Sign In
   var signInPassword by mutableStateOf("")
@@ -189,8 +196,16 @@ internal class AuthState(
   }
 
   private fun routeToFirstFactorOrHelp(signIn: SignIn) {
-    signIn.startingFirstFactor?.let { backStack.add(AuthDestination.SignInFactorOne(factor = it)) }
-      ?: backStack.add(AuthDestination.SignInGetHelp)
+    val resolvedSignIn =
+      if (signIn.identifier.isNullOrBlank() && !lastSubmittedIdentifier.isNullOrBlank()) {
+        signIn.copy(identifier = lastSubmittedIdentifier)
+      } else {
+        signIn
+      }
+
+    resolvedSignIn.startingFirstFactor?.let {
+      backStack.add(AuthDestination.SignInFactorOne(factor = it))
+    } ?: backStack.add(AuthDestination.SignInGetHelp)
   }
 
   private fun routeToSecondFactorOrHelp(signIn: SignIn) {
@@ -227,11 +242,15 @@ internal class AuthState(
   }
 
   private fun handleMissingRequirements(signUp: SignUp) {
+    val firstFieldToCollect = signUp.firstFieldToCollect
+    if (firstFieldToCollect != null) {
+      handleFieldCollection(signUp)
+      return
+    }
+
     val firstFieldToVerify = signUp.firstFieldToVerify
     if (firstFieldToVerify != null) {
       handleFieldVerification(signUp, firstFieldToVerify)
-    } else {
-      handleFieldCollection(signUp)
     }
   }
 
@@ -240,7 +259,13 @@ internal class AuthState(
       EMAIL_ADDRESS -> {
         val emailAddress = signUp.emailAddress
         if (emailAddress != null) {
-          backStack.add(AuthDestination.SignUpCode(field = SignUpCodeField.Email(emailAddress)))
+          val destination =
+            if (signUp.emailVerificationStrategy == Constants.Strategy.EMAIL_LINK) {
+              AuthDestination.SignUpEmailLink(emailAddress = emailAddress)
+            } else {
+              AuthDestination.SignUpCode(field = SignUpCodeField.Email(emailAddress))
+            }
+          backStack.add(destination)
         } else {
           resetToRoot()
         }
@@ -301,6 +326,10 @@ internal class AuthState(
         updateAuthStartPhoneNumber("")
       }
     }
+  }
+
+  internal fun updateOrganizationLogoUrl(logoUrl: String?) {
+    organizationLogoUrl = logoUrl
   }
 
   fun storeLastUsedIdentifierType(identifierType: IdentifierType) {

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.clerk.ui.auth
 
 import androidx.compose.animation.core.tween
@@ -6,11 +8,15 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.IntOffset
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
@@ -22,6 +28,8 @@ import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.organizations.OrganizationCreationDefaults
 import com.clerk.api.session.SessionTaskKey
 import com.clerk.api.session.pendingTaskKey
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signup.SignUp
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.telemetry.TelemetryEvents
 import com.clerk.telemetry.telemetryPayload
@@ -46,6 +54,7 @@ import com.clerk.ui.signup.code.SignUpCodeView
 import com.clerk.ui.signup.collectfield.CollectField
 import com.clerk.ui.signup.collectfield.SignUpCollectFieldView
 import com.clerk.ui.signup.completeprofile.SignUpCompleteProfileView
+import com.clerk.ui.signup.emaillink.SignUpEmailLinkView
 import com.clerk.ui.theme.ClerkThemeOverrideProvider
 import kotlinx.serialization.Serializable
 
@@ -83,6 +92,7 @@ fun AuthView(
       }
     AuthStateProvider(backStack = backStack, identifierConfig = identifierConfig) {
       ObservePendingSessionTaskRouting(backStack = backStack)
+      ObserveInProgressAuthRouting(backStack = backStack, onAuthComplete = onAuthComplete)
       TrackScreenLoaded(LocalAuthState.current.mode.name)
       DevelopmentModeWarningBox(
         modifier = fullScreenModifier,
@@ -98,6 +108,37 @@ fun AuthView(
         )
       }
     }
+  }
+}
+
+@Composable
+private fun ObserveInProgressAuthRouting(
+  backStack: NavBackStack<NavKey>,
+  onAuthComplete: () -> Unit,
+) {
+  val authState = LocalAuthState.current
+  val lifecycleOwner = LocalLifecycleOwner.current
+
+  fun routeIfNeeded() {
+    resumeInProgressAuthAttempt(
+      authState = authState,
+      top = backStack.lastOrNull(),
+      signIn = Clerk.auth.currentSignIn,
+      signUp = Clerk.auth.currentSignUp,
+      onAuthComplete = onAuthComplete,
+    )
+  }
+
+  LaunchedEffect(backStack.lastOrNull()) { routeIfNeeded() }
+
+  DisposableEffect(lifecycleOwner, authState, backStack) {
+    val observer = LifecycleEventObserver { _, event ->
+      if (event == Lifecycle.Event.ON_RESUME) {
+        routeIfNeeded()
+      }
+    }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
   }
 }
 
@@ -232,6 +273,9 @@ private fun authEntryProvider(
   entry<AuthDestination.SignUpCode> {
     SignUpCodeView(field = it.field, onAuthComplete = onAuthComplete)
   }
+  entry<AuthDestination.SignUpEmailLink> {
+    SignUpEmailLinkView(emailAddress = it.emailAddress, onAuthComplete = onAuthComplete)
+  }
   entry<AuthDestination.SignUpCompleteProfile> {
     SignUpCompleteProfileView(onAuthComplete = onAuthComplete)
   }
@@ -267,6 +311,21 @@ private fun NavKey?.satisfiesPendingSessionTask(
       this == AuthDestination.SessionTaskChooseOrganization ||
         this is AuthDestination.SessionTaskCreateOrganization
     else -> this == destination
+  }
+}
+
+internal fun resumeInProgressAuthAttempt(
+  authState: AuthState,
+  top: NavKey?,
+  signIn: SignIn?,
+  signUp: SignUp?,
+  onAuthComplete: () -> Unit,
+) {
+  if (top != null && top != AuthDestination.AuthStart) return
+
+  when {
+    signIn != null -> authState.setToStepForStatus(signIn, onAuthComplete = onAuthComplete)
+    signUp != null -> authState.setToStepForStatus(signUp, onAuthComplete = onAuthComplete)
   }
 }
 
@@ -323,6 +382,8 @@ internal object AuthDestination {
   @Serializable data class SignUpCollectField(val field: CollectField) : NavKey
 
   @Serializable data class SignUpCode(val field: SignUpCodeField) : NavKey
+
+  @Serializable data class SignUpEmailLink(val emailAddress: String) : NavKey
 
   @Serializable data class SignUpCompleteProfile(val progress: Int) : NavKey
 }

--- a/source/ui/src/main/java/com/clerk/ui/core/appbar/ClerkTopAppbar.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/appbar/ClerkTopAppbar.kt
@@ -24,9 +24,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.clerk.api.Clerk
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.R
-import com.clerk.ui.core.avatar.OrganizationLogo
+import com.clerk.ui.core.avatar.OrganizationAvatar
 import com.clerk.ui.core.dimens.dp12
 import com.clerk.ui.core.dimens.dp48
 import com.clerk.ui.core.dimens.dp68
@@ -43,6 +44,7 @@ internal fun ClerkTopAppBar(
   title: String? = null,
   backgroundColor: Color? = null, // sensible default
   clerkTheme: ClerkTheme? = null,
+  logoUrl: String? = Clerk.organizationLogoUrl,
   trailingContent: (@Composable () -> Unit)? = null,
 ) {
   ClerkMaterialTheme(clerkTheme = clerkTheme) {
@@ -69,12 +71,17 @@ internal fun ClerkTopAppBar(
             trailingContent = trailingContent,
           )
         } else {
+          val logoContent: (@Composable () -> Unit)? =
+            if (hasLogo) {
+              { OrganizationAvatar(clerkTheme = clerkTheme, imageUrl = logoUrl) }
+            } else {
+              null
+            }
           TopBarWithLogo(
             hasBackButton = hasBackButton,
             onBackPressed = onBackPressed,
             title = title,
-            hasLogo = hasLogo,
-            clerkTheme = clerkTheme,
+            logoContent = logoContent,
           )
         }
       }
@@ -105,13 +112,12 @@ private fun RowScope.TopBarWithLogo(
   hasBackButton: Boolean,
   onBackPressed: () -> Unit,
   title: String?,
-  hasLogo: Boolean,
-  clerkTheme: ClerkTheme?,
+  logoContent: (@Composable () -> Unit)?,
 ) {
   BackButton(hasBackButton = hasBackButton, onBackPressed = onBackPressed)
   Spacer(Modifier.weight(1f))
   TopBarTitle(title)
-  if (hasLogo) OrganizationLogo(clerkTheme = clerkTheme)
+  logoContent?.invoke()
   Spacer(Modifier.weight(1f))
   if (hasBackButton) {
     IconButton(onClick = {}) {}

--- a/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
@@ -204,11 +204,11 @@ internal fun OrganizationAvatar(
   shape: Shape? = null,
   size: AvatarSize = AvatarSize.MEDIUM,
   clerkTheme: ClerkTheme? = null,
+  imageUrl: String? = Clerk.organizationLogoUrl,
 ) {
-  val url = Clerk.organizationLogoUrl
   ClerkMaterialTheme(clerkTheme = clerkTheme) {
     AvatarView(
-      imageUrl = url,
+      imageUrl = imageUrl,
       size = size,
       shape = shape ?: ClerkMaterialTheme.shape,
       modifier = modifier,

--- a/source/ui/src/main/java/com/clerk/ui/core/common/StrategyKeys.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/common/StrategyKeys.kt
@@ -7,6 +7,7 @@ internal object StrategyKeys {
   internal const val PASSWORD = "password"
   internal const val PHONE_CODE = "phone_code"
   internal const val EMAIL_CODE = "email_code"
+  internal const val EMAIL_LINK = "email_link"
   internal const val TOTP = "totp"
 
   internal const val BACKUP_CODE = "backup_code"

--- a/source/ui/src/main/java/com/clerk/ui/core/composition/CompositionLocals.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/composition/CompositionLocals.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
+import com.clerk.api.Clerk
 import com.clerk.telemetry.ClerkTelemetryEnvironment
 import com.clerk.telemetry.TelemetryCollector
 import com.clerk.telemetry.TelemetryModule
@@ -27,7 +28,15 @@ internal val LocalTelemetryCollector =
 private fun rememberTelemetryCollector(): TelemetryCollector {
   val context = LocalContext.current.applicationContext
 
-  val environment = remember { ClerkTelemetryEnvironment() }
+  val environment = remember {
+    ClerkTelemetryEnvironment(
+      sdkVersion = Clerk.version,
+      instanceTypeProvider = { Clerk.instanceEnvironmentType.name },
+      telemetryEnabledProvider = { Clerk.telemetryEnabled },
+      debugModeEnabledProvider = { Clerk.debugMode },
+      publishableKeyProvider = { Clerk.publishableKey },
+    )
+  }
 
   return remember { TelemetryModule.createCollector(context = context, environment = environment) }
 }
@@ -54,9 +63,13 @@ internal fun AuthStateProvider(
         backStack = backStack,
         sharedPreferences = sharedPreferences,
         identifierConfig = identifierConfig,
+        organizationLogoUrl = Clerk.organizationLogoUrlFlow.value,
       )
     }
 
   LaunchedEffect(identifierConfig) { authState.applyIdentifierConfig(identifierConfig) }
+  LaunchedEffect(authState) {
+    Clerk.organizationLogoUrlFlow.collect { authState.updateOrganizationLogoUrl(it) }
+  }
   TelemetryProvider { CompositionLocalProvider(LocalAuthState provides authState) { content() } }
 }

--- a/source/ui/src/main/java/com/clerk/ui/core/footer/DevelopmentModeWarning.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/footer/DevelopmentModeWarning.kt
@@ -1,6 +1,5 @@
 package com.clerk.ui.core.footer
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -13,13 +12,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.paint
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
@@ -104,7 +103,11 @@ private fun DevelopmentModeWarningContent(
           DevelopmentModeBranding()
           Spacer(modifier = Modifier.height(DEVELOPMENT_MODE_BRANDING_LABEL_GAP))
         }
-        Text(text = stringResource(R.string.development_mode), style = DEVELOPMENT_MODE_TEXT_STYLE)
+        Text(
+          text = stringResource(R.string.development_mode),
+          style = DEVELOPMENT_MODE_TEXT_STYLE,
+          color = ClerkMaterialTheme.colors.warning,
+        )
       }
     }
   }
@@ -120,8 +123,16 @@ private fun DevelopmentModeBranding(modifier: Modifier = Modifier) {
       Arrangement.spacedBy(DEVELOPMENT_MODE_BRANDING_LOGO_GAP, Alignment.CenterHorizontally),
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    Text(text = stringResource(R.string.secured_by), style = DEVELOPMENT_MODE_BRANDING_TEXT_STYLE)
-    Image(painter = painterResource(R.drawable.ic_clerk_logo), contentDescription = "Clerk")
+    Text(
+      text = stringResource(R.string.secured_by),
+      style = DEVELOPMENT_MODE_BRANDING_TEXT_STYLE,
+      color = ClerkMaterialTheme.colors.mutedForeground,
+    )
+    Icon(
+      painter = painterResource(R.drawable.ic_clerk_logo),
+      contentDescription = "Clerk",
+      tint = ClerkMaterialTheme.colors.mutedForeground,
+    )
   }
 }
 
@@ -158,13 +169,11 @@ private val DEVELOPMENT_MODE_HOME_INDICATOR_HEIGHT = 26.dp
 private val DEVELOPMENT_MODE_LABEL_BOTTOM_GAP = 13.dp
 private val DEVELOPMENT_MODE_BRANDING_LABEL_GAP = 9.dp
 private val DEVELOPMENT_MODE_BRANDING_LOGO_GAP = 8.dp
-private val DEVELOPMENT_MODE_WARNING_COLOR = Color(0xFFF36B16)
 private val DEVELOPMENT_MODE_TEXT_STYLE =
   TextStyle(
     fontSize = 12.sp,
     lineHeight = 13.sp,
     fontWeight = FontWeight(590),
-    color = DEVELOPMENT_MODE_WARNING_COLOR,
     letterSpacing = 0.sp,
   )
 private val DEVELOPMENT_MODE_BRANDING_TEXT_STYLE =
@@ -172,6 +181,5 @@ private val DEVELOPMENT_MODE_BRANDING_TEXT_STYLE =
     fontSize = 13.sp,
     lineHeight = 18.sp,
     fontWeight = FontWeight.Normal,
-    color = Color(0xFF747686),
     letterSpacing = 0.sp,
   )

--- a/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedAuthScaffold.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedAuthScaffold.kt
@@ -83,6 +83,8 @@ internal fun ClerkThemedAuthScaffold(
 ) {
   val user = Clerk.userFlow.collectAsStateWithLifecycle().value
   val session = Clerk.sessionFlow.collectAsStateWithLifecycle().value
+  val shouldShowLogo =
+    shouldShowInstanceLogo(hasLogo = hasLogo, organizationLogoUrl = Clerk.organizationLogoUrl)
   var showSignedInAccountSheet by remember { mutableStateOf(false) }
   val displayName = user.displayName()
   val displayIdentifier = session?.publicUserData?.identifier ?: user?.username.orEmpty()
@@ -109,7 +111,7 @@ internal fun ClerkThemedAuthScaffold(
         ClerkTopAppBar(
           backgroundColor = ClerkMaterialTheme.colors.background,
           onBackPressed = onBackPressed,
-          hasLogo = hasLogo,
+          hasLogo = shouldShowLogo,
           hasBackButton = hasBackButton,
           trailingContent = trailingContent,
         )

--- a/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedProfileScaffold.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedProfileScaffold.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.core.appbar.ClerkTopAppBar
+import com.clerk.ui.core.composition.LocalAuthState
 import com.clerk.ui.core.dimens.dp18
 import com.clerk.ui.core.error.ClerkErrorSnackbar
 import com.clerk.ui.core.footer.SecuredByClerkView
@@ -42,6 +43,9 @@ internal fun ClerkThemedProfileScaffold(
   content: @Composable ColumnScope.() -> Unit,
 ) {
   val snackbarHostState = remember { SnackbarHostState() }
+  val organizationLogoUrl = if (hasLogo) LocalAuthState.current.organizationLogoUrl else null
+  val shouldShowLogo =
+    shouldShowInstanceLogo(hasLogo = hasLogo, organizationLogoUrl = organizationLogoUrl)
   LaunchedEffect(errorMessage) {
     if (errorMessage != null) {
       snackbarHostState.showSnackbar(errorMessage)
@@ -56,7 +60,8 @@ internal fun ClerkThemedProfileScaffold(
       topBar = {
         ClerkTopAppBar(
           backgroundColor = ClerkMaterialTheme.colors.background,
-          hasLogo = hasLogo,
+          hasLogo = shouldShowLogo,
+          logoUrl = organizationLogoUrl,
           hasBackButton = hasBackButton,
           title = title,
           onBackPressed = onBackPressed,

--- a/source/ui/src/main/java/com/clerk/ui/core/scaffold/LogoVisibility.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/scaffold/LogoVisibility.kt
@@ -1,0 +1,5 @@
+package com.clerk.ui.core.scaffold
+
+internal fun shouldShowInstanceLogo(hasLogo: Boolean, organizationLogoUrl: String?): Boolean {
+  return hasLogo && !organizationLogoUrl.isNullOrBlank()
+}

--- a/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorOneView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorOneView.kt
@@ -2,11 +2,15 @@ package com.clerk.ui.signin
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.clerk.api.Clerk
 import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signin.startingFirstFactor
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.auth.PreviewAuthStateProvider
 import com.clerk.ui.core.common.StrategyKeys
 import com.clerk.ui.signin.code.SignInFactorCodeView
+import com.clerk.ui.signin.emaillink.SignInFactorOneEmailLinkView
 import com.clerk.ui.signin.help.SignInGetHelpView
 import com.clerk.ui.signin.passkey.SignInFactorOnePasskeyView
 import com.clerk.ui.signin.password.set.SignInFactorOnePasswordView
@@ -19,22 +23,85 @@ fun SignInFactorOneView(
   clerkTheme: ClerkTheme? = null,
   onAuthComplete: () -> Unit,
 ) {
+  val effectiveFactor = resolveFirstFactor(factor)
   ClerkThemeOverrideProvider(clerkTheme) {
     ClerkMaterialTheme {
-      when (factor.strategy) {
+      when (effectiveFactor.strategy) {
         StrategyKeys.PASSKEY ->
-          SignInFactorOnePasskeyView(factor = factor, onAuthComplete = onAuthComplete)
+          SignInFactorOnePasskeyView(factor = effectiveFactor, onAuthComplete = onAuthComplete)
         StrategyKeys.PASSWORD ->
-          SignInFactorOnePasswordView(factor = factor, onAuthComplete = onAuthComplete)
+          SignInFactorOnePasswordView(factor = effectiveFactor, onAuthComplete = onAuthComplete)
+        StrategyKeys.EMAIL_LINK ->
+          SignInFactorOneEmailLinkView(factor = effectiveFactor, onAuthComplete = onAuthComplete)
         StrategyKeys.EMAIL_CODE,
         StrategyKeys.PHONE_CODE,
         StrategyKeys.RESET_PASSWORD_PHONE_CODE,
         StrategyKeys.RESET_PASSWORD_EMAIL_CODE ->
-          SignInFactorCodeView(factor = factor, onAuthComplete = onAuthComplete)
+          SignInFactorCodeView(factor = effectiveFactor, onAuthComplete = onAuthComplete)
         else -> SignInGetHelpView()
       }
     }
   }
+}
+
+internal fun resolveFirstFactor(fallback: Factor): Factor {
+  val currentSignIn = Clerk.auth.currentSignIn
+  val supportedFactors = currentSignIn?.supportedFirstFactors.orEmpty()
+  val hasSignInContext = currentSignIn != null && supportedFactors.isNotEmpty()
+
+  val preparedFactor =
+    if (hasSignInContext) {
+      supportedFactors.factorForStrategy(currentSignIn.firstFactorVerification?.strategy)
+    } else {
+      null
+    }
+  val emailLinkFactor =
+    if (hasSignInContext) {
+      currentSignIn.preferredEmailLinkFactor(fallback, supportedFactors)
+    } else {
+      null
+    }
+  val fallbackIsSupported = hasSignInContext && supportedFactors.hasStrategy(fallback.strategy)
+
+  return if (!hasSignInContext) {
+    fallback
+  } else {
+    emailLinkFactor
+      ?: preparedFactor
+      ?: if (fallbackIsSupported) fallback else currentSignIn.startingFirstFactor ?: fallback
+  }
+}
+
+private fun List<Factor>.factorForStrategy(strategy: String?): Factor? {
+  val preparedStrategy = strategy?.takeIf { it.isNotBlank() } ?: return null
+  return firstOrNull { it.strategy == preparedStrategy }
+}
+
+private fun List<Factor>.hasStrategy(strategy: String): Boolean {
+  return any { it.strategy == strategy }
+}
+
+private fun SignIn.preferredEmailLinkFactor(
+  fallback: Factor,
+  supportedFactors: List<Factor>,
+): Factor? {
+  return if (isEmailIdentifierSignIn(fallback, supportedFactors)) {
+    supportedFactors.firstOrNull { it.strategy == StrategyKeys.EMAIL_LINK }
+  } else {
+    null
+  }
+}
+
+private fun SignIn.isEmailIdentifierSignIn(
+  fallback: Factor,
+  supportedFactors: List<Factor>,
+): Boolean {
+  return (fallback.strategy == StrategyKeys.EMAIL_CODE && fallback.emailAddressId != null) ||
+    identifier?.contains("@") == true ||
+    supportedFactors.any {
+      (it.strategy == StrategyKeys.EMAIL_LINK || it.strategy == StrategyKeys.EMAIL_CODE) &&
+        it.safeIdentifier?.contains("@") == true
+    }
 }
 
 @PreviewLightDark

--- a/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeView.kt
@@ -126,8 +126,10 @@ private fun SignInFactorCodeViewImpl(
     SignInCodeInput(
       factor = factor,
       verificationTextState = verificationTextState,
-      isSecondFactor = isSecondFactor,
-      viewModel = viewModel,
+      onTextChange = {
+        handleCodeTextChange(it, verificationTextState, viewModel, factor, isSecondFactor)
+      },
+      onClickResend = { viewModel.prepare(factor, isSecondFactor = isSecondFactor) },
     )
     Spacers.Vertical.Spacer24()
     if (SignInFactorCodeUiHelper.showUseAnotherMethod(factor)) {
@@ -152,27 +154,35 @@ private fun SignInFactorCodeViewImpl(
 private fun signInFactorCodeViewModelKey(isSecondFactor: Boolean): String =
   "sign-in-code-${Clerk.auth.currentSignIn?.id ?: "no-sign-in"}-$isSecondFactor"
 
+private fun handleCodeTextChange(
+  code: String,
+  verificationTextState: VerificationUiState,
+  viewModel: SignInFactorCodeViewModel,
+  factor: Factor,
+  isSecondFactor: Boolean,
+) {
+  if (verificationTextState is VerificationUiState.Error) {
+    viewModel.resetState()
+    viewModel.resetVerificationState()
+  }
+  if (code.length == VERIFICATION_CODE_LENGTH) {
+    viewModel.attempt(factor, isSecondFactor = isSecondFactor, code = code)
+  }
+}
+
 @Composable
 private fun SignInCodeInput(
   factor: Factor,
   verificationTextState: VerificationUiState,
-  isSecondFactor: Boolean,
-  viewModel: SignInFactorCodeViewModel,
+  onTextChange: (String) -> Unit,
+  onClickResend: () -> Unit,
 ) {
   ClerkCodeInputField(
     verificationState = verificationTextState.verificationState(),
-    onTextChange = {
-      if (verificationTextState is VerificationUiState.Error) {
-        viewModel.resetState()
-        viewModel.resetVerificationState()
-      }
-      if (it.length == 6) {
-        viewModel.attempt(factor, isSecondFactor = isSecondFactor, code = it)
-      }
-    },
+    onTextChange = onTextChange,
     showResend =
       SignInFactorCodeUiHelper.showResend(factor, verificationTextState.verificationState()),
-    onClickResend = { viewModel.prepare(factor, isSecondFactor = isSecondFactor) },
+    onClickResend = onClickResend,
   )
 }
 
@@ -193,6 +203,8 @@ private fun PreviewSignInFactorCodeView() {
     }
   }
 }
+
+private const val VERIFICATION_CODE_LENGTH = 6
 
 /**
  * Sealed interface representing the various verification states for code input components.

--- a/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeViewModel.kt
@@ -32,6 +32,11 @@ internal class SignInFactorCodeViewModel(
 
     guardSignIn(_state) { inProgressSignIn ->
       viewModelScope.launch(workDispatcher) {
+        if (shouldRerouteForUnsupportedFactor(inProgressSignIn, factor, isSecondFactor)) {
+          _state.value = AuthenticationViewState.Success.SignIn(inProgressSignIn)
+          return@launch
+        }
+
         when (factor.strategy) {
           StrategyKeys.EMAIL_CODE -> {
             prepareHandler.prepareForEmailCode(inProgressSignIn, factor, isSecondFactor) {
@@ -130,5 +135,58 @@ internal class SignInFactorCodeViewModel(
 
   fun resetVerificationState() {
     _verificationUiState.value = VerificationUiState.Idle
+  }
+
+  private fun shouldRerouteForUnsupportedFactor(
+    signIn: SignIn,
+    factor: Factor,
+    isSecondFactor: Boolean,
+  ): Boolean {
+    val supportedFirstFactors = signIn.supportedFirstFactors.orEmpty()
+    val prefersEmailLinkOverEmailCode =
+      factor.strategy == StrategyKeys.EMAIL_CODE &&
+        signIn.firstFactorVerification?.strategy != StrategyKeys.EMAIL_CODE &&
+        signIn.shouldPreferEmailLink(
+          supportedFirstFactors = supportedFirstFactors,
+          fallbackFactor = factor,
+        )
+
+    return if (isSecondFactor) {
+      signIn.supportedSecondFactors?.none { it.matches(factor) } == true
+    } else {
+      supportedFirstFactors.none { it.matches(factor) } || prefersEmailLinkOverEmailCode
+    }
+  }
+
+  private fun SignIn.shouldPreferEmailLink(
+    supportedFirstFactors: List<Factor>,
+    fallbackFactor: Factor,
+  ): Boolean {
+    val hasEmailLink = supportedFirstFactors.any { it.strategy == StrategyKeys.EMAIL_LINK }
+    if (!hasEmailLink) return false
+
+    val isEmailIdentifier =
+      fallbackFactor.emailAddressId != null ||
+        fallbackFactor.safeIdentifier?.contains("@") == true ||
+        identifier?.contains("@") == true ||
+        supportedFirstFactors.any {
+          (it.strategy == StrategyKeys.EMAIL_LINK || it.strategy == StrategyKeys.EMAIL_CODE) &&
+            it.safeIdentifier?.contains("@") == true
+        }
+    return isEmailIdentifier
+  }
+
+  private fun Factor.matches(other: Factor): Boolean {
+    if (strategy != other.strategy) return false
+
+    return when {
+      emailAddressId != null || other.emailAddressId != null ->
+        emailAddressId == other.emailAddressId
+      phoneNumberId != null || other.phoneNumberId != null -> phoneNumberId == other.phoneNumberId
+      web3WalletId != null || other.web3WalletId != null -> web3WalletId == other.web3WalletId
+      safeIdentifier != null || other.safeIdentifier != null ->
+        safeIdentifier == other.safeIdentifier
+      else -> true
+    }
   }
 }

--- a/source/ui/src/main/java/com/clerk/ui/signin/code/SignInPrepareHandler.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/code/SignInPrepareHandler.kt
@@ -8,6 +8,7 @@ import com.clerk.api.network.serialization.onSuccess
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signin.prepareFirstFactor
 import com.clerk.api.signin.prepareSecondFactor
+import com.clerk.ui.core.common.StrategyKeys
 
 internal class SignInPrepareHandler {
 
@@ -66,19 +67,9 @@ internal class SignInPrepareHandler {
     }
 
     if (isSecondFactor) {
-      inProgressSignIn
-        .prepareSecondFactor(phoneNumberId)
-        .onSuccess { ClerkLog.v("Successfully prepared second factor for phone code") }
-        .onFailure { ClerkLog.e("Error preparing second factor for phone code: $it") }
+      prepareSecondFactorPhoneCode(inProgressSignIn, phoneNumberId, onError)
     } else {
-      inProgressSignIn
-        .prepareFirstFactor(
-          SignIn.PrepareFirstFactorParams.PhoneCode(phoneNumberId = phoneNumberId)
-        )
-        .onFailure {
-          onError(it.errorMessage)
-          ClerkLog.e("Error preparing for phone code: $it")
-        }
+      prepareFirstFactorPhoneCode(inProgressSignIn, phoneNumberId, onError)
     }
   }
 
@@ -95,10 +86,98 @@ internal class SignInPrepareHandler {
     }
 
     if (isSecondFactor) {
+      prepareSecondFactorEmailCode(inProgressSignIn, emailAddressId, onError)
+    } else {
+      prepareFirstFactorEmailCode(inProgressSignIn, emailAddressId, onError)
+    }
+  }
+
+  private suspend fun prepareSecondFactorPhoneCode(
+    inProgressSignIn: SignIn,
+    phoneNumberId: String,
+    onError: (String) -> Unit,
+  ) {
+    val isSupported =
+      isFactorStrategySupported(
+        factors = inProgressSignIn.supportedSecondFactors,
+        strategy = SignIn.PrepareSecondFactorParams.PHONE_CODE,
+      )
+    if (!isSupported) {
+      ClerkLog.e("Error preparing for phone code: strategy no longer supported for second factor")
+      onError("Selected sign-in method is no longer available.")
+    } else {
+      inProgressSignIn
+        .prepareSecondFactor(phoneNumberId)
+        .onSuccess { ClerkLog.v("Successfully prepared second factor for phone code") }
+        .onFailure {
+          onError(it.errorMessage)
+          ClerkLog.e("Error preparing second factor for phone code: $it")
+        }
+    }
+  }
+
+  private suspend fun prepareFirstFactorPhoneCode(
+    inProgressSignIn: SignIn,
+    phoneNumberId: String,
+    onError: (String) -> Unit,
+  ) {
+    val isSupported =
+      isFactorStrategySupported(
+        factors = inProgressSignIn.supportedFirstFactors,
+        strategy = StrategyKeys.PHONE_CODE,
+      )
+    if (!isSupported) {
+      ClerkLog.e("Error preparing for phone code: strategy no longer supported for first factor")
+      onError("Selected sign-in method is no longer available.")
+    } else {
+      inProgressSignIn
+        .prepareFirstFactor(
+          SignIn.PrepareFirstFactorParams.PhoneCode(phoneNumberId = phoneNumberId)
+        )
+        .onFailure {
+          onError(it.errorMessage)
+          ClerkLog.e("Error preparing for phone code: $it")
+        }
+    }
+  }
+
+  private suspend fun prepareSecondFactorEmailCode(
+    inProgressSignIn: SignIn,
+    emailAddressId: String,
+    onError: (String) -> Unit,
+  ) {
+    val isSupported =
+      isFactorStrategySupported(
+        factors = inProgressSignIn.supportedSecondFactors,
+        strategy = SignIn.PrepareSecondFactorParams.EMAIL_CODE,
+      )
+    if (!isSupported) {
+      ClerkLog.e("Error preparing for email code: strategy no longer supported for second factor")
+      onError("Selected sign-in method is no longer available.")
+    } else {
       inProgressSignIn
         .prepareSecondFactor(emailAddressId = emailAddressId)
         .onSuccess { ClerkLog.v("Successfully prepared second factor for email code") }
-        .onFailure { ClerkLog.e("Error preparing second factor for email code: $it") }
+        .onFailure {
+          onError(it.errorMessage)
+          ClerkLog.e("Error preparing second factor for email code: $it")
+        }
+    }
+  }
+
+  private suspend fun prepareFirstFactorEmailCode(
+    inProgressSignIn: SignIn,
+    emailAddressId: String,
+    onError: (String) -> Unit,
+  ) {
+    val isSupported =
+      isFactorStrategySupported(
+        factors = inProgressSignIn.supportedFirstFactors,
+        strategy = StrategyKeys.EMAIL_CODE,
+      )
+    if (!isSupported) {
+      ClerkLog.e("Error preparing for email code: strategy no longer supported for first factor")
+      onError("Selected sign-in method is no longer available.")
     } else {
       inProgressSignIn
         .prepareFirstFactor(
@@ -110,5 +189,9 @@ internal class SignInPrepareHandler {
           ClerkLog.e("Error preparing for email code: ${it.errorMessage}")
         }
     }
+  }
+
+  private fun isFactorStrategySupported(factors: List<Factor>?, strategy: String): Boolean {
+    return factors.isNullOrEmpty() || factors.any { it.strategy == strategy }
   }
 }

--- a/source/ui/src/main/java/com/clerk/ui/signin/emaillink/SignInFactorOneEmailLinkView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/emaillink/SignInFactorOneEmailLinkView.kt
@@ -1,0 +1,173 @@
+package com.clerk.ui.signin.emaillink
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.ui.ClerkTheme
+import com.clerk.ui.R
+import com.clerk.ui.auth.AuthDestination
+import com.clerk.ui.auth.AuthStateEffects
+import com.clerk.ui.auth.PreviewAuthStateProvider
+import com.clerk.ui.core.button.standard.ClerkButton
+import com.clerk.ui.core.button.standard.ClerkButtonConfiguration
+import com.clerk.ui.core.button.standard.ClerkButtonDefaults
+import com.clerk.ui.core.button.standard.ClerkTextButton
+import com.clerk.ui.core.common.StrategyKeys
+import com.clerk.ui.core.composition.LocalAuthState
+import com.clerk.ui.core.dimens.dp8
+import com.clerk.ui.core.scaffold.ClerkThemedAuthScaffold
+import com.clerk.ui.core.spacers.Spacers
+import com.clerk.ui.theme.ClerkThemeOverrideProvider
+import com.clerk.ui.util.EmailAppLauncher
+import kotlinx.coroutines.launch
+
+@Composable
+fun SignInFactorOneEmailLinkView(
+  factor: Factor,
+  modifier: Modifier = Modifier,
+  clerkTheme: ClerkTheme? = null,
+  onAuthComplete: () -> Unit,
+) {
+  ClerkThemeOverrideProvider(clerkTheme) {
+    SignInFactorOneEmailLinkViewImpl(
+      factor = factor,
+      modifier = modifier,
+      onAuthComplete = onAuthComplete,
+    )
+  }
+}
+
+@Composable
+private fun SignInFactorOneEmailLinkViewImpl(
+  factor: Factor,
+  modifier: Modifier = Modifier,
+  viewModel: SignInFactorOneEmailLinkViewModel = viewModel(),
+  onAuthComplete: () -> Unit,
+) {
+  val authState = LocalAuthState.current
+  val snackbarHostState = remember { SnackbarHostState() }
+  val state by viewModel.state.collectAsStateWithLifecycle()
+
+  LaunchedEffect(Unit) { viewModel.sendLink() }
+  ObserveHostResume(onHostResumed = viewModel::onHostResumed)
+
+  AuthStateEffects(
+    authState = authState,
+    state = state,
+    snackbarHostState = snackbarHostState,
+    onAuthComplete = onAuthComplete,
+    onReset = viewModel::resetState,
+  )
+
+  ClerkThemedAuthScaffold(
+    modifier = modifier,
+    onBackPressed = authState::navigateBack,
+    title = stringResource(R.string.check_your_email),
+    subtitle =
+      Clerk.applicationName?.let { stringResource(R.string.to_continue_to, it) }
+        ?: stringResource(R.string.to_continue),
+    identifier = factor.safeIdentifier,
+    onClickIdentifier = { authState.clearBackStack() },
+    snackbarHostState = snackbarHostState,
+  ) {
+    OpenEmailAppButton(snackbarHostState = snackbarHostState)
+    Spacers.Vertical.Spacer24()
+    SignInEmailLinkSecondaryActions(
+      onResendClick = viewModel::sendLink,
+      onUseAnotherMethodClick = {
+        authState.navigateTo(
+          AuthDestination.SignInFactorOneUseAnotherMethod(currentFactor = factor)
+        )
+      },
+    )
+  }
+}
+
+@Composable
+private fun ObserveHostResume(onHostResumed: () -> Unit) {
+  val lifecycleOwner = LocalLifecycleOwner.current
+
+  DisposableEffect(lifecycleOwner, onHostResumed) {
+    val observer = LifecycleEventObserver { _, event ->
+      if (event == Lifecycle.Event.ON_RESUME) {
+        onHostResumed()
+      }
+    }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+  }
+}
+
+@Composable
+private fun OpenEmailAppButton(snackbarHostState: SnackbarHostState) {
+  val context = LocalContext.current
+  val coroutineScope = rememberCoroutineScope()
+
+  ClerkButton(
+    text = stringResource(R.string.open_email_app),
+    onClick = {
+      if (!EmailAppLauncher.open(context)) {
+        coroutineScope.launch {
+          snackbarHostState.showSnackbar(
+            message = context.getString(R.string.no_email_clients_installed_on_device),
+            duration = SnackbarDuration.Short,
+          )
+        }
+      }
+    },
+    modifier = Modifier.fillMaxWidth(),
+    configuration =
+      ClerkButtonDefaults.configuration(
+        style = ClerkButtonConfiguration.ButtonStyle.Secondary,
+        emphasis = ClerkButtonConfiguration.Emphasis.High,
+      ),
+  )
+}
+
+@Composable
+private fun SignInEmailLinkSecondaryActions(
+  onResendClick: () -> Unit,
+  onUseAnotherMethodClick: () -> Unit,
+) {
+  Row(
+    modifier = Modifier.fillMaxWidth().padding(horizontal = dp8),
+    horizontalArrangement = Arrangement.SpaceBetween,
+  ) {
+    ClerkTextButton(text = stringResource(R.string.resend), onClick = onResendClick)
+    ClerkTextButton(
+      text = stringResource(R.string.use_another_method),
+      onClick = onUseAnotherMethodClick,
+    )
+  }
+}
+
+@PreviewLightDark
+@Composable
+private fun PreviewSignInFactorOneEmailLinkView() {
+  PreviewAuthStateProvider {
+    SignInFactorOneEmailLinkView(
+      factor = Factor(strategy = StrategyKeys.EMAIL_LINK, safeIdentifier = "sam@clerk.dev"),
+      onAuthComplete = {},
+    )
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/signin/emaillink/SignInFactorOneEmailLinkViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/emaillink/SignInFactorOneEmailLinkViewModel.kt
@@ -1,0 +1,92 @@
+package com.clerk.ui.signin.emaillink
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.clerk.api.Clerk
+import com.clerk.api.auth.AuthEvent
+import com.clerk.api.network.serialization.onFailure
+import com.clerk.api.network.serialization.onSuccess
+import com.clerk.api.signin.SignIn
+import com.clerk.ui.auth.AuthenticationViewState
+import com.clerk.ui.auth.guardSignIn
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+internal class SignInFactorOneEmailLinkViewModel(
+  private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : ViewModel() {
+  private val _state: MutableStateFlow<AuthenticationViewState> =
+    MutableStateFlow(AuthenticationViewState.Idle)
+  val state = _state.asStateFlow()
+
+  init {
+    syncCurrentSignInState()
+    viewModelScope.launch {
+      Clerk.auth.events.collectLatest { event ->
+        when (event) {
+          is AuthEvent.SignInCompleted -> {
+            _state.value = AuthenticationViewState.Success.SignIn(event.signIn)
+          }
+          is AuthEvent.SignInStarted -> {
+            if (event.signIn.status == SignIn.Status.NEEDS_SECOND_FACTOR) {
+              _state.value = AuthenticationViewState.Success.SignIn(event.signIn)
+            }
+          }
+          else -> Unit
+        }
+      }
+    }
+  }
+
+  internal fun onHostResumed() {
+    syncCurrentSignInState()
+  }
+
+  fun sendLink() {
+    _state.value = AuthenticationViewState.Loading
+
+    guardSignIn(_state) { inProgressSignIn ->
+      val identifier = inProgressSignIn.identifier
+      if (identifier.isNullOrBlank() || !identifier.isEmailAddress()) {
+        _state.value = AuthenticationViewState.Error(null)
+        return@guardSignIn
+      }
+
+      viewModelScope.launch(ioDispatcher) {
+        Clerk.auth
+          .startEmailLinkSignIn(identifier)
+          .onSuccess { _state.value = AuthenticationViewState.Idle }
+          .onFailure { failure ->
+            _state.value = AuthenticationViewState.Error(failure.error?.message)
+          }
+      }
+    }
+  }
+
+  fun resetState() {
+    if (_state.value !is AuthenticationViewState.Success.SignIn) {
+      _state.value = AuthenticationViewState.Idle
+    }
+  }
+
+  private fun syncCurrentSignInState() {
+    val currentSignIn = Clerk.auth.currentSignIn ?: return
+    when (currentSignIn.status) {
+      SignIn.Status.COMPLETE,
+      SignIn.Status.NEEDS_SECOND_FACTOR,
+      SignIn.Status.NEEDS_NEW_PASSWORD,
+      SignIn.Status.NEEDS_CLIENT_TRUST -> {
+        _state.value = AuthenticationViewState.Success.SignIn(currentSignIn)
+      }
+      else -> Unit
+    }
+  }
+}
+
+private val emailRegex = Regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")
+
+private fun String.isEmailAddress(): Boolean = emailRegex.matches(this)

--- a/source/ui/src/main/java/com/clerk/ui/signup/code/SignUpCodeViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/code/SignUpCodeViewModel.kt
@@ -3,11 +3,13 @@ package com.clerk.ui.signup.code
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.clerk.api.Clerk
+import com.clerk.api.Constants
 import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
 import com.clerk.api.signup.SignUp
 import com.clerk.api.signup.attemptVerification
+import com.clerk.api.signup.emailVerificationStrategy
 import com.clerk.api.signup.prepareVerification
 import com.clerk.ui.auth.AuthenticationViewState
 import com.clerk.ui.auth.VerificationUiState
@@ -25,6 +27,13 @@ internal class SignUpCodeViewModel : ViewModel() {
 
   fun prepare(field: SignUpCodeField) {
     val signUp = Clerk.client.signUp ?: return
+    if (
+      field is SignUpCodeField.Email &&
+        signUp.emailVerificationStrategy == Constants.Strategy.EMAIL_LINK
+    ) {
+      _state.value = AuthenticationViewState.Success.SignUp(signUp)
+      return
+    }
     viewModelScope.launch {
       val signUp =
         when (field) {

--- a/source/ui/src/main/java/com/clerk/ui/signup/emaillink/SignUpEmailLinkView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/emaillink/SignUpEmailLinkView.kt
@@ -1,0 +1,153 @@
+package com.clerk.ui.signup.emaillink
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.clerk.api.Clerk
+import com.clerk.api.ui.ClerkTheme
+import com.clerk.ui.R
+import com.clerk.ui.auth.AuthStateEffects
+import com.clerk.ui.auth.PreviewAuthStateProvider
+import com.clerk.ui.core.button.standard.ClerkButton
+import com.clerk.ui.core.button.standard.ClerkButtonConfiguration
+import com.clerk.ui.core.button.standard.ClerkButtonDefaults
+import com.clerk.ui.core.button.standard.ClerkTextButton
+import com.clerk.ui.core.composition.LocalAuthState
+import com.clerk.ui.core.dimens.dp8
+import com.clerk.ui.core.scaffold.ClerkThemedAuthScaffold
+import com.clerk.ui.core.spacers.Spacers
+import com.clerk.ui.theme.ClerkThemeOverrideProvider
+import com.clerk.ui.util.EmailAppLauncher
+import kotlinx.coroutines.launch
+
+@Composable
+fun SignUpEmailLinkView(
+  emailAddress: String,
+  modifier: Modifier = Modifier,
+  clerkTheme: ClerkTheme? = null,
+  onAuthComplete: () -> Unit,
+) {
+  ClerkThemeOverrideProvider(clerkTheme) {
+    SignUpEmailLinkViewImpl(
+      emailAddress = emailAddress,
+      modifier = modifier,
+      onAuthComplete = onAuthComplete,
+    )
+  }
+}
+
+@Composable
+private fun SignUpEmailLinkViewImpl(
+  emailAddress: String,
+  modifier: Modifier = Modifier,
+  viewModel: SignUpEmailLinkViewModel = viewModel(),
+  onAuthComplete: () -> Unit,
+) {
+  val authState = LocalAuthState.current
+  val snackbarHostState = remember { SnackbarHostState() }
+  val state by viewModel.state.collectAsStateWithLifecycle()
+
+  LaunchedEffect(Unit) { viewModel.sendLink() }
+  ObserveSignUpEmailLinkHostResume(onHostResumed = viewModel::onHostResumed)
+
+  AuthStateEffects(
+    authState = authState,
+    state = state,
+    snackbarHostState = snackbarHostState,
+    onAuthComplete = onAuthComplete,
+    onReset = viewModel::resetState,
+  )
+
+  ClerkThemedAuthScaffold(
+    modifier = modifier,
+    onBackPressed = authState::navigateBack,
+    title = stringResource(R.string.check_your_email),
+    subtitle =
+      Clerk.applicationName?.let { stringResource(R.string.to_continue_to, it) }
+        ?: stringResource(R.string.to_continue),
+    identifier = emailAddress,
+    onClickIdentifier = authState::clearBackStack,
+    hasLogo = false,
+    snackbarHostState = snackbarHostState,
+  ) {
+    OpenEmailAppButton(snackbarHostState = snackbarHostState)
+    Spacers.Vertical.Spacer24()
+    Row(
+      modifier = Modifier.fillMaxWidth().padding(horizontal = dp8),
+      horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+      ClerkTextButton(text = stringResource(R.string.resend), onClick = viewModel::sendLink)
+      ClerkTextButton(
+        text = stringResource(R.string.use_another_method),
+        onClick = authState::navigateBack,
+      )
+    }
+  }
+}
+
+@Composable
+private fun ObserveSignUpEmailLinkHostResume(onHostResumed: () -> Unit) {
+  val lifecycleOwner = LocalLifecycleOwner.current
+
+  DisposableEffect(lifecycleOwner, onHostResumed) {
+    val observer = LifecycleEventObserver { _, event ->
+      if (event == Lifecycle.Event.ON_RESUME) {
+        onHostResumed()
+      }
+    }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+  }
+}
+
+@Composable
+private fun OpenEmailAppButton(snackbarHostState: SnackbarHostState) {
+  val context = LocalContext.current
+  val coroutineScope = rememberCoroutineScope()
+
+  ClerkButton(
+    text = stringResource(R.string.open_email_app),
+    onClick = {
+      if (!EmailAppLauncher.open(context)) {
+        coroutineScope.launch {
+          snackbarHostState.showSnackbar(
+            message = context.getString(R.string.no_email_clients_installed_on_device),
+            duration = SnackbarDuration.Short,
+          )
+        }
+      }
+    },
+    modifier = Modifier.fillMaxWidth(),
+    configuration =
+      ClerkButtonDefaults.configuration(
+        style = ClerkButtonConfiguration.ButtonStyle.Secondary,
+        emphasis = ClerkButtonConfiguration.Emphasis.High,
+      ),
+  )
+}
+
+@PreviewLightDark
+@Composable
+private fun PreviewSignUpEmailLinkView() {
+  PreviewAuthStateProvider {
+    SignUpEmailLinkView(emailAddress = "sam@clerk.dev", onAuthComplete = {})
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/signup/emaillink/SignUpEmailLinkViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/emaillink/SignUpEmailLinkViewModel.kt
@@ -1,0 +1,88 @@
+package com.clerk.ui.signup.emaillink
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.clerk.api.Clerk
+import com.clerk.api.auth.AuthEvent
+import com.clerk.api.network.serialization.errorMessage
+import com.clerk.api.network.serialization.onFailure
+import com.clerk.api.network.serialization.onSuccess
+import com.clerk.api.signup.SignUp
+import com.clerk.api.signup.prepareVerification
+import com.clerk.ui.auth.AuthenticationViewState
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+internal class SignUpEmailLinkViewModel(
+  private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : ViewModel() {
+  private val _state = MutableStateFlow<AuthenticationViewState>(AuthenticationViewState.Idle)
+  val state = _state.asStateFlow()
+
+  init {
+    syncCurrentSignUpState()
+    viewModelScope.launch {
+      Clerk.auth.events.collectLatest { event ->
+        when (event) {
+          is AuthEvent.SignUpStarted -> {
+            if (event.signUp.status == SignUp.Status.MISSING_REQUIREMENTS) {
+              _state.value = AuthenticationViewState.Success.SignUp(event.signUp)
+            }
+          }
+          is AuthEvent.SignUpCompleted -> {
+            _state.value = AuthenticationViewState.Success.SignUp(event.signUp)
+          }
+          is AuthEvent.SignInCompleted -> {
+            _state.value = AuthenticationViewState.Success.SignIn(event.signIn)
+          }
+          else -> Unit
+        }
+      }
+    }
+  }
+
+  internal fun onHostResumed() {
+    syncCurrentSignUpState()
+  }
+
+  fun sendLink() {
+    _state.value = AuthenticationViewState.Loading
+
+    val signUp = Clerk.client.signUp
+    if (signUp == null || signUp.emailAddress.isNullOrBlank()) {
+      _state.value = AuthenticationViewState.Error(null)
+      return
+    }
+
+    viewModelScope.launch(ioDispatcher) {
+      signUp
+        .prepareVerification(SignUp.PrepareVerificationParams.Strategy.EmailLink())
+        .onSuccess { _state.value = AuthenticationViewState.Idle }
+        .onFailure { failure -> _state.value = AuthenticationViewState.Error(failure.errorMessage) }
+    }
+  }
+
+  fun resetState() {
+    if (
+      _state.value !is AuthenticationViewState.Success.SignUp &&
+        _state.value !is AuthenticationViewState.Success.SignIn
+    ) {
+      _state.value = AuthenticationViewState.Idle
+    }
+  }
+
+  private fun syncCurrentSignUpState() {
+    val currentSignUp = Clerk.auth.currentSignUp ?: return
+    when (currentSignUp.status) {
+      SignUp.Status.MISSING_REQUIREMENTS,
+      SignUp.Status.COMPLETE -> {
+        _state.value = AuthenticationViewState.Success.SignUp(currentSignUp)
+      }
+      else -> Unit
+    }
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/userbutton/UserButton.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userbutton/UserButton.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.clerk.ui.userbutton
 
 import android.annotation.SuppressLint
@@ -16,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -29,8 +32,10 @@ import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.clerk.api.Clerk
+import com.clerk.api.session.Session
 import com.clerk.api.session.requiresForcedMfa
 import com.clerk.api.ui.ClerkTheme
+import com.clerk.api.user.User
 import com.clerk.telemetry.TelemetryEvents
 import com.clerk.ui.R
 import com.clerk.ui.auth.AuthView
@@ -73,16 +78,26 @@ fun UserButton(
     TelemetryProvider {
       val session by Clerk.sessionFlow.collectAsStateWithLifecycle()
       val sessionUser by Clerk.userFlow.collectAsStateWithLifecycle()
-      val requiresForcedMfa = session?.requiresForcedMfa == true
-      val user = if (treatPendingAsSignedOut) Clerk.activeUser else sessionUser
+      val effectiveSession = session ?: Clerk.session
+      val resolved =
+        resolveUserButtonState(
+          sessionExists = effectiveSession != null,
+          sessionUser = sessionUser ?: effectiveSession?.user,
+          activeUser =
+            effectiveSession?.takeIf { it.status == Session.SessionStatus.ACTIVE }?.user
+              ?: Clerk.activeUser
+              ?: Clerk.user,
+          treatPendingAsSignedOut = treatPendingAsSignedOut,
+        )
+      val requiresForcedMfa = effectiveSession?.requiresForcedMfa == true
+      val user = resolved.user
+      val shouldShowButton = resolved.shouldShowButton
       val telemetry = LocalTelemetryCollector.current
       var showProfile by rememberSaveable { mutableStateOf(false) }
       var authMode by rememberSaveable { mutableStateOf<UserButtonAuthMode?>(null) }
-      val shouldRenderButton =
-        shouldShowUserButton(sessionUser != null, Clerk.activeUser != null, treatPendingAsSignedOut)
 
-      LaunchedEffect(user?.id) {
-        if (user != null) telemetry.record(TelemetryEvents.viewDidAppear("UserButton"))
+      LaunchedEffect(shouldShowButton, user?.id) {
+        if (shouldShowButton) telemetry.record(TelemetryEvents.viewDidAppear("UserButton"))
       }
       DismissAuthWhenMfaResolved(
         requiresForcedMfa = requiresForcedMfa,
@@ -90,17 +105,17 @@ fun UserButton(
         onDismissAuth = { authMode = null },
       )
 
-      if (shouldRenderButton && user != null) {
+      if (shouldShowButton && user != null) {
         UserButtonContent(
           imageUrl = user.imageUrl,
           onClick = {
-            when (userButtonClickAction(requiresForcedMfa, routeToAuthWhenForcedMfa)) {
-              UserButtonClickAction.OPEN_PROFILE -> showProfile = true
-              UserButtonClickAction.ROUTE_TO_AUTH -> {
-                onRequiresForcedMfaClick?.invoke()
-                  ?: run { authMode = UserButtonAuthMode.ForcedMfa }
-              }
-            }
+            handleUserButtonClick(
+              requiresForcedMfa = requiresForcedMfa,
+              routeToAuthWhenForcedMfa = routeToAuthWhenForcedMfa,
+              onRequiresForcedMfaClick = onRequiresForcedMfaClick,
+              onOpenProfile = { showProfile = true },
+              onOpenAuth = { authMode = UserButtonAuthMode.ForcedMfa },
+            )
           },
         )
       }
@@ -119,10 +134,54 @@ fun UserButton(
   }
 }
 
+private data class ResolvedUserButtonState(val user: User?, val shouldShowButton: Boolean)
+
+private fun resolveUserButtonState(
+  sessionExists: Boolean,
+  sessionUser: User?,
+  activeUser: User?,
+  treatPendingAsSignedOut: Boolean,
+): ResolvedUserButtonState {
+  val user =
+    if (treatPendingAsSignedOut) {
+      activeUser
+    } else {
+      sessionUser ?: activeUser
+    }
+
+  val shouldShowButton =
+    shouldShowUserButton(
+      hasSession = sessionExists,
+      hasActiveUser = activeUser != null,
+      treatPendingAsSignedOut = treatPendingAsSignedOut,
+    )
+
+  return ResolvedUserButtonState(user = user, shouldShowButton = shouldShowButton)
+}
+
+private fun handleUserButtonClick(
+  requiresForcedMfa: Boolean,
+  routeToAuthWhenForcedMfa: Boolean,
+  onRequiresForcedMfaClick: (() -> Unit)?,
+  onOpenProfile: () -> Unit,
+  onOpenAuth: () -> Unit,
+) {
+  when (
+    userButtonClickAction(
+      requiresForcedMfa = requiresForcedMfa,
+      routeToAuthWhenForcedMfa = routeToAuthWhenForcedMfa,
+    )
+  ) {
+    UserButtonClickAction.OPEN_PROFILE -> onOpenProfile()
+    UserButtonClickAction.ROUTE_TO_AUTH -> onRequiresForcedMfaClick?.invoke() ?: onOpenAuth()
+  }
+}
+
 @SuppressLint("LocalContextGetResourceValueCall")
 @Composable
 private fun UserButtonContent(imageUrl: String?, onClick: () -> Unit) {
   val context = LocalContext.current
+  val profilePainter = painterResource(id = R.drawable.ic_profile)
   IconButton(onClick = onClick) {
     Box(
       modifier =
@@ -131,17 +190,25 @@ private fun UserButtonContent(imageUrl: String?, onClick: () -> Unit) {
         },
       contentAlignment = Alignment.Center,
     ) {
-      val model = ImageRequest.Builder(LocalContext.current).data(imageUrl).crossfade(true).build()
-      AsyncImage(
-        modifier = Modifier.matchParentSize().clip(CircleShape),
-        model = model,
-        contentDescription = stringResource(R.string.user_avatar),
-        contentScale = ContentScale.Crop,
-        fallback = painterResource(id = R.drawable.ic_profile),
-        onError = { /* fall through to placeholder below */ },
-      )
-      if (imageUrl?.isBlank() == true) {
-        Icon(painterResource(id = R.drawable.ic_profile), null, Modifier.matchParentSize())
+      if (imageUrl.isNullOrBlank()) {
+        Icon(
+          painter = profilePainter,
+          contentDescription = stringResource(R.string.user_avatar),
+          modifier = Modifier.matchParentSize(),
+          tint = Color.Unspecified,
+        )
+      } else {
+        val model =
+          ImageRequest.Builder(LocalContext.current).data(imageUrl).crossfade(true).build()
+        AsyncImage(
+          modifier = Modifier.matchParentSize().clip(CircleShape),
+          model = model,
+          contentDescription = stringResource(R.string.user_avatar),
+          contentScale = ContentScale.Crop,
+          placeholder = profilePainter,
+          fallback = profilePainter,
+          error = profilePainter,
+        )
       }
     }
   }
@@ -260,9 +327,13 @@ internal fun userButtonClickAction(
 }
 
 internal fun shouldShowUserButton(
-  hasSessionUser: Boolean,
+  hasSession: Boolean,
   hasActiveUser: Boolean,
   treatPendingAsSignedOut: Boolean,
 ): Boolean {
-  return if (treatPendingAsSignedOut) hasActiveUser else hasSessionUser
+  return if (treatPendingAsSignedOut) {
+    hasActiveUser
+  } else {
+    hasSession
+  }
 }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/custom/CustomRouteNavKey.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/custom/CustomRouteNavKey.kt
@@ -4,5 +4,4 @@ import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 
 /** A [NavKey] that carries a string route key for custom user profile destinations. */
-@Serializable
-internal data class CustomRouteNavKey(val routeKey: String) : NavKey
+@Serializable internal data class CustomRouteNavKey(val routeKey: String) : NavKey

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/custom/CustomRowView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/custom/CustomRowView.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import com.clerk.ui.core.dimens.dp16
 import com.clerk.ui.core.dimens.dp18

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/update/UserProfileUpdateProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/update/UserProfileUpdateProfileView.kt
@@ -68,7 +68,8 @@ private fun UserProfileUpdateProfileViewImpl(
 
   val context = LocalContext.current
 
-  val (takePhotoLauncher, pickPhotoLauncher) = createLaunchers(context, viewModel)
+  val (takePhotoLauncher, pickPhotoLauncher) =
+    createLaunchers(context, onUploadProfileImage = viewModel::uploadProfileImage)
 
   ClerkMaterialTheme {
     ClerkThemedProfileScaffold(
@@ -99,7 +100,7 @@ private fun UserProfileUpdateProfileViewImpl(
         Spacers.Vertical.Spacer32()
         ProfileFields(
           isLoading = state is UpdateProfileViewModel.State.Loading,
-          viewModel = viewModel,
+          onSave = viewModel::save,
         )
       },
     )
@@ -109,7 +110,7 @@ private fun UserProfileUpdateProfileViewImpl(
 @Composable
 private fun createLaunchers(
   context: Context,
-  viewModel: UpdateProfileViewModel,
+  onUploadProfileImage: (File) -> Unit,
 ): Pair<
   ManagedActivityResultLauncher<Void?, Bitmap?>,
   ManagedActivityResultLauncher<PickVisualMediaRequest, Uri?>,
@@ -118,7 +119,7 @@ private fun createLaunchers(
     rememberLauncherForActivityResult(ActivityResultContracts.TakePicturePreview()) { bitmap ->
       if (bitmap != null) {
         val file = createImageFileFromBitmap(context.cacheDir.absolutePath, bitmap)
-        viewModel.uploadProfileImage(file)
+        onUploadProfileImage(file)
       }
     }
 
@@ -126,14 +127,17 @@ private fun createLaunchers(
     rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
       if (uri != null) {
         val file = createImageFileFromUri(context, uri)
-        viewModel.uploadProfileImage(file)
+        onUploadProfileImage(file)
       }
     }
   return Pair(takePhotoLauncher, pickPhotoLauncher)
 }
 
 @Composable
-private fun ProfileFields(isLoading: Boolean, viewModel: UpdateProfileViewModel) {
+private fun ProfileFields(
+  isLoading: Boolean,
+  onSave: (firstName: String?, lastName: String?, username: String?) -> Unit,
+) {
   val user by Clerk.userFlow.collectAsStateWithLifecycle()
   var username by rememberSaveable { mutableStateOf(user?.username) }
   var firstName by rememberSaveable { mutableStateOf(user?.firstName) }
@@ -172,13 +176,7 @@ private fun ProfileFields(isLoading: Boolean, viewModel: UpdateProfileViewModel)
         isLoading = isLoading,
         modifier = Modifier.fillMaxWidth(),
         text = stringResource(R.string.save),
-        onClick = {
-          viewModel.save(
-            firstName = firstName,
-            lastName = lastName,
-            username = if (usernameIsEditable) username else null,
-          )
-        },
+        onClick = { onSave(firstName, lastName, if (usernameIsEditable) username else null) },
       )
     }
   }

--- a/source/ui/src/main/java/com/clerk/ui/util/EmailAppLauncher.kt
+++ b/source/ui/src/main/java/com/clerk/ui/util/EmailAppLauncher.kt
@@ -1,0 +1,31 @@
+package com.clerk.ui.util
+
+import android.content.Context
+import android.content.Intent
+
+internal object EmailAppLauncher {
+  fun open(context: Context): Boolean {
+    val packageManager = context.packageManager
+    val appIntent = Intent(Intent.ACTION_MAIN).apply { addCategory(Intent.CATEGORY_APP_EMAIL) }
+
+    val explicitLaunchIntent =
+      packageManager.queryIntentActivities(appIntent, 0).firstNotNullOfOrNull { resolveInfo ->
+        packageManager.getLaunchIntentForPackage(resolveInfo.activityInfo.packageName)
+      }
+
+    if (explicitLaunchIntent != null && context.tryStartActivity(explicitLaunchIntent)) {
+      return true
+    }
+
+    return context.tryStartActivity(appIntent)
+  }
+
+  private fun Context.tryStartActivity(intent: Intent): Boolean {
+    val launchIntent = Intent(intent).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+    return runCatching {
+        startActivity(launchIntent)
+        true
+      }
+      .getOrElse { false }
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/util/TextIconHelper.kt
+++ b/source/ui/src/main/java/com/clerk/ui/util/TextIconHelper.kt
@@ -34,6 +34,14 @@ internal class TextIconHelper {
           context.getString(R.string.email_code_to_email, safeIdentifier)
         }
       }
+      StrategyKeys.EMAIL_LINK -> {
+        val safeIdentifier = factor.safeIdentifier
+        if (safeIdentifier.isNullOrBlank()) {
+          context.getString(R.string.send_email_to, context.getString(R.string.email_address))
+        } else {
+          context.getString(R.string.send_email_to, safeIdentifier)
+        }
+      }
       StrategyKeys.PASSKEY -> context.getString(R.string.sign_in_with_your_passkey)
       StrategyKeys.PASSWORD -> context.getString(R.string.sign_in_with_your_password)
       StrategyKeys.TOTP -> context.getString(R.string.use_your_authenticator_app)
@@ -52,6 +60,7 @@ internal class TextIconHelper {
     return when (factor.strategy) {
       StrategyKeys.PHONE_CODE -> R.drawable.ic_sms
       StrategyKeys.EMAIL_CODE -> R.drawable.ic_email
+      StrategyKeys.EMAIL_LINK -> R.drawable.ic_email
       StrategyKeys.PASSKEY -> R.drawable.ic_fingerprint
       StrategyKeys.PASSWORD -> R.drawable.ic_lock
       else -> null

--- a/source/ui/src/main/res/drawable/dev_mode_background_grey.xml
+++ b/source/ui/src/main/res/drawable/dev_mode_background_grey.xml
@@ -9,112 +9,112 @@
         android:pathData="M0,0h402v100h-402z"/>
     <path
         android:pathData="M0,0h402v100h-402z"
-        android:fillColor="#FFF6ED"/>
+        android:fillColor="@color/dev_mode_warning_background"/>
     <path
         android:pathData="M210.44,-207.56l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M219.37,-198.63l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M228.3,-189.7l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M237.23,-180.77l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M246.16,-171.84l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M255.09,-162.91l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M264.02,-153.98l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M272.95,-145.04l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M281.89,-136.12l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M290.82,-127.18l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M299.75,-118.25l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M308.68,-109.32l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M317.61,-100.39l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M326.54,-91.46l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M335.47,-82.53l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M344.4,-73.6l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M353.33,-64.67l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M362.26,-55.74l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M371.19,-46.81l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M380.12,-37.88l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M389.05,-28.95l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M397.98,-20.02l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M406.91,-11.09l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M415.84,-2.16l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M424.77,6.77l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M433.7,15.7l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M442.63,24.63l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M451.56,33.56l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M460.49,42.49l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M469.42,51.42l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M478.35,60.35l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M487.28,69.28l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M496.21,78.21l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M505.14,87.14l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M514.07,96.07l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M0,0h402v100h-402z">
       <aapt:attr name="android:fillColor">
@@ -124,8 +124,8 @@
             android:endX="201"
             android:endY="100"
             android:type="linear">
-          <item android:offset="0" android:color="#FFF9F9F9"/>
-          <item android:offset="1" android:color="#99FFF6ED"/>
+          <item android:offset="0" android:color="@color/dev_mode_background_grey_start"/>
+          <item android:offset="1" android:color="@color/dev_mode_warning_gradient_end"/>
         </gradient>
       </aapt:attr>
     </path>

--- a/source/ui/src/main/res/drawable/dev_mode_background_white.xml
+++ b/source/ui/src/main/res/drawable/dev_mode_background_white.xml
@@ -9,112 +9,112 @@
         android:pathData="M0,0h402v125h-402z"/>
     <path
         android:pathData="M0,0h402v125h-402z"
-        android:fillColor="#FFF6ED"/>
+        android:fillColor="@color/dev_mode_warning_background"/>
     <path
         android:pathData="M210.44,-207.56l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M219.37,-198.63l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M228.3,-189.7l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M237.23,-180.77l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M246.16,-171.84l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M255.09,-162.91l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M264.02,-153.98l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M272.95,-145.04l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M281.89,-136.12l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M290.82,-127.18l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M299.75,-118.25l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M308.68,-109.32l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M317.61,-100.39l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M326.54,-91.46l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M335.47,-82.53l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M344.4,-73.6l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M353.33,-64.67l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M362.26,-55.74l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M371.19,-46.81l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M380.12,-37.88l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M389.05,-28.95l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M397.98,-20.02l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M406.91,-11.09l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M415.84,-2.16l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M424.77,6.77l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M433.7,15.7l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M442.63,24.63l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M451.56,33.56l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M460.49,42.49l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M469.42,51.42l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M478.35,60.35l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M487.28,69.28l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M496.21,78.21l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M505.14,87.14l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M514.07,96.07l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="#FFEBD5"/>
+        android:fillColor="@color/dev_mode_warning_stripe"/>
     <path
         android:pathData="M0,0h402v125h-402z">
       <aapt:attr name="android:fillColor">
@@ -124,8 +124,8 @@
             android:endX="201"
             android:endY="125"
             android:type="linear">
-          <item android:offset="0" android:color="#FFFFFFFF"/>
-          <item android:offset="1" android:color="#99FFF6ED"/>
+          <item android:offset="0" android:color="@color/dev_mode_background_white_start"/>
+          <item android:offset="1" android:color="@color/dev_mode_warning_gradient_end"/>
         </gradient>
       </aapt:attr>
     </path>

--- a/source/ui/src/main/res/values-night/colors.xml
+++ b/source/ui/src/main/res/values-night/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="dev_mode_background_grey_start">#FF1A1A1D</color>
+    <color name="dev_mode_background_white_start">#FF131316</color>
+    <color name="dev_mode_warning_background">#FF241A14</color>
+    <color name="dev_mode_warning_gradient_end">#991F1712</color>
+</resources>

--- a/source/ui/src/main/res/values/colors.xml
+++ b/source/ui/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="dev_mode_background_grey_start">#FFF9F9F9</color>
+    <color name="dev_mode_background_white_start">#FFFFFFFF</color>
+    <color name="dev_mode_warning_background">#FFFFF6ED</color>
+    <color name="dev_mode_warning_gradient_end">#99FFF6ED</color>
+    <color name="dev_mode_warning_stripe">#FFFFEBD5</color>
+</resources>

--- a/source/ui/src/main/res/values/strings.xml
+++ b/source/ui/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="get_help">Get help</string>
     <string name="if_you_have_trouble_signing_into_your_account">If you have trouble signing into your account, email us and we will work with you to restore access as soon as possible.</string>
     <string name="email_support">Email support</string>
+    <string name="open_email_app">Open email app</string>
     <string name="support_clerk_com" translatable="false">support@clerk.com</string>
     <string name="no_email_clients_installed_on_device">No email clients installed on device.</string>
     <string name="set_new_password">Set new password</string>

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthStartViewHelperTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthStartViewHelperTest.kt
@@ -1,5 +1,7 @@
 package com.clerk.ui.auth
 
+import androidx.compose.ui.autofill.ContentType
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -54,5 +56,32 @@ class AuthStartViewHelperTest {
       )
 
     assertFalse(result)
+  }
+
+  @Test
+  fun identifierContentTypeReturnsEmailAddressWhenOnlyEmailIsEnabled() {
+    val helper = AuthStartViewHelper()
+    helper.setTestValues(enabledFirstFactorAttributes = listOf("email_address"))
+
+    assertEquals(ContentType.EmailAddress, helper.identifierContentType())
+  }
+
+  @Test
+  fun identifierContentTypeReturnsUsernameWhenOnlyUsernameIsEnabled() {
+    val helper = AuthStartViewHelper()
+    helper.setTestValues(enabledFirstFactorAttributes = listOf("username"))
+
+    assertEquals(ContentType.Username, helper.identifierContentType())
+  }
+
+  @Test
+  fun identifierContentTypeReturnsEmailAndUsernameWhenBothAreEnabled() {
+    val helper = AuthStartViewHelper()
+    helper.setTestValues(enabledFirstFactorAttributes = listOf("email_address", "username"))
+
+    val contentType = helper.identifierContentType()
+
+    assertFalse(contentType == ContentType.EmailAddress)
+    assertFalse(contentType == ContentType.Username)
   }
 }

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthStateSignUpRoutingTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthStateSignUpRoutingTest.kt
@@ -1,0 +1,130 @@
+package com.clerk.ui.auth
+
+import android.content.Context
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.test.core.app.ApplicationProvider
+import com.clerk.api.Constants
+import com.clerk.api.network.model.verification.Verification
+import com.clerk.api.signup.SignUp
+import com.clerk.ui.signup.collectfield.CollectField
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AuthStateSignUpRoutingTest {
+
+  private lateinit var context: Context
+  private val backStack = mockk<NavBackStack<NavKey>>(relaxed = true)
+  private lateinit var authState: AuthState
+
+  @Before
+  fun setUp() {
+    context = ApplicationProvider.getApplicationContext()
+    preferences().edit().clear().commit()
+    authState =
+      AuthState(
+        mode = AuthMode.SignInOrUp,
+        backStack = backStack,
+        sharedPreferences = preferences(),
+      )
+  }
+
+  @Test
+  fun setToStepForStatusRoutesToSignUpEmailLinkWhenEmailVerificationStrategyIsEmailLink() {
+    val signUp =
+      signUp(
+        verifications =
+          mapOf(
+            "email_address" to
+              Verification(
+                status = Verification.Status.UNVERIFIED,
+                strategy = Constants.Strategy.EMAIL_LINK,
+              )
+          )
+      )
+
+    authState.setToStepForStatus(signUp) {}
+
+    verify(exactly = 1) {
+      backStack.add(AuthDestination.SignUpEmailLink(emailAddress = "sam@clerk.dev"))
+    }
+  }
+
+  @Test
+  fun setToStepForStatusRoutesToSignUpCodeWhenEmailVerificationStrategyIsEmailCode() {
+    val signUp =
+      signUp(
+        verifications =
+          mapOf(
+            "email_address" to
+              Verification(
+                status = Verification.Status.UNVERIFIED,
+                strategy = Constants.Strategy.EMAIL_CODE,
+              )
+          )
+      )
+
+    authState.setToStepForStatus(signUp) {}
+
+    verify(exactly = 1) {
+      backStack.add(
+        AuthDestination.SignUpCode(
+          field = com.clerk.ui.signup.code.SignUpCodeField.Email("sam@clerk.dev")
+        )
+      )
+    }
+  }
+
+  @Test
+  fun setToStepForStatusCollectsRequiredFieldsBeforeStartingEmailLinkVerification() {
+    val signUp =
+      signUp(
+        verifications =
+          mapOf(
+            "email_address" to
+              Verification(
+                status = Verification.Status.UNVERIFIED,
+                strategy = Constants.Strategy.EMAIL_LINK,
+              )
+          ),
+        missingFields = listOf("password"),
+      )
+
+    authState.setToStepForStatus(signUp) {}
+
+    verify(exactly = 1) { backStack.add(AuthDestination.SignUpCollectField(CollectField.Password)) }
+    verify(exactly = 0) {
+      backStack.add(AuthDestination.SignUpEmailLink(emailAddress = "sam@clerk.dev"))
+    }
+  }
+
+  private fun signUp(
+    verifications: Map<String, Verification?>,
+    missingFields: List<String> = emptyList(),
+  ): SignUp {
+    every { backStack.add(any()) } returns true
+    return SignUp(
+      id = "sign_up_123",
+      status = SignUp.Status.MISSING_REQUIREMENTS,
+      requiredFields = listOf("email_address", "password"),
+      optionalFields = emptyList(),
+      missingFields = missingFields,
+      unverifiedFields = listOf("email_address"),
+      verifications = verifications,
+      emailAddress = "sam@clerk.dev",
+      passwordEnabled = false,
+    )
+  }
+
+  private fun preferences() =
+    context.getSharedPreferences(
+      Constants.Storage.CLERK_PREFERENCES_FILE_NAME,
+      Context.MODE_PRIVATE,
+    )
+}

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewPendingAuthRoutingTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewPendingAuthRoutingTest.kt
@@ -1,0 +1,85 @@
+package com.clerk.ui.auth
+
+import android.content.Context
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.test.core.app.ApplicationProvider
+import com.clerk.api.Constants
+import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.signin.SignIn
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AuthViewPendingAuthRoutingTest {
+
+  private lateinit var context: Context
+  private val backStack = mockk<NavBackStack<NavKey>>(relaxed = true)
+  private lateinit var authState: AuthState
+
+  @Before
+  fun setUp() {
+    context = ApplicationProvider.getApplicationContext()
+    preferences().edit().clear().commit()
+    every { backStack.add(any()) } returns true
+    authState =
+      AuthState(
+        mode = AuthMode.SignInOrUp,
+        backStack = backStack,
+        sharedPreferences = preferences(),
+      )
+  }
+
+  @Test
+  fun `resumeInProgressAuthAttempt routes sign in to second factor from auth start`() {
+    val factor = Factor(strategy = Constants.Strategy.TOTP)
+    val signIn =
+      SignIn(
+        id = "sign_in_123",
+        status = SignIn.Status.NEEDS_SECOND_FACTOR,
+        supportedSecondFactors = listOf(factor),
+      )
+
+    resumeInProgressAuthAttempt(
+      authState = authState,
+      top = AuthDestination.AuthStart,
+      signIn = signIn,
+      signUp = null,
+      onAuthComplete = {},
+    )
+
+    verify(exactly = 1) { backStack.add(AuthDestination.SignInFactorTwo(factor = factor)) }
+  }
+
+  @Test
+  fun `resumeInProgressAuthAttempt does not reroute when auth stack is already past root`() {
+    val factor = Factor(strategy = Constants.Strategy.TOTP)
+    val signIn =
+      SignIn(
+        id = "sign_in_123",
+        status = SignIn.Status.NEEDS_SECOND_FACTOR,
+        supportedSecondFactors = listOf(factor),
+      )
+
+    resumeInProgressAuthAttempt(
+      authState = authState,
+      top = AuthDestination.SignInFactorTwo(factor),
+      signIn = signIn,
+      signUp = null,
+      onAuthComplete = {},
+    )
+
+    verify(exactly = 0) { backStack.add(any()) }
+  }
+
+  private fun preferences() =
+    context.getSharedPreferences(
+      Constants.Storage.CLERK_PREFERENCES_FILE_NAME,
+      Context.MODE_PRIVATE,
+    )
+}

--- a/source/ui/src/test/java/com/clerk/ui/core/scaffold/LogoVisibilityTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/core/scaffold/LogoVisibilityTest.kt
@@ -1,0 +1,32 @@
+package com.clerk.ui.core.scaffold
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LogoVisibilityTest {
+
+  @Test
+  fun shouldShowInstanceLogoReturnsFalseWhenHasLogoIsFalse() {
+    assertFalse(
+      shouldShowInstanceLogo(hasLogo = false, organizationLogoUrl = "https://example.com/logo.png")
+    )
+  }
+
+  @Test
+  fun shouldShowInstanceLogoReturnsFalseWhenLogoUrlIsNull() {
+    assertFalse(shouldShowInstanceLogo(hasLogo = true, organizationLogoUrl = null))
+  }
+
+  @Test
+  fun shouldShowInstanceLogoReturnsFalseWhenLogoUrlIsBlank() {
+    assertFalse(shouldShowInstanceLogo(hasLogo = true, organizationLogoUrl = "   "))
+  }
+
+  @Test
+  fun shouldShowInstanceLogoReturnsTrueWhenHasLogoAndUrlArePresent() {
+    assertTrue(
+      shouldShowInstanceLogo(hasLogo = true, organizationLogoUrl = "https://example.com/logo.png")
+    )
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/signin/SignInFactorOneViewTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/SignInFactorOneViewTest.kt
@@ -1,0 +1,90 @@
+package com.clerk.ui.signin
+
+import com.clerk.api.Clerk
+import com.clerk.api.auth.Auth
+import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.signin.SignIn
+import com.clerk.ui.core.common.StrategyKeys
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class SignInFactorOneViewTest {
+
+  private val mockAuth = mockk<Auth>(relaxed = true)
+
+  @Before
+  fun setUp() {
+    mockkObject(Clerk)
+    every { Clerk.auth } returns mockAuth
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun resolveFirstFactorShouldPreferEmailLinkWhenFallbackEmailCodeHasEmailAddressId() {
+    every { mockAuth.currentSignIn } returns
+      SignIn(
+        id = "sign_in_123",
+        identifier = null,
+        supportedFirstFactors =
+          listOf(
+            Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123"),
+            Factor(strategy = StrategyKeys.EMAIL_LINK, emailAddressId = "email_123"),
+          ),
+      )
+
+    val resolved =
+      resolveFirstFactor(Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123"))
+
+    assertEquals(StrategyKeys.EMAIL_LINK, resolved.strategy)
+  }
+
+  @Test
+  fun resolveFirstFactorShouldKeepFallbackWhenEmailLinkIsNotSupported() {
+    every { mockAuth.currentSignIn } returns
+      SignIn(
+        id = "sign_in_123",
+        identifier = null,
+        supportedFirstFactors =
+          listOf(Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123")),
+      )
+
+    val fallback = Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123")
+    val resolved = resolveFirstFactor(fallback)
+
+    assertEquals(fallback, resolved)
+  }
+
+  @Test
+  fun resolveFirstFactorShouldPreferEmailLinkOverPreparedEmailCodeForEmailIdentifier() {
+    every { mockAuth.currentSignIn } returns
+      SignIn(
+        id = "sign_in_123",
+        identifier = "sam@clerk.dev",
+        supportedFirstFactors =
+          listOf(
+            Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123"),
+            Factor(strategy = StrategyKeys.EMAIL_LINK, emailAddressId = "email_123"),
+          ),
+        firstFactorVerification =
+          com.clerk.api.network.model.verification.Verification(
+            status = com.clerk.api.network.model.verification.Verification.Status.UNVERIFIED,
+            strategy = StrategyKeys.EMAIL_CODE,
+          ),
+      )
+
+    val resolved =
+      resolveFirstFactor(Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123"))
+
+    assertEquals(StrategyKeys.EMAIL_LINK, resolved.strategy)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/signin/code/SignInFactorCodeViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/code/SignInFactorCodeViewModelTest.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.test
 import com.clerk.api.Clerk
 import com.clerk.api.auth.Auth
 import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.signin.SignIn
 import com.clerk.ui.auth.AuthenticationViewState
 import com.clerk.ui.core.common.StrategyKeys
@@ -50,6 +51,18 @@ class SignInFactorCodeViewModelTest {
     mockkObject(Clerk)
     every { Clerk.auth } returns mockAuth
     every { mockAuth.currentSignIn } returns mockSignIn
+    every { mockSignIn.identifier } returns "user@example.com"
+    every { mockSignIn.supportedFirstFactors } returns
+      listOf(
+        Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123"),
+        Factor(strategy = StrategyKeys.PHONE_CODE, phoneNumberId = "phone_456"),
+      )
+    every { mockSignIn.supportedSecondFactors } returns
+      listOf(
+        Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123"),
+        Factor(strategy = StrategyKeys.PHONE_CODE, phoneNumberId = "phone_456"),
+        Factor(strategy = StrategyKeys.TOTP),
+      )
 
     viewModel =
       SignInFactorCodeViewModel(
@@ -336,5 +349,110 @@ class SignInFactorCodeViewModelTest {
 
       assertEquals(AuthenticationViewState.Loading, awaitItem())
     }
+  }
+
+  @Test
+  fun prepareShouldRerouteToFirstFactorWhenEmailLinkIsAvailableForEmailIdentifier() = runTest {
+    every { mockSignIn.identifier } returns "sam@clerk.dev"
+    every { mockSignIn.supportedFirstFactors } returns
+      listOf(
+        Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123"),
+        Factor(strategy = StrategyKeys.EMAIL_LINK, emailAddressId = "email_123"),
+      )
+    val factor = Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123")
+
+    viewModel.state.test {
+      assertEquals(AuthenticationViewState.Idle, awaitItem())
+
+      viewModel.prepare(factor, isSecondFactor = false)
+      testDispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(AuthenticationViewState.Loading, awaitItem())
+      assertEquals(AuthenticationViewState.Success.SignIn(mockSignIn), awaitItem())
+    }
+
+    coVerify(exactly = 0) { mockPrepareHandler.prepareForEmailCode(any(), any(), any(), any()) }
+  }
+
+  @Test
+  fun prepareShouldRerouteToFirstFactorWhenIdentifierIsMissingButEmailFactorExists() = runTest {
+    every { mockSignIn.identifier } returns null
+    every { mockSignIn.supportedFirstFactors } returns
+      listOf(
+        Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123"),
+        Factor(strategy = StrategyKeys.EMAIL_LINK, emailAddressId = "email_123"),
+      )
+    val factor = Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123")
+
+    viewModel.state.test {
+      assertEquals(AuthenticationViewState.Idle, awaitItem())
+
+      viewModel.prepare(factor, isSecondFactor = false)
+      testDispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(AuthenticationViewState.Loading, awaitItem())
+      assertEquals(AuthenticationViewState.Success.SignIn(mockSignIn), awaitItem())
+    }
+
+    coVerify(exactly = 0) { mockPrepareHandler.prepareForEmailCode(any(), any(), any(), any()) }
+  }
+
+  @Test
+  fun prepareShouldNotRerouteWhenEmailCodeIsAlreadyPrepared() = runTest {
+    every { mockSignIn.identifier } returns "sam@clerk.dev"
+    every { mockSignIn.firstFactorVerification } returns
+      Verification(status = Verification.Status.UNVERIFIED, strategy = StrategyKeys.EMAIL_CODE)
+    every { mockSignIn.supportedFirstFactors } returns
+      listOf(
+        Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123"),
+        Factor(strategy = StrategyKeys.EMAIL_LINK, emailAddressId = "email_123"),
+      )
+    val factor = Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123")
+
+    viewModel.prepare(factor, isSecondFactor = false)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    coVerify(exactly = 1) {
+      mockPrepareHandler.prepareForEmailCode(mockSignIn, factor, false, any())
+    }
+  }
+
+  @Test
+  fun prepareShouldRerouteWhenRequestedFactorIsNoLongerSupported() = runTest {
+    every { mockSignIn.identifier } returns null
+    every { mockSignIn.supportedFirstFactors } returns listOf(Factor(strategy = "ticket"))
+    val factor = Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123")
+
+    viewModel.state.test {
+      assertEquals(AuthenticationViewState.Idle, awaitItem())
+
+      viewModel.prepare(factor, isSecondFactor = false)
+      testDispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(AuthenticationViewState.Loading, awaitItem())
+      assertEquals(AuthenticationViewState.Success.SignIn(mockSignIn), awaitItem())
+    }
+
+    coVerify(exactly = 0) { mockPrepareHandler.prepareForEmailCode(any(), any(), any(), any()) }
+  }
+
+  @Test
+  fun prepareShouldRerouteWhenMatchingStrategyHasDifferentIdentifier() = runTest {
+    every { mockSignIn.identifier } returns null
+    every { mockSignIn.supportedFirstFactors } returns
+      listOf(Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_456"))
+    val factor = Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123")
+
+    viewModel.state.test {
+      assertEquals(AuthenticationViewState.Idle, awaitItem())
+
+      viewModel.prepare(factor, isSecondFactor = false)
+      testDispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(AuthenticationViewState.Loading, awaitItem())
+      assertEquals(AuthenticationViewState.Success.SignIn(mockSignIn), awaitItem())
+    }
+
+    coVerify(exactly = 0) { mockPrepareHandler.prepareForEmailCode(any(), any(), any(), any()) }
   }
 }

--- a/source/ui/src/test/java/com/clerk/ui/signin/code/SignInPrepareHandlerTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/code/SignInPrepareHandlerTest.kt
@@ -18,6 +18,8 @@ import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 
@@ -82,15 +84,28 @@ class SignInPrepareHandlerTest {
   @Test
   fun prepareForEmailCodeAsSecondFactorShouldHandleFailureGracefully() = runTest {
     val factor = Factor(strategy = "email_code", emailAddressId = "email_123")
-    val errorResponse = mockk<ClerkErrorResponse>()
+    val errorResponse =
+      ClerkErrorResponse(
+        errors =
+          listOf(
+            ClerkApiError(message = "Short", longMessage = "Email second factor failed", code = "x")
+          ),
+        clerkTraceId = null,
+      )
     val failureResult = ClerkResult.apiFailure(errorResponse)
+    var capturedMessage: String? = null
 
     coEvery { mockSignIn.prepareSecondFactor(emailAddressId = "email_123") } returns failureResult
 
-    // This should not throw an exception - the handler logs but doesn't propagate errors
-    handler.prepareForEmailCode(mockSignIn, factor, isSecondFactor = true, onError = {})
+    handler.prepareForEmailCode(
+      mockSignIn,
+      factor,
+      isSecondFactor = true,
+      onError = { capturedMessage = it },
+    )
 
     coVerify { mockSignIn.prepareSecondFactor(emailAddressId = "email_123") }
+    assertEquals("Email second factor failed", capturedMessage)
   }
 
   @Test
@@ -128,15 +143,28 @@ class SignInPrepareHandlerTest {
   @Test
   fun prepareForPhoneCodeAsSecondFactorShouldHandleFailureGracefully() = runTest {
     val factor = Factor(strategy = "phone_code", phoneNumberId = "phone_789")
-    val errorResponse = mockk<ClerkErrorResponse>()
+    val errorResponse =
+      ClerkErrorResponse(
+        errors =
+          listOf(
+            ClerkApiError(message = "Short", longMessage = "Phone second factor failed", code = "x")
+          ),
+        clerkTraceId = null,
+      )
     val failureResult = ClerkResult.apiFailure(errorResponse)
+    var capturedMessage: String? = null
 
     coEvery { mockSignIn.prepareSecondFactor("phone_789") } returns failureResult
 
-    // This should not throw an exception - the handler logs but doesn't propagate errors
-    handler.prepareForPhoneCode(mockSignIn, factor, isSecondFactor = true, onError = {})
+    handler.prepareForPhoneCode(
+      mockSignIn,
+      factor,
+      isSecondFactor = true,
+      onError = { capturedMessage = it },
+    )
 
     coVerify { mockSignIn.prepareSecondFactor("phone_789") }
+    assertEquals("Phone second factor failed", capturedMessage)
   }
 
   @Test
@@ -222,9 +250,14 @@ class SignInPrepareHandlerTest {
     } returns failureResult
 
     var capturedMessage: String? = null
-    handler.prepareForEmailCode(mockSignIn, factor, isSecondFactor = false, onError = { capturedMessage = it })
+    handler.prepareForEmailCode(
+      mockSignIn,
+      factor,
+      isSecondFactor = false,
+      onError = { capturedMessage = it },
+    )
 
-    assert(capturedMessage == "Long message")
+    assertEquals("Long message", capturedMessage)
   }
 
   @Test
@@ -252,7 +285,7 @@ class SignInPrepareHandlerTest {
     )
 
     // Falls back to default when no message present in error
-    assert(capturedMessage == "Error occurred with unknown message.")
+    assertEquals("Error occurred with unknown message.", capturedMessage)
   }
 
   @Test
@@ -274,7 +307,7 @@ class SignInPrepareHandlerTest {
     var capturedMessage: String? = null
     handler.prepareForResetPasswordWithPhone(mockSignIn, factor, onError = { capturedMessage = it })
 
-    assert(capturedMessage == "Short")
+    assertEquals("Short", capturedMessage)
   }
 
   @Test
@@ -296,7 +329,7 @@ class SignInPrepareHandlerTest {
     var capturedMessage: String? = null
     handler.prepareForResetWithEmailCode(mockSignIn, factor, onError = { capturedMessage = it })
 
-    assert(capturedMessage == "Long fail")
+    assertEquals("Long fail", capturedMessage)
   }
 
   @Test
@@ -304,10 +337,15 @@ class SignInPrepareHandlerTest {
     val factor = Factor(strategy = "email_code", emailAddressId = null)
     var called = false
 
-    handler.prepareForEmailCode(mockSignIn, factor, isSecondFactor = false, onError = { called = true })
+    handler.prepareForEmailCode(
+      mockSignIn,
+      factor,
+      isSecondFactor = false,
+      onError = { called = true },
+    )
 
     coVerify(exactly = 0) { mockSignIn.prepareFirstFactor(any()) }
-    assert(!called)
+    assertFalse(called)
   }
 
   @Test
@@ -323,6 +361,40 @@ class SignInPrepareHandlerTest {
     )
 
     coVerify(exactly = 0) { mockSignIn.prepareFirstFactor(any()) }
-    assert(!called)
+    assertFalse(called)
+  }
+
+  @Test
+  fun prepareForEmailCodeShouldSkipApiCallWhenFirstFactorIsNotSupported() = runTest {
+    every { mockSignIn.supportedFirstFactors } returns listOf(Factor(strategy = "ticket"))
+    val factor = Factor(strategy = "email_code", emailAddressId = "email_123")
+    var capturedMessage: String? = null
+
+    handler.prepareForEmailCode(
+      inProgressSignIn = mockSignIn,
+      factor = factor,
+      isSecondFactor = false,
+      onError = { capturedMessage = it },
+    )
+
+    coVerify(exactly = 0) { mockSignIn.prepareFirstFactor(any()) }
+    assertEquals("Selected sign-in method is no longer available.", capturedMessage)
+  }
+
+  @Test
+  fun prepareForEmailCodeShouldSkipApiCallWhenSecondFactorIsNotSupported() = runTest {
+    every { mockSignIn.supportedSecondFactors } returns listOf(Factor(strategy = "totp"))
+    val factor = Factor(strategy = "email_code", emailAddressId = "email_123")
+    var capturedMessage: String? = null
+
+    handler.prepareForEmailCode(
+      inProgressSignIn = mockSignIn,
+      factor = factor,
+      isSecondFactor = true,
+      onError = { capturedMessage = it },
+    )
+
+    coVerify(exactly = 0) { mockSignIn.prepareSecondFactor(emailAddressId = any()) }
+    assertEquals("Selected sign-in method is no longer available.", capturedMessage)
   }
 }

--- a/source/ui/src/test/java/com/clerk/ui/signin/emaillink/SignInFactorOneEmailLinkViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/emaillink/SignInFactorOneEmailLinkViewModelTest.kt
@@ -1,0 +1,128 @@
+package com.clerk.ui.signin.emaillink
+
+import com.clerk.api.Clerk
+import com.clerk.api.auth.Auth
+import com.clerk.api.auth.AuthEvent
+import com.clerk.api.magiclink.NativeMagicLinkError
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.ui.auth.AuthenticationViewState
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class SignInFactorOneEmailLinkViewModelTest {
+
+  private val testDispatcher = StandardTestDispatcher()
+  private val auth = mockk<Auth>(relaxed = true)
+  private val events = MutableSharedFlow<AuthEvent>(extraBufferCapacity = 1)
+
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+    mockkObject(Clerk)
+    every { Clerk.auth } returns auth
+    every { auth.events } returns events
+    every { auth.currentSignIn } returns null
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+    unmockkAll()
+  }
+
+  @Test
+  fun `sendLink surfaces backend long message for rate limits`() = runTest {
+    every { auth.currentSignIn } returns SignIn(id = "sia_123", identifier = "sam@clerk.dev")
+    coEvery { auth.startEmailLinkSignIn("sam@clerk.dev") } returns
+      ClerkResult.apiFailure(
+        NativeMagicLinkError(
+          reasonCode = "too_many_requests",
+          message = "Too many requests, retry later",
+        )
+      )
+
+    val viewModel = SignInFactorOneEmailLinkViewModel(ioDispatcher = testDispatcher)
+    advanceUntilIdle()
+    viewModel.sendLink()
+    advanceUntilIdle()
+
+    assertEquals(
+      AuthenticationViewState.Error("Too many requests, retry later"),
+      viewModel.state.value,
+    )
+  }
+
+  @Test
+  fun `mfa sign in started event advances email link flow to second factor`() = runTest {
+    val mfaSignIn =
+      SignIn(
+        id = "sia_mfa",
+        status = SignIn.Status.NEEDS_SECOND_FACTOR,
+        identifier = "sam@clerk.dev",
+      )
+
+    val viewModel = SignInFactorOneEmailLinkViewModel(ioDispatcher = testDispatcher)
+    advanceUntilIdle()
+
+    events.tryEmit(AuthEvent.SignInStarted(mfaSignIn))
+    advanceUntilIdle()
+
+    assertEquals(AuthenticationViewState.Success.SignIn(mfaSignIn), viewModel.state.value)
+  }
+
+  @Test
+  fun `resume sync advances email link flow to second factor from current sign in`() = runTest {
+    val mfaSignIn =
+      SignIn(
+        id = "sia_mfa_resume",
+        status = SignIn.Status.NEEDS_SECOND_FACTOR,
+        identifier = "sam@clerk.dev",
+      )
+    every { auth.currentSignIn } returns mfaSignIn
+
+    val viewModel = SignInFactorOneEmailLinkViewModel(ioDispatcher = testDispatcher)
+    advanceUntilIdle()
+
+    viewModel.onHostResumed()
+
+    assertEquals(AuthenticationViewState.Success.SignIn(mfaSignIn), viewModel.state.value)
+  }
+
+  @Test
+  fun `first factor sign in started event does not advance email link flow`() = runTest {
+    val firstFactorSignIn =
+      SignIn(
+        id = "sia_first_factor",
+        status = SignIn.Status.NEEDS_FIRST_FACTOR,
+        identifier = "sam@clerk.dev",
+      )
+
+    val viewModel = SignInFactorOneEmailLinkViewModel(ioDispatcher = testDispatcher)
+    advanceUntilIdle()
+
+    events.tryEmit(AuthEvent.SignInStarted(firstFactorSignIn))
+    advanceUntilIdle()
+
+    assertEquals(AuthenticationViewState.Idle, viewModel.state.value)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/signup/emaillink/SignUpEmailLinkViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signup/emaillink/SignUpEmailLinkViewModelTest.kt
@@ -1,0 +1,93 @@
+package com.clerk.ui.signup.emaillink
+
+import com.clerk.api.Clerk
+import com.clerk.api.auth.Auth
+import com.clerk.api.auth.AuthEvent
+import com.clerk.api.signup.SignUp
+import com.clerk.ui.auth.AuthenticationViewState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class SignUpEmailLinkViewModelTest {
+
+  private val testDispatcher = StandardTestDispatcher()
+  private val auth = mockk<Auth>(relaxed = true)
+  private val events = MutableSharedFlow<AuthEvent>(extraBufferCapacity = 1)
+
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+    mockkObject(Clerk)
+    every { Clerk.auth } returns auth
+    every { auth.events } returns events
+    every { auth.currentSignUp } returns null
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+    unmockkAll()
+  }
+
+  @Test
+  fun `sign up started event advances email link flow to next sign up step`() = runTest {
+    val pendingSignUp = signUp(id = "sua_pending", unverifiedFields = listOf("phone_number"))
+
+    val viewModel = SignUpEmailLinkViewModel(ioDispatcher = testDispatcher)
+    advanceUntilIdle()
+
+    events.tryEmit(AuthEvent.SignUpStarted(pendingSignUp))
+    advanceUntilIdle()
+
+    assertEquals(AuthenticationViewState.Success.SignUp(pendingSignUp), viewModel.state.value)
+  }
+
+  @Test
+  fun `resume sync advances email link flow from current sign up`() = runTest {
+    val pendingSignUp = signUp(id = "sua_resume", unverifiedFields = listOf("phone_number"))
+    every { auth.currentSignUp } returns pendingSignUp
+
+    val viewModel = SignUpEmailLinkViewModel(ioDispatcher = testDispatcher)
+    advanceUntilIdle()
+
+    viewModel.onHostResumed()
+
+    assertEquals(AuthenticationViewState.Success.SignUp(pendingSignUp), viewModel.state.value)
+  }
+
+  private fun signUp(
+    id: String = "sua_123",
+    unverifiedFields: List<String> = listOf("email_address"),
+  ): SignUp =
+    SignUp(
+      id = id,
+      status = SignUp.Status.MISSING_REQUIREMENTS,
+      requiredFields = listOf("email_address", "phone_number", "username"),
+      optionalFields = emptyList(),
+      missingFields = emptyList(),
+      unverifiedFields = unverifiedFields,
+      verifications = emptyMap(),
+      emailAddress = "sam@clerk.dev",
+      phoneNumber = "+13012370655",
+      username = "swolfand",
+      passwordEnabled = false,
+    )
+}

--- a/source/ui/src/test/java/com/clerk/ui/userbutton/UserButtonBehaviorTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userbutton/UserButtonBehaviorTest.kt
@@ -29,10 +29,10 @@ class UserButtonBehaviorTest {
   }
 
   @Test
-  fun `shouldShowUserButton uses session user when pending sessions are allowed`() {
+  fun `shouldShowUserButton shows when session exists and pending sessions are allowed`() {
     assertTrue(
       shouldShowUserButton(
-        hasSessionUser = true,
+        hasSession = true,
         hasActiveUser = false,
         treatPendingAsSignedOut = false,
       )
@@ -40,13 +40,27 @@ class UserButtonBehaviorTest {
   }
 
   @Test
-  fun `shouldShowUserButton hides when only session user exists and pending is treated as signed out`() {
+  fun `shouldShowUserButton hides when no session exists and pending sessions are allowed`() {
     assertFalse(
       shouldShowUserButton(
-        hasSessionUser = true,
-        hasActiveUser = false,
-        treatPendingAsSignedOut = true,
+        hasSession = false,
+        hasActiveUser = true,
+        treatPendingAsSignedOut = false,
       )
+    )
+  }
+
+  @Test
+  fun `shouldShowUserButton shows when active user exists and pending is treated as signed out`() {
+    assertTrue(
+      shouldShowUserButton(hasSession = false, hasActiveUser = true, treatPendingAsSignedOut = true)
+    )
+  }
+
+  @Test
+  fun `shouldShowUserButton hides when only session user exists and pending is treated as signed out`() {
+    assertFalse(
+      shouldShowUserButton(hasSession = true, hasActiveUser = false, treatPendingAsSignedOut = true)
     )
   }
 

--- a/workbench/src/debug/AndroidManifest.xml
+++ b/workbench/src/debug/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:networkSecurityConfig="@xml/workbench_debug_network_security_config" />
+
+</manifest>

--- a/workbench/src/debug/res/xml/workbench_debug_network_security_config.xml
+++ b/workbench/src/debug/res/xml/workbench_debug_network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/workbench/src/main/java/com/clerk/workbench/HomeView.kt
+++ b/workbench/src/main/java/com/clerk/workbench/HomeView.kt
@@ -20,13 +20,13 @@ import com.clerk.ui.userbutton.UserButton
 @Composable
 fun UserProfileTopBar() {
   val session by Clerk.sessionFlow.collectAsStateWithLifecycle()
-  val user by Clerk.userFlow.collectAsStateWithLifecycle()
+  val currentSession = session
   Scaffold(
     topBar = {
       TopAppBar(
         title = { Text("Home screen") },
         actions = {
-          if (user != null && session?.pendingTaskKey == null) {
+          if (currentSession != null && currentSession.pendingTaskKey == null) {
             UserButton()
           }
         },

--- a/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
+++ b/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
@@ -54,11 +54,27 @@ class MainActivity : ComponentActivity() {
       val context = LocalContext.current
       WorkbenchTheme {
         MainContent(
-          onSave = {
-            StorageHelper.saveValue(StorageKey.PUBLIC_KEY, it)
+          onSave = { publishableKey, proxyUrl ->
+            val normalizedKey = publishableKey.trim()
+            val normalizedProxy = proxyUrl.trim()
+
+            if (normalizedKey.isBlank()) {
+              StorageHelper.deleteValue(StorageKey.PUBLIC_KEY)
+            } else {
+              StorageHelper.saveValue(StorageKey.PUBLIC_KEY, normalizedKey)
+            }
+
+            if (normalizedProxy.isBlank()) {
+              StorageHelper.deleteValue(StorageKey.PROXY_URL)
+            } else {
+              StorageHelper.saveValue(StorageKey.PROXY_URL, normalizedProxy)
+            }
             ProcessPhoenix.triggerRebirth(context)
           },
-          onClear = { StorageHelper.deleteValue(StorageKey.PUBLIC_KEY) },
+          onClear = {
+            StorageHelper.deleteValue(StorageKey.PUBLIC_KEY)
+            StorageHelper.deleteValue(StorageKey.PROXY_URL)
+          },
           onClickFirstItem = { context.startActivity(Intent(context, UiActivity1::class.java)) },
           onClickSecondItem = { context.startActivity(Intent(context, UiActivity2::class.java)) },
         )
@@ -71,7 +87,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 private fun MainContent(
   onClear: () -> Unit,
-  onSave: (String) -> Unit,
+  onSave: (String, String) -> Unit,
   onClickFirstItem: () -> Unit,
   onClickSecondItem: () -> Unit,
 ) {
@@ -107,9 +123,9 @@ private fun MainContent(
   if (showBottomSheet) {
     ModalBottomSheet(onDismissRequest = { showBottomSheet = false }) {
       SettingsBottomSheetContent(
-        onSave = { publishableKey ->
+        onSave = { publishableKey, proxyUrl ->
           showBottomSheet = false
-          onSave(publishableKey)
+          onSave(publishableKey, proxyUrl)
         },
         onClear = onClear,
       )
@@ -195,9 +211,11 @@ private fun ClickableTestItem(text: String, onClick: () -> Unit) {
 }
 
 @Composable
-private fun SettingsBottomSheetContent(onSave: (String) -> Unit, onClear: () -> Unit) {
+private fun SettingsBottomSheetContent(onSave: (String, String) -> Unit, onClear: () -> Unit) {
   val publicKey = StorageHelper.loadValue(StorageKey.PUBLIC_KEY) ?: ""
+  val savedProxyUrl = StorageHelper.loadValue(StorageKey.PROXY_URL) ?: ""
   var publishableKey by remember { mutableStateOf(publicKey) }
+  var proxyUrl by remember { mutableStateOf(savedProxyUrl) }
 
   Column(
     modifier =
@@ -227,13 +245,23 @@ private fun SettingsBottomSheetContent(onSave: (String) -> Unit, onClear: () -> 
       singleLine = true,
     )
     Spacer(modifier = Modifier.height(Spacing.medium))
-    Button(onClick = { onSave(publishableKey) }, modifier = Modifier.fillMaxWidth()) {
+    OutlinedTextField(
+      value = proxyUrl,
+      onValueChange = { proxyUrl = it },
+      label = { Text(WorkbenchConstants.PROXY_URL_LABEL) },
+      placeholder = { Text(WorkbenchConstants.PROXY_URL_PLACEHOLDER) },
+      modifier = Modifier.fillMaxWidth(),
+      singleLine = true,
+    )
+    Spacer(modifier = Modifier.height(Spacing.medium))
+    Button(onClick = { onSave(publishableKey, proxyUrl) }, modifier = Modifier.fillMaxWidth()) {
       Text(WorkbenchConstants.SAVE_BUTTON_TEXT)
     }
     Button(
       modifier = Modifier.fillMaxWidth(),
       onClick = {
         publishableKey = ""
+        proxyUrl = ""
         onClear()
       },
       colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
@@ -248,9 +276,11 @@ private object WorkbenchConstants {
   const val APP_TITLE = "Clerk Workbench"
   const val INSTRUCTIONS_TITLE = "Instructions:"
   const val SETTINGS_TITLE = "Settings"
-  const val SETTINGS_DESCRIPTION = "Please enter your publishable key"
+  const val SETTINGS_DESCRIPTION = "Please enter your publishable key and optional proxy URL"
   const val PUBLISHABLE_KEY_LABEL = "Publishable Key"
   const val PUBLISHABLE_KEY_PLACEHOLDER = "Enter publishable key"
+  const val PROXY_URL_LABEL = "Proxy URL"
+  const val PROXY_URL_PLACEHOLDER = "Enter proxy URL for local/dev instances"
   const val SAVE_BUTTON_TEXT = "Save"
 
   val instructionSteps =

--- a/workbench/src/main/java/com/clerk/workbench/PreferencesManager.kt
+++ b/workbench/src/main/java/com/clerk/workbench/PreferencesManager.kt
@@ -41,5 +41,6 @@ internal object StorageHelper {
 }
 
 internal enum class StorageKey {
-  PUBLIC_KEY
+  PUBLIC_KEY,
+  PROXY_URL,
 }

--- a/workbench/src/main/java/com/clerk/workbench/WorkbenchApplication.kt
+++ b/workbench/src/main/java/com/clerk/workbench/WorkbenchApplication.kt
@@ -10,9 +10,14 @@ class WorkbenchApplication : Application() {
     super.onCreate()
     StorageHelper.initialize(this)
 
-    val publicKey = "pk_test_d2lubmluZy1jb3VnYXItNDkuY2xlcmsuYWNjb3VudHMuZGV2JA"
+    val publicKey = StorageHelper.loadValue(StorageKey.PUBLIC_KEY)
+    val proxyUrl = StorageHelper.loadValue(StorageKey.PROXY_URL)
     publicKey?.let { key ->
-      Clerk.initialize(this, key, options = ClerkConfigurationOptions(enableDebugMode = true))
+      Clerk.initialize(
+        this,
+        key,
+        options = ClerkConfigurationOptions(enableDebugMode = true, proxyUrl = proxyUrl),
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary
- move dev mode warning drawable colors into resources with night-mode overrides
- use theme colors for the warning label and Clerk branding
- keep the existing drawable-backed warning background

## Testing
- ./gradlew :source:ui:compileDebugKotlin
- ./gradlew :source:ui:spotlessCheck :source:ui:detekt