### PR TITLE
fix(ui): set IME actions on auth input fields to submit on Enter

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -4,7 +4,9 @@ import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -153,28 +155,8 @@ internal fun AuthStartViewImpl(
         verticalArrangement = Arrangement.spacedBy(dp24, alignment = Alignment.CenterVertically),
       ) {
         if (authViewHelper.showIdentifierField) {
-          AuthInputField(
-            authViewHelper = authViewHelper,
-            phoneNumberFieldIsActive = phoneActive,
-            authStartPhoneNumber = authState.authStartPhoneNumber,
-            authStartIdentifier = authState.authStartIdentifier,
-            onPhoneNumberChange = { authState.authStartPhoneNumber = it },
-            onIdentifierChange = { authState.authStartIdentifier = it },
-            showPhoneBadge = lastUsedAuth?.showsPhoneBadge == true,
-            showEmailUsernameBadge = lastUsedAuth?.showsEmailUsernameBadge == true,
-          )
-
-          ClerkButton(
-            modifier = Modifier.fillMaxWidth(),
-            text = stringResource(R.string.continue_text),
-            isLoading = state is AuthStartViewModel.AuthState.Loading,
-            isEnabled = isContinueEnabled,
-            icons =
-              ClerkButtonDefaults.icons(
-                trailingIcon = R.drawable.ic_triangle_right,
-                trailingIconColor = ClerkMaterialTheme.colors.primaryForeground,
-              ),
-            onClick = {
+          val onSubmit: () -> Unit = {
+            if (isContinueEnabled) {
               if (authState.mode != AuthMode.SignUp) {
                 storeIdentifierType(
                   authState = authState,
@@ -195,7 +177,32 @@ internal fun AuthStartViewImpl(
                 identifier = authState.authStartIdentifier,
                 phoneNumber = authState.authStartPhoneNumber,
               )
-            },
+            }
+          }
+
+          AuthInputField(
+            authViewHelper = authViewHelper,
+            phoneNumberFieldIsActive = phoneActive,
+            authStartPhoneNumber = authState.authStartPhoneNumber,
+            authStartIdentifier = authState.authStartIdentifier,
+            onPhoneNumberChange = { authState.authStartPhoneNumber = it },
+            onIdentifierChange = { authState.authStartIdentifier = it },
+            showPhoneBadge = lastUsedAuth?.showsPhoneBadge == true,
+            showEmailUsernameBadge = lastUsedAuth?.showsEmailUsernameBadge == true,
+            onSubmit = onSubmit,
+          )
+
+          ClerkButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.continue_text),
+            isLoading = state is AuthStartViewModel.AuthState.Loading,
+            isEnabled = isContinueEnabled,
+            icons =
+              ClerkButtonDefaults.icons(
+                trailingIcon = R.drawable.ic_triangle_right,
+                trailingIconColor = ClerkMaterialTheme.colors.primaryForeground,
+              ),
+            onClick = onSubmit,
           )
 
           if (authViewHelper.showIdentifierSwitcher) {
@@ -258,6 +265,7 @@ private fun AuthInputField(
   onIdentifierChange: (String) -> Unit,
   showPhoneBadge: Boolean,
   showEmailUsernameBadge: Boolean,
+  onSubmit: () -> Unit,
 ) {
   if (authViewHelper.phoneNumberIsEnabled && phoneNumberFieldIsActive) {
     LastUsedAuthBadgeOverlay(isVisible = showPhoneBadge) {
@@ -265,6 +273,8 @@ private fun AuthInputField(
         value = authStartPhoneNumber,
         modifier = Modifier.fillMaxWidth(),
         onValueChange = onPhoneNumberChange,
+        imeAction = ImeAction.Go,
+        keyboardActions = KeyboardActions(onGo = { onSubmit() }),
       )
     }
   } else {
@@ -275,7 +285,8 @@ private fun AuthInputField(
         onValueChange = onIdentifierChange,
         label = authViewHelper.emailOrUsernamePlaceholder(),
         keyboardOptions =
-          KeyboardOptions(keyboardType = authViewHelper.getKeyboardType(phoneNumberFieldIsActive)),
+          KeyboardOptions(keyboardType = authViewHelper.getKeyboardType(phoneNumberFieldIsActive), imeAction = ImeAction.Go),
+        keyboardActions = KeyboardActions(onGo = { onSubmit() }),
       )
     }
   }

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -19,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -156,7 +156,7 @@ internal fun AuthStartViewImpl(
       ) {
         if (authViewHelper.showIdentifierField) {
           val onSubmit: () -> Unit = {
-            if (isContinueEnabled) {
+            if (isContinueEnabled && state !is AuthStartViewModel.AuthState.Loading) {
               if (authState.mode != AuthMode.SignUp) {
                 storeIdentifierType(
                   authState = authState,
@@ -285,7 +285,10 @@ private fun AuthInputField(
         onValueChange = onIdentifierChange,
         label = authViewHelper.emailOrUsernamePlaceholder(),
         keyboardOptions =
-          KeyboardOptions(keyboardType = authViewHelper.getKeyboardType(phoneNumberFieldIsActive), imeAction = ImeAction.Go),
+          KeyboardOptions(
+            keyboardType = authViewHelper.getKeyboardType(phoneNumberFieldIsActive),
+            imeAction = ImeAction.Go,
+          ),
         keyboardActions = KeyboardActions(onGo = { onSubmit() }),
       )
     }

--- a/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -42,6 +43,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentType
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -111,6 +113,8 @@ fun ClerkPhoneNumberField(
   modifier: Modifier = Modifier,
   errorText: String? = null,
   onValueChange: (String) -> Unit,
+  imeAction: ImeAction = ImeAction.Default,
+  keyboardActions: KeyboardActions = KeyboardActions.Default,
   clerkTheme: ClerkTheme? = null,
 ) {
   ClerkPhoneNumberFieldImpl(
@@ -118,6 +122,8 @@ fun ClerkPhoneNumberField(
     errorText = errorText,
     value = value,
     onValueChange = onValueChange,
+    imeAction = imeAction,
+    keyboardActions = keyboardActions,
     clerkTheme = clerkTheme,
   )
 }
@@ -192,6 +198,8 @@ internal fun ClerkPhoneNumberFieldImpl(
   value: String,
   modifier: Modifier = Modifier,
   errorText: String? = null,
+  imeAction: ImeAction = ImeAction.Default,
+  keyboardActions: KeyboardActions = KeyboardActions.Default,
   clerkTheme: ClerkTheme? = null,
 ) {
   val defaultCountry = PhoneInputUtils.getDefaultCountry()
@@ -252,6 +260,8 @@ internal fun ClerkPhoneNumberFieldImpl(
           onValueChange = onValueChange,
           errorText = errorText,
           countryCode = selectedCountry.countryShortName,
+          imeAction = imeAction,
+          keyboardActions = keyboardActions,
         )
       }
     }
@@ -280,6 +290,8 @@ private fun PhoneNumberInput(
   onValueChange: (String) -> Unit,
   countryCode: String,
   errorText: String? = null,
+  imeAction: ImeAction = ImeAction.Default,
+  keyboardActions: KeyboardActions = KeyboardActions.Default,
 ) {
 
   val interactionSource = remember { MutableInteractionSource() }
@@ -323,7 +335,8 @@ private fun PhoneNumberInput(
         )
       },
       shape = ClerkMaterialTheme.shape,
-      keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+      keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone, imeAction = imeAction),
+      keyboardActions = keyboardActions,
       singleLine = true,
     )
     errorText?.let { errorText ->

--- a/source/ui/src/main/java/com/clerk/ui/signin/backupcode/SigninFactorTwoBackupCodeView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/backupcode/SigninFactorTwoBackupCodeView.kt
@@ -92,9 +92,15 @@ private fun SignInFactorTwoBackupCodeViewImpl(
       onValueChange = { authState.signInBackupCode = it },
       label = stringResource(R.string.backup_code),
       keyboardOptions = KeyboardOptions(imeAction = ImeAction.Go),
-      keyboardActions = KeyboardActions(onGo = {
-        if (authState.signInBackupCode.isNotEmpty()) viewModel.submit(authState.signInBackupCode)
-      }),
+      keyboardActions =
+        KeyboardActions(
+          onGo = {
+            if (
+              authState.signInBackupCode.isNotEmpty() && state !is AuthenticationViewState.Loading
+            )
+              viewModel.submit(authState.signInBackupCode)
+          }
+        ),
     )
     Spacers.Vertical.Spacer24()
     ClerkButton(

--- a/source/ui/src/main/java/com/clerk/ui/signin/backupcode/SigninFactorTwoBackupCodeView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/backupcode/SigninFactorTwoBackupCodeView.kt
@@ -1,12 +1,15 @@
 package com.clerk.ui.signin.backupcode
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -88,6 +91,10 @@ private fun SignInFactorTwoBackupCodeViewImpl(
       value = authState.signInBackupCode,
       onValueChange = { authState.signInBackupCode = it },
       label = stringResource(R.string.backup_code),
+      keyboardOptions = KeyboardOptions(imeAction = ImeAction.Go),
+      keyboardActions = KeyboardActions(onGo = {
+        if (authState.signInBackupCode.isNotEmpty()) viewModel.submit(authState.signInBackupCode)
+      }),
     )
     Spacers.Vertical.Spacer24()
     ClerkButton(

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
@@ -117,7 +117,7 @@ private fun SignInSetNewPasswordViewImpl(
       authState.signInConfirmNewPassword.isNotBlank() &&
       passwordsMatch
   val onResetPassword = {
-    if (passwordsMatch && state !is AuthenticationViewState.Loading) {
+    if (isButtonEnabled && state !is AuthenticationViewState.Loading) {
       when (mode) {
         ResetPasswordMode.SIGN_IN ->
           viewModel.setNewPassword(authState.signInNewPassword, signOutOtherDevices)

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
@@ -117,7 +117,7 @@ private fun SignInSetNewPasswordViewImpl(
       authState.signInConfirmNewPassword.isNotBlank() &&
       passwordsMatch
   val onResetPassword = {
-    if (passwordsMatch) {
+    if (passwordsMatch && state !is AuthenticationViewState.Loading) {
       when (mode) {
         ResetPasswordMode.SIGN_IN ->
           viewModel.setNewPassword(authState.signInNewPassword, signOutOtherDevices)
@@ -169,7 +169,12 @@ private fun PasswordInputs(authState: AuthState, passwordsMatch: Boolean, onSubm
     visualTransformation = PasswordVisualTransformation(),
     label = stringResource(R.string.new_password),
     inputContentType = ContentType.Password,
-    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Next, autoCorrectEnabled = false),
+    keyboardOptions =
+      KeyboardOptions(
+        keyboardType = KeyboardType.Password,
+        imeAction = ImeAction.Next,
+        autoCorrectEnabled = false,
+      ),
     keyboardActions = KeyboardActions(onNext = { confirmFocusRequester.requestFocus() }),
   )
   Spacers.Vertical.Spacer24()
@@ -182,7 +187,12 @@ private fun PasswordInputs(authState: AuthState, passwordsMatch: Boolean, onSubm
     inputContentType = ContentType.Password,
     isError = showPasswordMismatchError,
     supportingText = if (showPasswordMismatchError) "Passwords don't match" else null,
-    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Done, autoCorrectEnabled = false),
+    keyboardOptions =
+      KeyboardOptions(
+        keyboardType = KeyboardType.Password,
+        imeAction = ImeAction.Done,
+        autoCorrectEnabled = false,
+      ),
     keyboardActions = KeyboardActions(onDone = { onSubmit() }),
   )
 }

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -18,7 +20,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -130,7 +136,7 @@ private fun SignInSetNewPasswordViewImpl(
     hasBackButton = mode == ResetPasswordMode.SIGN_IN,
     snackbarHostState = snackbarHostState,
   ) {
-    PasswordInputs(authState, passwordsMatch)
+    PasswordInputs(authState, passwordsMatch, onSubmit = onResetPassword)
     Spacers.Vertical.Spacer24()
     SignOutOfOtherDevicesRow(signOutOtherDevices, onCheckChange = { signOutOtherDevices = it })
     Spacers.Vertical.Spacer24()
@@ -154,17 +160,21 @@ private fun ResetPasswordMode.subtitle(): String? {
 }
 
 @Composable
-private fun PasswordInputs(authState: AuthState, passwordsMatch: Boolean) {
+private fun PasswordInputs(authState: AuthState, passwordsMatch: Boolean, onSubmit: () -> Unit) {
   val showPasswordMismatchError = authState.signInConfirmNewPassword.isNotBlank() && !passwordsMatch
+  val confirmFocusRequester = remember { FocusRequester() }
   ClerkTextField(
     value = authState.signInNewPassword,
     onValueChange = { authState.signInNewPassword = it },
     visualTransformation = PasswordVisualTransformation(),
     label = stringResource(R.string.new_password),
     inputContentType = ContentType.Password,
+    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Next, autoCorrectEnabled = false),
+    keyboardActions = KeyboardActions(onNext = { confirmFocusRequester.requestFocus() }),
   )
   Spacers.Vertical.Spacer24()
   ClerkTextField(
+    modifier = Modifier.focusRequester(confirmFocusRequester),
     value = authState.signInConfirmNewPassword,
     onValueChange = { authState.signInConfirmNewPassword = it },
     label = stringResource(R.string.confirm_password),
@@ -172,6 +182,8 @@ private fun PasswordInputs(authState: AuthState, passwordsMatch: Boolean) {
     inputContentType = ContentType.Password,
     isError = showPasswordMismatchError,
     supportingText = if (showPasswordMismatchError) "Passwords don't match" else null,
+    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Done, autoCorrectEnabled = false),
+    keyboardActions = KeyboardActions(onDone = { onSubmit() }),
   )
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/set/SignInFactorOnePasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/set/SignInFactorOnePasswordView.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
@@ -18,6 +19,7 @@ import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -108,7 +110,10 @@ private fun SignInFactorOnePasswordViewImpl(
       visualTransformation = PasswordVisualTransformation(),
       inputContentType = ContentType.Password,
       keyboardOptions =
-        KeyboardOptions(autoCorrectEnabled = false, keyboardType = KeyboardType.Password),
+        KeyboardOptions(autoCorrectEnabled = false, keyboardType = KeyboardType.Password, imeAction = ImeAction.Go),
+      keyboardActions = KeyboardActions(onGo = {
+        if (authState.signInPassword.isNotEmpty()) viewModel.submitPassword(authState.signInPassword)
+      }),
     )
     Spacer(Modifier.height(dp24))
     ClerkButton(

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/set/SignInFactorOnePasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/set/SignInFactorOnePasswordView.kt
@@ -34,6 +34,7 @@ import com.clerk.ui.R
 import com.clerk.ui.auth.AuthDestination
 import com.clerk.ui.auth.AuthState
 import com.clerk.ui.auth.AuthStateEffects
+import com.clerk.ui.auth.AuthenticationViewState
 import com.clerk.ui.auth.PreviewAuthStateProvider
 import com.clerk.ui.core.button.standard.ClerkButton
 import com.clerk.ui.core.button.standard.ClerkButtonDefaults
@@ -110,10 +111,18 @@ private fun SignInFactorOnePasswordViewImpl(
       visualTransformation = PasswordVisualTransformation(),
       inputContentType = ContentType.Password,
       keyboardOptions =
-        KeyboardOptions(autoCorrectEnabled = false, keyboardType = KeyboardType.Password, imeAction = ImeAction.Go),
-      keyboardActions = KeyboardActions(onGo = {
-        if (authState.signInPassword.isNotEmpty()) viewModel.submitPassword(authState.signInPassword)
-      }),
+        KeyboardOptions(
+          autoCorrectEnabled = false,
+          keyboardType = KeyboardType.Password,
+          imeAction = ImeAction.Go,
+        ),
+      keyboardActions =
+        KeyboardActions(
+          onGo = {
+            if (authState.signInPassword.isNotEmpty() && state !is AuthenticationViewState.Loading)
+              viewModel.submitPassword(authState.signInPassword)
+          }
+        ),
     )
     Spacer(Modifier.height(dp24))
     ClerkButton(
@@ -121,6 +130,7 @@ private fun SignInFactorOnePasswordViewImpl(
       onClick = { viewModel.submitPassword(password = authState.signInPassword) },
       text = stringResource(R.string.continue_text),
       isEnabled = authState.signInPassword.isNotEmpty(),
+      isLoading = state is AuthenticationViewState.Loading,
       icons =
         ClerkButtonDefaults.icons(
           trailingIcon = R.drawable.ic_triangle_right,

--- a/source/ui/src/main/java/com/clerk/ui/signup/collectfield/SignUpCollectFieldView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/collectfield/SignUpCollectFieldView.kt
@@ -94,7 +94,7 @@ private fun SignUpCollectFieldViewImpl(
       horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       val onSubmit: () -> Unit = {
-        if (continueIsEnabled) {
+        if (continueIsEnabled && state !is AuthenticationViewState.Loading) {
           viewModel.updateSignUp(
             collectField,
             email = authState.signUpEmail,
@@ -164,7 +164,8 @@ private fun InputField(
           onValueChange = onEmailChange,
           label = collectFieldHelper.label(collectField),
           inputContentType = ContentType.EmailAddress,
-          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Go),
+          keyboardOptions =
+            KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Go),
           keyboardActions = KeyboardActions(onGo = { onSubmit() }),
         )
       }
@@ -176,7 +177,12 @@ private fun InputField(
           label = collectFieldHelper.label(collectField),
           inputContentType = ContentType.Password,
           visualTransformation = PasswordVisualTransformation(),
-          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Go, autoCorrectEnabled = false),
+          keyboardOptions =
+            KeyboardOptions(
+              keyboardType = KeyboardType.Password,
+              imeAction = ImeAction.Go,
+              autoCorrectEnabled = false,
+            ),
           keyboardActions = KeyboardActions(onGo = { onSubmit() }),
         )
       }

--- a/source/ui/src/main/java/com/clerk/ui/signup/collectfield/SignUpCollectFieldView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/collectfield/SignUpCollectFieldView.kt
@@ -3,6 +3,8 @@ package com.clerk.ui.signup.collectfield
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -12,6 +14,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -89,6 +93,18 @@ private fun SignUpCollectFieldViewImpl(
       verticalArrangement = Arrangement.spacedBy(dp24, alignment = Alignment.CenterVertically),
       horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+      val onSubmit: () -> Unit = {
+        if (continueIsEnabled) {
+          viewModel.updateSignUp(
+            collectField,
+            email = authState.signUpEmail,
+            password = authState.signUpPassword,
+            phone = authState.signUpPhoneNumber,
+            username = authState.signUpUsername,
+          )
+        }
+      }
+
       InputField(
         collectField = collectField,
         collectFieldHelper = collectFieldHelper,
@@ -100,19 +116,12 @@ private fun SignUpCollectFieldViewImpl(
         onPhoneChange = { authState.signUpPhoneNumber = it },
         username = authState.signUpUsername,
         onUsernameChange = { authState.signUpUsername = it },
+        onSubmit = onSubmit,
       )
 
       ClerkButton(
         text = stringResource(R.string.continue_text),
-        onClick = {
-          viewModel.updateSignUp(
-            collectField,
-            email = authState.signUpEmail,
-            password = authState.signUpPassword,
-            phone = authState.signUpPhoneNumber,
-            username = authState.signUpUsername,
-          )
-        },
+        onClick = onSubmit,
         modifier = Modifier.fillMaxWidth(),
         isEnabled = continueIsEnabled,
         isLoading = state is AuthenticationViewState.Loading,
@@ -145,6 +154,7 @@ private fun InputField(
   onPhoneChange: (String) -> Unit,
   username: String,
   onUsernameChange: (String) -> Unit,
+  onSubmit: () -> Unit,
 ) {
   Column(modifier = Modifier.fillMaxWidth()) {
     when (collectField) {
@@ -154,6 +164,8 @@ private fun InputField(
           onValueChange = onEmailChange,
           label = collectFieldHelper.label(collectField),
           inputContentType = ContentType.EmailAddress,
+          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Go),
+          keyboardActions = KeyboardActions(onGo = { onSubmit() }),
         )
       }
 
@@ -164,11 +176,18 @@ private fun InputField(
           label = collectFieldHelper.label(collectField),
           inputContentType = ContentType.Password,
           visualTransformation = PasswordVisualTransformation(),
+          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Go, autoCorrectEnabled = false),
+          keyboardActions = KeyboardActions(onGo = { onSubmit() }),
         )
       }
 
       CollectField.Phone -> {
-        ClerkPhoneNumberField(value = phone, onValueChange = onPhoneChange)
+        ClerkPhoneNumberField(
+          value = phone,
+          onValueChange = onPhoneChange,
+          imeAction = ImeAction.Go,
+          keyboardActions = KeyboardActions(onGo = { onSubmit() }),
+        )
       }
 
       CollectField.Username -> {
@@ -177,6 +196,8 @@ private fun InputField(
           onValueChange = onUsernameChange,
           label = collectFieldHelper.label(collectField),
           inputContentType = ContentType.Username,
+          keyboardOptions = KeyboardOptions(imeAction = ImeAction.Go),
+          keyboardActions = KeyboardActions(onGo = { onSubmit() }),
         )
       }
     }

--- a/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -13,7 +15,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -141,6 +146,15 @@ private fun SignUpCompleteProfileImpl(
         onFirstChange = { authState.signUpFirstName = it },
         onLastChange = { authState.signUpLastName = it },
         onFocusChange = { helper.focusTo(it) },
+        onSubmit = {
+          if (isSubmitEnabled) {
+            viewModel.updateSignUp(
+              firstName = authState.signUpFirstName.takeIf { firstEnabled },
+              lastName = authState.signUpLastName.takeIf { lastEnabled },
+              legalAccepted = if (showLegalConsent) authState.signUpLegalAccepted else null,
+            )
+          }
+        },
       )
 
       if (showLegalConsent) {
@@ -178,7 +192,20 @@ private fun InputRow(
   onFirstChange: (String) -> Unit,
   onLastChange: (String) -> Unit,
   onFocusChange: (CompleteProfileField) -> Unit = {},
+  onSubmit: () -> Unit = {},
 ) {
+  val bothEnabled = firstEnabled && lastEnabled
+  val lastNameFocusRequester = remember { FocusRequester() }
+
+  // When both fields are shown, first→Next moves focus; last→Done submits.
+  // When only one field is shown, Done submits directly.
+  val firstNameImeAction = if (bothEnabled) ImeAction.Next else ImeAction.Done
+  val firstNameKeyboardActions = if (bothEnabled) {
+    KeyboardActions(onNext = { lastNameFocusRequester.requestFocus() })
+  } else {
+    KeyboardActions(onDone = { onSubmit() })
+  }
+
   BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
     val enabledCount = (if (firstEnabled) 1 else 0) + (if (lastEnabled) 1 else 0)
     val spacing = dp12
@@ -199,16 +226,20 @@ private fun InputRow(
             onValueChange = onFirstChange,
             label = stringResource(R.string.first_name),
             onFocusChange = { onFocusChange(CompleteProfileField.FirstName) },
+            keyboardOptions = KeyboardOptions(imeAction = firstNameImeAction),
+            keyboardActions = firstNameKeyboardActions,
           )
         }
         if (lastEnabled) {
           ClerkTextField(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().focusRequester(lastNameFocusRequester),
             value = last,
             inputContentType = ContentType.PersonLastName,
             onValueChange = onLastChange,
             label = stringResource(R.string.last_name),
             onFocusChange = { onFocusChange(CompleteProfileField.LastName) },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { onSubmit() }),
           )
         }
       }
@@ -226,16 +257,20 @@ private fun InputRow(
             onValueChange = onFirstChange,
             label = stringResource(R.string.first_name),
             onFocusChange = { onFocusChange(CompleteProfileField.FirstName) },
+            keyboardOptions = KeyboardOptions(imeAction = firstNameImeAction),
+            keyboardActions = firstNameKeyboardActions,
           )
         }
         if (lastEnabled) {
           ClerkTextField(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f).focusRequester(lastNameFocusRequester),
             value = last,
             inputContentType = ContentType.PersonLastName,
             onValueChange = onLastChange,
             label = stringResource(R.string.last_name),
             onFocusChange = { onFocusChange(CompleteProfileField.LastName) },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { onSubmit() }),
           )
         }
       }

--- a/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
@@ -138,6 +138,16 @@ private fun SignUpCompleteProfileImpl(
       verticalArrangement = Arrangement.spacedBy(dp24, alignment = Alignment.CenterVertically),
       horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+      val onSubmit: () -> Unit = {
+        if (isSubmitEnabled && state !is AuthenticationViewState.Loading) {
+          viewModel.updateSignUp(
+            firstName = authState.signUpFirstName.takeIf { firstEnabled },
+            lastName = authState.signUpLastName.takeIf { lastEnabled },
+            legalAccepted = if (showLegalConsent) authState.signUpLegalAccepted else null,
+          )
+        }
+      }
+
       InputRow(
         firstEnabled = firstEnabled,
         lastEnabled = lastEnabled,
@@ -146,15 +156,7 @@ private fun SignUpCompleteProfileImpl(
         onFirstChange = { authState.signUpFirstName = it },
         onLastChange = { authState.signUpLastName = it },
         onFocusChange = { helper.focusTo(it) },
-        onSubmit = {
-          if (isSubmitEnabled && state !is AuthenticationViewState.Loading) {
-            viewModel.updateSignUp(
-              firstName = authState.signUpFirstName.takeIf { firstEnabled },
-              lastName = authState.signUpLastName.takeIf { lastEnabled },
-              legalAccepted = if (showLegalConsent) authState.signUpLegalAccepted else null,
-            )
-          }
-        },
+        onSubmit = onSubmit,
       )
 
       if (showLegalConsent) {
@@ -171,13 +173,7 @@ private fun SignUpCompleteProfileImpl(
         isEnabled = isSubmitEnabled,
         text = stringResource(helper.submitLabelRes()),
         isLoading = state is AuthenticationViewState.Loading,
-        onClick = {
-          viewModel.updateSignUp(
-            firstName = authState.signUpFirstName.takeIf { firstEnabled },
-            lastName = authState.signUpLastName.takeIf { lastEnabled },
-            legalAccepted = if (showLegalConsent) authState.signUpLegalAccepted else null,
-          )
-        },
+        onClick = onSubmit,
       )
     }
   }

--- a/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
@@ -147,7 +147,7 @@ private fun SignUpCompleteProfileImpl(
         onLastChange = { authState.signUpLastName = it },
         onFocusChange = { helper.focusTo(it) },
         onSubmit = {
-          if (isSubmitEnabled) {
+          if (isSubmitEnabled && state !is AuthenticationViewState.Loading) {
             viewModel.updateSignUp(
               firstName = authState.signUpFirstName.takeIf { firstEnabled },
               lastName = authState.signUpLastName.takeIf { lastEnabled },
@@ -200,11 +200,12 @@ private fun InputRow(
   // When both fields are shown, first→Next moves focus; last→Done submits.
   // When only one field is shown, Done submits directly.
   val firstNameImeAction = if (bothEnabled) ImeAction.Next else ImeAction.Done
-  val firstNameKeyboardActions = if (bothEnabled) {
-    KeyboardActions(onNext = { lastNameFocusRequester.requestFocus() })
-  } else {
-    KeyboardActions(onDone = { onSubmit() })
-  }
+  val firstNameKeyboardActions =
+    if (bothEnabled) {
+      KeyboardActions(onNext = { lastNameFocusRequester.requestFocus() })
+    } else {
+      KeyboardActions(onDone = { onSubmit() })
+    }
 
   BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
     val enabledCount = (if (firstEnabled) 1 else 0) + (if (lastEnabled) 1 else 0)


### PR DESCRIPTION
## Summary of changes

Closes #670

---

Auth input fields across the prebuilt UI used `ImeAction.Default`, which inserts a newline when the user presses Enter/Return on the soft keyboard instead of submitting the form. On single-line fields this is especially bad — the newline is invisible, the field appears to clear, and the user gets repeated "Identifier is invalid" errors. The state also persists across app restarts via `rememberSaveable`, making it hard to recover from.

This PR sets appropriate IME actions and `KeyboardActions` submit handlers on all affected single-input auth screens:

| Screen | Fields | Action |
|--------|--------|--------|
| `AuthStartView` | Email/username, phone | `Go` → submits |
| `SignInFactorOnePasswordView` | Password | `Go` → submits |
| `SignUpCollectFieldView` | Email, password, phone, username | `Go` → submits |
| `SignInSetNewPasswordView` | New password → confirm password | `Next` → moves focus, `Done` → submits |
| `SignInFactorTwoBackupCodeView` | Backup code | `Go` → submits |
| `SignUpCompleteProfileView` | First name → last name | `Next` → moves focus, `Done` → submits |

`ClerkPhoneNumberField` was updated to accept `imeAction` and `keyboardActions` parameters since it previously hardcoded `KeyboardOptions(keyboardType = KeyboardType.Phone)` with no way to override.

OTP/code fields (`ClerkCodeInputField`) already used `ImeAction.Done` correctly and are unchanged.

## Follow-up

The same fix should be applied to the UserProfile and OrganizationProfile screens, which have the same issue, but I personally haven't really used them so didn't feel comfortable including them in the PR without testing. I could add them on request though.

- `UserProfileNewPasswordView` — `ImeAction.Next`/`Done` are already set but missing `FocusRequester` and `KeyboardActions` to actually move focus and submit
- `UserProfileUpdateProfileView` — username, first name, last name fields have no IME actions
- `OrganizationProfileFormView` — org name + slug fields have no IME actions

## Demo

I tested the change on an Android emulator:


https://github.com/user-attachments/assets/fdd20bc7-3a25-4ad6-b05a-ed563d21123f

