### PR TITLE
Fix forgot-password email code routing

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -270,7 +270,7 @@ private fun authEntryProvider(backStack: NavBackStack<NavKey>, options: AuthNavO
     }
     entry<AuthDestination.SignInForgotPassword> {
       SignInFactorOneForgotPasswordView(
-        onClickFactor = { backStack.removeLastOrNull() },
+        onClickFactor = { navigateToForgotPasswordFactor(backStack, it) },
         onAuthComplete = options.onAuthComplete,
       )
     }
@@ -314,6 +314,10 @@ internal fun shouldRouteToPendingSessionTask(taskKey: SessionTaskKey?, top: NavK
   return taskKey != null &&
     destination != null &&
     !top.satisfiesPendingSessionTask(taskKey = taskKey, destination = destination)
+}
+
+internal fun navigateToForgotPasswordFactor(backStack: NavBackStack<NavKey>, factor: Factor) {
+  backStack.add(AuthDestination.SignInFactorOne(factor = factor))
 }
 
 private fun NavKey?.satisfiesPendingSessionTask(

--- a/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorOneView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorOneView.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.clerk.api.Clerk
 import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.network.model.factor.isResetFactor
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signin.startingFirstFactor
 import com.clerk.api.ui.ClerkTheme
@@ -45,6 +46,8 @@ fun SignInFactorOneView(
 }
 
 internal fun resolveFirstFactor(fallback: Factor): Factor {
+  if (fallback.isResetFactor()) return fallback
+
   val currentSignIn = Clerk.auth.currentSignIn
   val supportedFactors = currentSignIn?.supportedFirstFactors.orEmpty()
   val hasSignInContext = currentSignIn != null && supportedFactors.isNotEmpty()
@@ -67,8 +70,8 @@ internal fun resolveFirstFactor(fallback: Factor): Factor {
     fallback
   } else {
     emailLinkFactor
-      ?: preparedFactor
-      ?: if (fallbackIsSupported) fallback else currentSignIn.startingFirstFactor ?: fallback
+      ?: if (fallbackIsSupported) fallback else preparedFactor ?: currentSignIn.startingFirstFactor
+        ?: fallback
   }
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorOneView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorOneView.kt
@@ -70,8 +70,8 @@ internal fun resolveFirstFactor(fallback: Factor): Factor {
     fallback
   } else {
     emailLinkFactor
-      ?: if (fallbackIsSupported) fallback else preparedFactor ?: currentSignIn.startingFirstFactor
-        ?: fallback
+      ?: if (fallbackIsSupported) fallback
+      else preparedFactor ?: currentSignIn.startingFirstFactor ?: fallback
   }
 }
 

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewForceMfaRoutingTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewForceMfaRoutingTest.kt
@@ -1,7 +1,11 @@
 package com.clerk.ui.auth
 
+import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
+import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.session.SessionTaskKey
+import com.clerk.ui.core.common.StrategyKeys
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -84,5 +88,24 @@ class AuthViewForceMfaRoutingTest {
   @Test
   fun `regular auth route is not a session task destination`() {
     assertFalse(AuthDestination.SignInGetHelp.isSessionTaskDestination())
+  }
+
+  @Test
+  fun `forgot password factor selection pushes the selected first factor`() {
+    val passwordFactor = Factor(strategy = StrategyKeys.PASSWORD)
+    val emailCodeFactor =
+      Factor(
+        strategy = StrategyKeys.EMAIL_CODE,
+        emailAddressId = "email_123",
+        safeIdentifier = "sam@clerk.dev",
+      )
+    val backStack = NavBackStack<NavKey>(AuthDestination.AuthStart)
+    backStack.add(AuthDestination.SignInFactorOne(passwordFactor))
+    backStack.add(AuthDestination.SignInForgotPassword)
+
+    navigateToForgotPasswordFactor(backStack, emailCodeFactor)
+
+    assertEquals(AuthDestination.SignInFactorOne(emailCodeFactor), backStack.last())
+    assertEquals(AuthDestination.SignInForgotPassword, backStack[backStack.size - 2])
   }
 }

--- a/source/ui/src/test/java/com/clerk/ui/signin/SignInFactorOneViewTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/SignInFactorOneViewTest.kt
@@ -89,6 +89,31 @@ class SignInFactorOneViewTest {
   }
 
   @Test
+  fun resolveFirstFactorShouldKeepSupportedFallbackWhenPasswordIsPrepared() {
+    val emailCodeFactor =
+      Factor(
+        strategy = StrategyKeys.EMAIL_CODE,
+        emailAddressId = "email_123",
+        safeIdentifier = "sam@clerk.dev",
+      )
+    every { mockAuth.currentSignIn } returns
+      SignIn(
+        id = "sign_in_123",
+        identifier = "sam@clerk.dev",
+        supportedFirstFactors = listOf(Factor(strategy = StrategyKeys.PASSWORD), emailCodeFactor),
+        firstFactorVerification =
+          com.clerk.api.network.model.verification.Verification(
+            status = com.clerk.api.network.model.verification.Verification.Status.UNVERIFIED,
+            strategy = StrategyKeys.PASSWORD,
+          ),
+      )
+
+    val resolved = resolveFirstFactor(emailCodeFactor)
+
+    assertEquals(emailCodeFactor, resolved)
+  }
+
+  @Test
   fun resolveFirstFactorShouldKeepResetPasswordEmailCodeWhenEmailLinkIsSupported() {
     val resetFactor =
       Factor(

--- a/source/ui/src/test/java/com/clerk/ui/signin/SignInFactorOneViewTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/SignInFactorOneViewTest.kt
@@ -87,4 +87,29 @@ class SignInFactorOneViewTest {
 
     assertEquals(StrategyKeys.EMAIL_LINK, resolved.strategy)
   }
+
+  @Test
+  fun resolveFirstFactorShouldKeepResetPasswordEmailCodeWhenEmailLinkIsSupported() {
+    val resetFactor =
+      Factor(
+        strategy = StrategyKeys.RESET_PASSWORD_EMAIL_CODE,
+        emailAddressId = "email_123",
+        safeIdentifier = "sam@clerk.dev",
+      )
+    every { mockAuth.currentSignIn } returns
+      SignIn(
+        id = "sign_in_123",
+        identifier = "sam@clerk.dev",
+        supportedFirstFactors =
+          listOf(
+            resetFactor,
+            Factor(strategy = StrategyKeys.EMAIL_LINK, emailAddressId = "email_123"),
+            Factor(strategy = StrategyKeys.PASSWORD),
+          ),
+      )
+
+    val resolved = resolveFirstFactor(resetFactor)
+
+    assertEquals(resetFactor, resolved)
+  }
 }


### PR DESCRIPTION
## Summary
- Route forgot-password factor selections to the selected first-factor screen instead of popping back to password
- Preserve reset-password factors in `resolveFirstFactor` so reset-code flows keep their verification step
- Add regression coverage for the forgot-password navigation and factor resolution

## Testing
- `:source:ui:testDebugUnitTest` passed
- `:source:ui:spotlessCheck` passed
- `:source:ui:detekt` still reports unrelated pre-existing issues in other UI files