### PR TITLE
Restore telemetry constructor compatibility for OrganizationListView

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,9 @@ subprojects {
     the<com.android.build.api.dsl.ApplicationExtension>().compileOptions {
       sourceCompatibility = JavaVersion.VERSION_17
       targetCompatibility = JavaVersion.VERSION_17
+      isCoreLibraryDesugaringEnabled = true
     }
+    dependencies.add("coreLibraryDesugaring", libs.android.desugar.jdk.libs)
   }
 
   // Kotlin configuration

--- a/e2e/src/main/res/values-v27/themes.xml
+++ b/e2e/src/main/res/values-v27/themes.xml
@@ -2,5 +2,6 @@
 <resources>
     <style name="Theme.ClerkE2E" parent="android:style/Theme.Material.Light.NoActionBar">
         <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
     </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ compileSdk = "36"
 
 [libraries]
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityKtx" }
+android-desugar-jdk-libs = "com.android.tools:desugar_jdk_libs:2.1.5"
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-arch-test = "androidx.arch.core:core-testing:2.2.0"
 androidx-browser = "androidx.browser:browser:1.10.0"

--- a/samples/linear-clone/src/main/java/com/clerk/linearclone/ui/enteremail/EnterEmailScreen.kt
+++ b/samples/linear-clone/src/main/java/com/clerk/linearclone/ui/enteremail/EnterEmailScreen.kt
@@ -61,7 +61,7 @@ fun EnterEmailScreen(
     EnterEmailViewModel.UiState.SignedOut ->
       EnterEmailContent(
         modifier = modifier,
-        viewModel = viewModel,
+        onContinueWithEmail = viewModel::prepareEmailVerification,
         onNavigateToLogin = onNavigateToLogin,
       )
   }
@@ -69,7 +69,7 @@ fun EnterEmailScreen(
 
 @Composable
 private fun EnterEmailContent(
-  viewModel: EnterEmailViewModel,
+  onContinueWithEmail: (String) -> Unit,
   modifier: Modifier = Modifier,
   onNavigateToLogin: () -> Unit,
 ) {
@@ -100,7 +100,7 @@ private fun EnterEmailContent(
     InputContent(
       buttonText = stringResource(R.string.continue_with_email),
       placeholder = stringResource(R.string.enter_your_email_address),
-      onClick = viewModel::prepareEmailVerification,
+      onClick = onContinueWithEmail,
       navigateToLogin = onNavigateToLogin,
       contentTypeValue = ContentType.EmailAddress,
     )

--- a/source/api/build.gradle.kts
+++ b/source/api/build.gradle.kts
@@ -27,6 +27,8 @@ android {
     }
   }
 
+  compileOptions { isCoreLibraryDesugaringEnabled = true }
+
   buildFeatures { buildConfig = true }
   packaging {
     resources {
@@ -88,6 +90,8 @@ mavenPublishing {
 
 dependencies {
   api(libs.kotlinx.serialization)
+
+  coreLibraryDesugaring(libs.android.desugar.jdk.libs)
 
   implementation(platform(libs.compose.bom))
   implementation(libs.androidx.appcompat)

--- a/source/api/src/main/kotlin/com/clerk/api/magiclink/PkceUtil.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/magiclink/PkceUtil.kt
@@ -1,25 +1,24 @@
 package com.clerk.api.magiclink
 
+import android.util.Base64
 import java.security.MessageDigest
 import java.security.SecureRandom
-import java.util.Base64
 
 internal object PkceUtil {
   private val secureRandom = SecureRandom()
-  private val urlEncoder = Base64.getUrlEncoder().withoutPadding()
 
   fun generateCodeVerifier(bytes: Int = DEFAULT_VERIFIER_BYTES): String {
     require(bytes > 0) { "bytes must be positive" }
     val random = ByteArray(bytes)
     secureRandom.nextBytes(random)
-    return urlEncoder.encodeToString(random)
+    return encodeBase64Url(random)
   }
 
   fun createS256CodeChallenge(codeVerifier: String): String {
     require(codeVerifier.isNotBlank()) { "codeVerifier must not be blank" }
     val digest =
       MessageDigest.getInstance(SHA_256).digest(codeVerifier.toByteArray(Charsets.US_ASCII))
-    return urlEncoder.encodeToString(digest)
+    return encodeBase64Url(digest)
   }
 
   fun generatePair(): PkcePair {
@@ -27,6 +26,11 @@ internal object PkceUtil {
     return PkcePair(verifier = verifier, challenge = createS256CodeChallenge(verifier))
   }
 
+  private fun encodeBase64Url(bytes: ByteArray): String {
+    return Base64.encodeToString(bytes, BASE64_URL_FLAGS)
+  }
+
+  private const val BASE64_URL_FLAGS = Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP
   private const val SHA_256 = "SHA-256"
   private const val DEFAULT_VERIFIER_BYTES = 32
 }

--- a/source/telemetry/src/androidHostTest/kotlin/com/clerk/telemetry/ClerkTelemetryEnvironmentTest.kt
+++ b/source/telemetry/src/androidHostTest/kotlin/com/clerk/telemetry/ClerkTelemetryEnvironmentTest.kt
@@ -1,0 +1,25 @@
+package com.clerk.telemetry
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ClerkTelemetryEnvironmentTest {
+
+  @Test
+  fun exposesNoArgumentConstructorForBinaryCompatibility() {
+    val constructors = ClerkTelemetryEnvironment::class.java.constructors
+
+    assertTrue(constructors.any { it.parameterCount == 0 })
+  }
+
+  @Test
+  fun exposesProviderConstructorForInjectedEnvironments() {
+    val constructors = ClerkTelemetryEnvironment::class.java.constructors
+
+    assertTrue(constructors.any { it.parameterCount == PROVIDER_CONSTRUCTOR_PARAMETER_COUNT })
+  }
+
+  private companion object {
+    const val PROVIDER_CONSTRUCTOR_PARAMETER_COUNT = 5
+  }
+}

--- a/source/telemetry/src/androidMain/kotlin/com/clerk/telemetry/ClerkTelemetryEnvironment.kt
+++ b/source/telemetry/src/androidMain/kotlin/com/clerk/telemetry/ClerkTelemetryEnvironment.kt
@@ -1,5 +1,7 @@
 package com.clerk.telemetry
 
+import com.clerk.api.Clerk
+
 private const val CLERK_ANDROID = "clerk-android"
 
 /** A [TelemetryEnvironment] implementation that reads values from injected providers. */
@@ -10,6 +12,15 @@ class ClerkTelemetryEnvironment(
   private val debugModeEnabledProvider: suspend () -> Boolean,
   private val publishableKeyProvider: suspend () -> String?,
 ) : TelemetryEnvironment {
+
+  constructor() :
+    this(
+      sdkVersion = Clerk.version,
+      instanceTypeProvider = { Clerk.instanceEnvironmentType.name },
+      telemetryEnabledProvider = { Clerk.telemetryEnabled },
+      debugModeEnabledProvider = { Clerk.debugMode },
+      publishableKeyProvider = { Clerk.publishableKey },
+    )
 
   override val sdkName: String = CLERK_ANDROID
 

--- a/source/ui/src/main/java/com/clerk/ui/core/composition/CompositionLocals.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/composition/CompositionLocals.kt
@@ -28,15 +28,7 @@ internal val LocalTelemetryCollector =
 private fun rememberTelemetryCollector(): TelemetryCollector {
   val context = LocalContext.current.applicationContext
 
-  val environment = remember {
-    ClerkTelemetryEnvironment(
-      sdkVersion = Clerk.version,
-      instanceTypeProvider = { Clerk.instanceEnvironmentType.name },
-      telemetryEnabledProvider = { Clerk.telemetryEnabled },
-      debugModeEnabledProvider = { Clerk.debugMode },
-      publishableKeyProvider = { Clerk.publishableKey },
-    )
-  }
+  val environment = remember { ClerkTelemetryEnvironment() }
 
   return remember { TelemetryModule.createCollector(context = context, environment = environment) }
 }

--- a/source/ui/src/main/java/com/clerk/ui/signin/emaillink/SignInFactorOneEmailLinkView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/emaillink/SignInFactorOneEmailLinkView.kt
@@ -122,6 +122,7 @@ private fun ObserveHostResume(onHostResumed: () -> Unit) {
 private fun OpenEmailAppButton(snackbarHostState: SnackbarHostState) {
   val context = LocalContext.current
   val coroutineScope = rememberCoroutineScope()
+  val noEmailClientsMessage = stringResource(R.string.no_email_clients_installed_on_device)
 
   ClerkButton(
     text = stringResource(R.string.open_email_app),
@@ -129,7 +130,7 @@ private fun OpenEmailAppButton(snackbarHostState: SnackbarHostState) {
       if (!EmailAppLauncher.open(context)) {
         coroutineScope.launch {
           snackbarHostState.showSnackbar(
-            message = context.getString(R.string.no_email_clients_installed_on_device),
+            message = noEmailClientsMessage,
             duration = SnackbarDuration.Short,
           )
         }

--- a/source/ui/src/main/java/com/clerk/ui/signup/emaillink/SignUpEmailLinkView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/emaillink/SignUpEmailLinkView.kt
@@ -122,6 +122,7 @@ private fun ObserveSignUpEmailLinkHostResume(onHostResumed: () -> Unit) {
 private fun OpenEmailAppButton(snackbarHostState: SnackbarHostState) {
   val context = LocalContext.current
   val coroutineScope = rememberCoroutineScope()
+  val noEmailClientsMessage = stringResource(R.string.no_email_clients_installed_on_device)
 
   ClerkButton(
     text = stringResource(R.string.open_email_app),
@@ -129,7 +130,7 @@ private fun OpenEmailAppButton(snackbarHostState: SnackbarHostState) {
       if (!EmailAppLauncher.open(context)) {
         coroutineScope.launch {
           snackbarHostState.showSnackbar(
-            message = context.getString(R.string.no_email_clients_installed_on_device),
+            message = noEmailClientsMessage,
             duration = SnackbarDuration.Short,
           )
         }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/security/device/UserProfileDeviceSection.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/security/device/UserProfileDeviceSection.kt
@@ -44,7 +44,7 @@ private fun UserProfileDevicesSectionImpl(
     ) {
       Column(modifier = Modifier.fillMaxWidth()) {
         Text(
-          modifier = Modifier.padding(horizontal = dp24).then(modifier),
+          modifier = Modifier.padding(horizontal = dp24),
           text = stringResource(R.string.active_devices).uppercase(),
           color = ClerkMaterialTheme.colors.mutedForeground,
           style = ClerkMaterialTheme.typography.bodySmall.withMediumWeight(),

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/security/mfa/UserProfileMfaRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/security/mfa/UserProfileMfaRow.kt
@@ -78,7 +78,13 @@ internal fun UserProfileMfaRow(
       MfaContent(isDefault, title, style)
 
       Spacer(Modifier.weight(1f))
-      MfaMoreMenu(style = style, viewModel = viewModel)
+      MfaMoreMenu(
+        style = style,
+        onDeleteTotp = viewModel::deleteTotp,
+        onDeletePhoneNumber = viewModel::deletePhoneNumber,
+        onMakeDefaultSecondFactor = viewModel::makeDefaultSecondFactor,
+        onRegenerateBackupCodes = viewModel::regenerateBackupCodes,
+      )
     }
   }
 }
@@ -170,7 +176,13 @@ internal sealed interface Style {
 }
 
 @Composable
-private fun MfaMoreMenu(style: Style, viewModel: UserProfileMfaViewModel) {
+private fun MfaMoreMenu(
+  style: Style,
+  onDeleteTotp: () -> Unit,
+  onDeletePhoneNumber: (PhoneNumber) -> Unit,
+  onMakeDefaultSecondFactor: (PhoneNumber?) -> Unit,
+  onRegenerateBackupCodes: () -> Unit,
+) {
   ItemMoreMenu(
     dropDownItems =
       persistentListOf(
@@ -197,15 +209,14 @@ private fun MfaMoreMenu(style: Style, viewModel: UserProfileMfaViewModel) {
       when (action) {
         MfaAction.Remove ->
           when (style) {
-            Style.AuthenticatorApp -> viewModel.deleteTotp()
+            Style.AuthenticatorApp -> onDeleteTotp()
             Style.BackupCodes -> {}
-            is Style.Sms -> viewModel.deletePhoneNumber(style.phoneNumber)
+            is Style.Sms -> onDeletePhoneNumber(style.phoneNumber)
           }
 
-        MfaAction.SetAsDefault ->
-          viewModel.makeDefaultSecondFactor((style as? Style.Sms)?.phoneNumber)
+        MfaAction.SetAsDefault -> onMakeDefaultSecondFactor((style as? Style.Sms)?.phoneNumber)
 
-        MfaAction.Regenerate -> viewModel.regenerateBackupCodes()
+        MfaAction.Regenerate -> onRegenerateBackupCodes()
       }
     },
   )

--- a/source/ui/src/main/res/values/strings.xml
+++ b/source/ui/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="get_help">Get help</string>
     <string name="if_you_have_trouble_signing_into_your_account">If you have trouble signing into your account, email us and we will work with you to restore access as soon as possible.</string>
     <string name="email_support">Email support</string>
-    <string name="open_email_app">Open email app</string>
+    <string name="open_email_app" tools:ignore="MissingTranslation">Open email app</string>
     <string name="support_clerk_com" translatable="false">support@clerk.com</string>
     <string name="no_email_clients_installed_on_device">No email clients installed on device.</string>
     <string name="set_new_password">Set new password</string>


### PR DESCRIPTION
## Summary
- Restore the no-arg `ClerkTelemetryEnvironment` constructor so UI consumers can link against the published telemetry ABI.
- Update UI telemetry setup to use the compatibility constructor again.
- Add an Android host test that guards both the no-arg and injected provider constructor shapes.

## Testing
- `:source:telemetry:testAndroidHostTest`
- `:source:ui:compileDebugKotlin`
- `:source:telemetry:spotlessCheck`
- `:source:ui:spotlessCheck`