### PR TITLE
Notify Slack on Android SDK releases

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -107,6 +107,75 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Get release metadata
+        id: release_metadata
+        env:
+          EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          EVENT_RELEASE_URL: ${{ github.event.release.html_url }}
+          DISPATCH_RELEASE_TAG_NAME: ${{ needs.create-release.outputs.tag_name }}
+          PUBLISH_API: ${{ github.event.inputs.publish_api }}
+          PUBLISH_UI: ${{ github.event.inputs.publish_ui }}
+          PUBLISH_TELEMETRY: ${{ github.event.inputs.publish_telemetry }}
+        run: |
+          CLERK_API_VERSION=$(awk -F= '/^CLERK_API_VERSION=/{print $2}' gradle.properties | tr -d '[:space:]')
+          CLERK_TELEMETRY_VERSION=$(awk -F= '/^CLERK_TELEMETRY_VERSION=/{print $2}' gradle.properties | tr -d '[:space:]')
+          CLERK_UI_VERSION=$(awk -F= '/^CLERK_UI_VERSION=/{print $2}' gradle.properties | tr -d '[:space:]')
+
+          if [ -z "$CLERK_API_VERSION" ] || [ -z "$CLERK_TELEMETRY_VERSION" ] || [ -z "$CLERK_UI_VERSION" ]; then
+            echo "Failed to read Clerk release versions from gradle.properties"
+            exit 1
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            TAG_NAME="$EVENT_RELEASE_TAG_NAME"
+            RELEASE_URL="$EVENT_RELEASE_URL"
+            TASKS=":source:api:publishAndReleaseToMavenCentral :source:ui:publishAndReleaseToMavenCentral :source:telemetry:publishAndReleaseToMavenCentral"
+            PUBLISHED_MODULES="clerk-android-api $CLERK_API_VERSION, clerk-android-ui $CLERK_UI_VERSION, clerk-android-telemetry $CLERK_TELEMETRY_VERSION"
+          else
+            TAG_NAME="$DISPATCH_RELEASE_TAG_NAME"
+            RELEASE_URL="https://github.com/$GITHUB_REPOSITORY/releases/tag/$TAG_NAME"
+            TASKS=""
+            PUBLISHED_MODULES=""
+
+            if [ "$PUBLISH_API" = "true" ]; then
+              TASKS="$TASKS :source:api:publishMavenPublicationToMavenCentralRepository"
+              PUBLISHED_MODULES="${PUBLISHED_MODULES}clerk-android-api $CLERK_API_VERSION, "
+            fi
+            if [ "$PUBLISH_UI" = "true" ]; then
+              TASKS="$TASKS :source:ui:publishAndReleaseToMavenCentral"
+              PUBLISHED_MODULES="${PUBLISHED_MODULES}clerk-android-ui $CLERK_UI_VERSION, "
+            fi
+            if [ "$PUBLISH_TELEMETRY" = "true" ]; then
+              TASKS="$TASKS :source:telemetry:publishAndReleaseToMavenCentral"
+              PUBLISHED_MODULES="${PUBLISHED_MODULES}clerk-android-telemetry $CLERK_TELEMETRY_VERSION, "
+            fi
+
+            TASKS="${TASKS# }"
+            PUBLISHED_MODULES="${PUBLISHED_MODULES%, }"
+          fi
+
+          if [ -z "$TAG_NAME" ]; then
+            echo "Failed to determine release tag"
+            exit 1
+          fi
+          if [ -z "$RELEASE_URL" ]; then
+            RELEASE_URL="https://github.com/$GITHUB_REPOSITORY/releases/tag/$TAG_NAME"
+          fi
+          if [ -z "$TASKS" ]; then
+            echo "No modules selected for publishing"
+            exit 1
+          fi
+
+          {
+            echo "tag_name=$TAG_NAME"
+            echo "release_url=$RELEASE_URL"
+            echo "tasks=$TASKS"
+            echo "published_modules=$PUBLISHED_MODULES"
+            echo "clerk_api_version=$CLERK_API_VERSION"
+            echo "clerk_ui_version=$CLERK_UI_VERSION"
+            echo "clerk_telemetry_version=$CLERK_TELEMETRY_VERSION"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Publish to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
@@ -115,27 +184,83 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
         run: |
-          TASKS=""
-
-          # For release events, publish all modules. For workflow_dispatch, use the inputs.
-          if [ "${{ github.event_name }}" == "release" ]; then
-            TASKS=":source:api:publishAndReleaseToMavenCentral :source:ui:publishAndReleaseToMavenCentral :source:telemetry:publishAndReleaseToMavenCentral"
-          else
-            if [ "${{ github.event.inputs.publish_api }}" == "true" ]; then
-              TASKS="$TASKS :source:api:publishMavenPublicationToMavenCentralRepository"
-            fi
-            if [ "${{ github.event.inputs.publish_ui }}" == "true" ]; then
-              TASKS="$TASKS :source:ui:publishAndReleaseToMavenCentral"
-            fi
-            if [ "${{ github.event.inputs.publish_telemetry }}" == "true" ]; then
-              TASKS="$TASKS :source:telemetry:publishAndReleaseToMavenCentral"
-            fi
-          fi
-
-          if [ -z "$TASKS" ]; then
-            echo "No modules selected for publishing"
-            exit 1
-          fi
-
+          TASKS="${{ steps.release_metadata.outputs.tasks }}"
           echo "Publishing modules: $TASKS"
           ./gradlew $TASKS
+
+      - name: Notify Slack
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RELEASE_TAG: ${{ steps.release_metadata.outputs.tag_name }}
+          RELEASE_URL: ${{ steps.release_metadata.outputs.release_url }}
+          PUBLISHED_MODULES: ${{ steps.release_metadata.outputs.published_modules }}
+          CLERK_API_VERSION: ${{ steps.release_metadata.outputs.clerk_api_version }}
+          CLERK_UI_VERSION: ${{ steps.release_metadata.outputs.clerk_ui_version }}
+          CLERK_TELEMETRY_VERSION: ${{ steps.release_metadata.outputs.clerk_telemetry_version }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::warning::SLACK_WEBHOOK_URL is not configured; skipping Slack notification"
+            exit 0
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg tag "$RELEASE_TAG" \
+            --arg release_url "$RELEASE_URL" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg published_modules "$PUBLISHED_MODULES" \
+            --arg api_version "$CLERK_API_VERSION" \
+            --arg ui_version "$CLERK_UI_VERSION" \
+            --arg telemetry_version "$CLERK_TELEMETRY_VERSION" \
+            '{
+              text: "Clerk Android SDK \($tag) has been released",
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: "*Clerk Android SDK \($tag) has been released*"
+                  }
+                },
+                {
+                  type: "section",
+                  fields: [
+                    {
+                      type: "mrkdwn",
+                      text: "*Published modules:*\n\($published_modules)"
+                    },
+                    {
+                      type: "mrkdwn",
+                      text: "*Repository:*\n\($repository)"
+                    },
+                    {
+                      type: "mrkdwn",
+                      text: "*clerk-android-api:*\n\($api_version)"
+                    },
+                    {
+                      type: "mrkdwn",
+                      text: "*clerk-android-ui:*\n\($ui_version)"
+                    },
+                    {
+                      type: "mrkdwn",
+                      text: "*clerk-android-telemetry:*\n\($telemetry_version)"
+                    }
+                  ]
+                },
+                {
+                  type: "context",
+                  elements: [
+                    {
+                      type: "mrkdwn",
+                      text: "<\($release_url)|View the GitHub release>"
+                    }
+                  ]
+                }
+              ]
+            }')
+
+          curl --fail-with-body \
+            --request POST \
+            --header "Content-type: application/json" \
+            --data "$PAYLOAD" \
+            "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Summary
- Update the manual release workflow to compute release metadata once and reuse it for publishing and notifications.
- Post a Slack message after a successful Android SDK release publish, using `SLACK_WEBHOOK_URL` from GitHub Actions secrets.
- Include the release tag, release URL, module versions, and published modules in the Slack payload.

## Testing
- YAML parsing and shell syntax checks passed for the updated workflow.
- Simulated the metadata step for both `release` and `workflow_dispatch` paths to verify task selection and release fields.
- Verified the workflow logic without running a live release.