### PR TITLE
fix(ui): fallback to OAuth when Google account unavailable

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/credentials/CredentialFlowException.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/credentials/CredentialFlowException.kt
@@ -95,6 +95,9 @@ private val ClerkResult.Failure<ClerkErrorResponse>.credentialFlowUiMessage: Str
 val ClerkResult.Failure<ClerkErrorResponse>.shouldSuppressCredentialFlowError: Boolean
   get() = (throwable as? CredentialFlowException)?.suppressUserFacingError == true
 
+val ClerkResult.Failure<ClerkErrorResponse>.shouldFallbackToOAuthFromGoogleOneTap: Boolean
+  get() = throwable is CredentialFlowException.NoGoogleAccount
+
 val ClerkResult.Failure<ClerkErrorResponse>.resolvedCredentialFlowMessage: String
   get() = credentialFlowUiMessage ?: errorMessage
 

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.clerk.api.Clerk
 import com.clerk.api.credentials.resolvedCredentialFlowMessage
+import com.clerk.api.credentials.shouldFallbackToOAuthFromGoogleOneTap
 import com.clerk.api.credentials.shouldSuppressCredentialFlowError
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.model.error.ClerkErrorResponse
@@ -176,13 +177,18 @@ internal class AuthStartViewModel : ViewModel() {
   ) {
     _state.value = AuthState.OAuthState.Loading
     if (preferGoogleOneTap && provider == OAuthProvider.GOOGLE && Clerk.isGoogleOneTapEnabled) {
-      handleGoogleOneTap(transferable)
+      handleGoogleOneTap(provider, transferable, startOAuthWithSignUp, unsafeMetadata)
     } else {
       authenticateWithOAuthProvider(provider, transferable, startOAuthWithSignUp, unsafeMetadata)
     }
   }
 
-  private fun handleGoogleOneTap(transferable: Boolean) {
+  private fun handleGoogleOneTap(
+    provider: OAuthProvider,
+    transferable: Boolean,
+    startOAuthWithSignUp: Boolean,
+    unsafeMetadata: Map<String, Any>?,
+  ) {
     viewModelScope.launch(Dispatchers.IO) {
       SignIn.authenticateWithGoogleOneTap(transferable)
         .onSuccess {
@@ -204,12 +210,17 @@ internal class AuthStartViewModel : ViewModel() {
         }
         .onFailure {
           withContext(Dispatchers.Main) {
-            _state.value =
-              if (it.shouldSuppressCredentialFlowError) {
-                AuthState.Idle
-              } else {
-                AuthState.OAuthState.Error(it.resolvedCredentialFlowMessage)
-              }
+            when {
+              it.shouldSuppressCredentialFlowError -> _state.value = AuthState.Idle
+              it.shouldFallbackToOAuthFromGoogleOneTap ->
+                authenticateWithOAuthProvider(
+                  provider = provider,
+                  transferable = transferable,
+                  startOAuthWithSignUp = startOAuthWithSignUp,
+                  unsafeMetadata = unsafeMetadata,
+                )
+              else -> _state.value = AuthState.OAuthState.Error(it.resolvedCredentialFlowMessage)
+            }
           }
         }
     }

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -441,4 +441,31 @@ class AuthViewModelTest {
     coVerify(timeout = 1_000, exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
     coVerify(exactly = 0) { SignIn.authenticateWithRedirect(any(), any()) }
   }
+
+  @Test
+  fun googleSocialAuthFallsBackToBrowserRedirectWhenOneTapHasNoGoogleAccount() = runTest {
+    mockkObject(Clerk)
+    every { Clerk.isGoogleOneTapEnabled } returns true
+    mockkObject(SignIn.Companion)
+    val mockSignIn = mockk<SignIn>(relaxed = true)
+    val noGoogleAccountException =
+      Class.forName("com.clerk.api.credentials.CredentialFlowException\$NoGoogleAccount")
+        .getDeclaredConstructor()
+        .newInstance() as Throwable
+
+    coEvery { SignIn.authenticateWithGoogleOneTap(any()) } returns
+      ClerkResult.unknownFailure(noGoogleAccountException)
+    coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
+      ClerkResult.success(OAuthResult(signIn = mockSignIn))
+
+    viewModel.authenticateWithSocialProvider(
+      provider = OAuthProvider.GOOGLE,
+      transferable = true,
+      preferGoogleOneTap = true,
+    )
+
+    coVerify(timeout = 1_000, exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
+    testDispatcher.scheduler.advanceUntilIdle()
+    coVerify(timeout = 1_000, exactly = 1) { SignIn.authenticateWithRedirect(any(), true) }
+  }
 }


### PR DESCRIPTION
## Summary

- Adds a Google One Tap failure helper for the no-device-Google-account case.
- Falls back from the main login page Google One Tap attempt to browser OAuth when no Google account is available on the device.
- Adds a ViewModel regression test for the fallback path.

## Root cause

The main login page preferred Google One Tap when it was enabled, but treated Credential Manager's no-account response as a terminal UI error. The alternative-methods screen starts browser OAuth directly, so it already avoided that device-account requirement.

## Validation

- `./gradlew :source:ui:testDebugUnitTest --tests "com.clerk.ui.auth.AuthViewModelTest"`
- `./gradlew :source:api:testDebugUnitTest --tests "com.clerk.api.sso.GoogleSignInServiceTest"`
- `./gradlew :source:api:spotlessCheck :source:ui:spotlessCheck`