### PR TITLE
Add custom trigger support to OrganizationSwitcher

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/organizationlist/OrganizationListView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/organizationlist/OrganizationListView.kt
@@ -7,16 +7,22 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.clerk.api.Clerk
+import com.clerk.api.organizations.Organization
 import com.clerk.api.organizations.OrganizationCreationDefaults
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.api.user.User
@@ -28,6 +34,8 @@ import com.clerk.ui.core.composition.TelemetryProvider
 import com.clerk.ui.core.dimens.dp16
 import com.clerk.ui.core.error.ClerkErrorSnackbar
 import com.clerk.ui.core.footer.DevelopmentModeWarningBox
+import com.clerk.ui.organizationprofile.create.OrganizationCreateFlowView
+import com.clerk.ui.organizationprofile.invite.OrganizationInviteMembersView
 import com.clerk.ui.theme.ClerkMaterialTheme
 import com.clerk.ui.theme.ClerkThemeOverrideProvider
 
@@ -43,12 +51,12 @@ import com.clerk.ui.theme.ClerkThemeOverrideProvider
  *   allowed.
  * @param isDismissable Shows a top dismiss affordance and calls [onDismissRequest] after a
  *   successful selection when possible.
- * @param skipPostCreateInviteFlow Reserved for create-organization flows that include a post-create
- *   invitation step. Android's current create flow already stops after creation.
+ * @param skipPostCreateInviteFlow Skips the post-create invitation step in the default
+ *   create-organization flow.
  * @param onDismissRequest Called when the dismiss affordance is pressed or a dismissable selection
  *   completes.
- * @param onCreateOrganization Called when the create-organization row is selected. The latest
- *   creation defaults are provided when available.
+ * @param onCreateOrganization Optional callback for apps that own create-organization navigation.
+ *   When `null`, the list opens Clerk's default create-organization flow.
  * @param onAccountSelected Called after selecting the personal account (`null`) or an organization
  *   ID.
  */
@@ -61,7 +69,7 @@ fun OrganizationListView(
   isDismissable: Boolean = true,
   skipPostCreateInviteFlow: Boolean = false,
   onDismissRequest: (() -> Unit)? = null,
-  onCreateOrganization: (OrganizationCreationDefaults?) -> Unit = {},
+  onCreateOrganization: ((OrganizationCreationDefaults?) -> Unit)? = null,
   onAccountSelected: ((String?) -> Unit)? = null,
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
@@ -73,6 +81,7 @@ fun OrganizationListView(
             clerkTheme = clerkTheme,
             hidePersonalAccount = hidePersonalAccount,
             isDismissable = isDismissable,
+            skipPostCreateInviteFlow = skipPostCreateInviteFlow,
             onDismissRequest = onDismissRequest,
             onCreateOrganization = onCreateOrganization,
             onAccountSelected = onAccountSelected,
@@ -90,8 +99,9 @@ internal fun OrganizationListViewImpl(
   clerkTheme: ClerkTheme? = null,
   hidePersonalAccount: Boolean = false,
   isDismissable: Boolean = true,
+  skipPostCreateInviteFlow: Boolean = false,
   onDismissRequest: (() -> Unit)? = null,
-  onCreateOrganization: (OrganizationCreationDefaults?) -> Unit = {},
+  onCreateOrganization: ((OrganizationCreationDefaults?) -> Unit)? = null,
   onAccountSelected: ((String?) -> Unit)? = null,
   viewModel: OrganizationAccountListViewModel = viewModel(),
 ) {
@@ -100,10 +110,16 @@ internal fun OrganizationListViewImpl(
   val session by Clerk.sessionFlow.collectAsStateWithLifecycle()
   val snackbarHostState = remember { SnackbarHostState() }
   val telemetry = LocalTelemetryCollector.current
+  val createFlowState = remember { OrganizationListCreateFlowState() }
+  val createOrganizationAction =
+    onCreateOrganization
+      ?: { creationDefaults: OrganizationCreationDefaults? ->
+        createFlowState.openCreate(creationDefaults)
+      }
   val callbacks =
     OrganizationListCallbacks(
       onDismissRequest = onDismissRequest,
-      onCreateOrganization = onCreateOrganization,
+      onCreateOrganization = createOrganizationAction,
       onAccountSelected = onAccountSelected,
     )
   val chrome =
@@ -140,6 +156,40 @@ internal fun OrganizationListViewImpl(
       actions = organizationListActions(state = state, viewModel = viewModel, chrome = chrome),
     )
   }
+
+  OrganizationListCreateFlowDialogs(
+    state = createFlowState,
+    skipPostCreateInviteFlow = skipPostCreateInviteFlow,
+  )
+}
+
+@Composable
+private fun OrganizationListCreateFlowDialogs(
+  state: OrganizationListCreateFlowState,
+  skipPostCreateInviteFlow: Boolean,
+) {
+  if (state.showOrganizationCreate) {
+    OrganizationListFullScreenPage(onDismiss = state::dismissCreate) {
+      OrganizationCreateFlowView(
+        modifier = Modifier.fillMaxSize(),
+        creationDefaults = state.organizationCreateDefaults,
+        skipInvitationScreen = skipPostCreateInviteFlow,
+        onComplete = state::dismissCreate,
+        onInviteMembers = state::showPostCreateInvitations,
+        onBackPressed = state::dismissCreate,
+      )
+    }
+  }
+
+  state.postCreateInviteOrganization?.let { organization ->
+    OrganizationListFullScreenPage(onDismiss = state::dismissPostCreateInvitations) {
+      OrganizationInviteMembersView(
+        modifier = Modifier.fillMaxSize(),
+        organization = organization,
+        onComplete = state::dismissPostCreateInvitations,
+      )
+    }
+  }
 }
 
 private data class OrganizationListCallbacks(
@@ -147,6 +197,52 @@ private data class OrganizationListCallbacks(
   val onCreateOrganization: (OrganizationCreationDefaults?) -> Unit,
   val onAccountSelected: ((String?) -> Unit)?,
 )
+
+private class OrganizationListCreateFlowState {
+  var showOrganizationCreate by mutableStateOf(false)
+    private set
+
+  var organizationCreateDefaults by mutableStateOf<OrganizationCreationDefaults?>(null)
+    private set
+
+  var postCreateInviteOrganization by mutableStateOf<Organization?>(null)
+    private set
+
+  fun openCreate(creationDefaults: OrganizationCreationDefaults?) {
+    organizationCreateDefaults = creationDefaults
+    showOrganizationCreate = true
+  }
+
+  fun dismissCreate() {
+    showOrganizationCreate = false
+    organizationCreateDefaults = null
+  }
+
+  fun showPostCreateInvitations(organization: Organization) {
+    dismissCreate()
+    postCreateInviteOrganization = organization
+  }
+
+  fun dismissPostCreateInvitations() {
+    postCreateInviteOrganization = null
+  }
+}
+
+@Composable
+private fun OrganizationListFullScreenPage(onDismiss: () -> Unit, content: @Composable () -> Unit) {
+  Dialog(
+    onDismissRequest = onDismiss,
+    properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
+  ) {
+    Surface(
+      modifier = Modifier.fillMaxSize(),
+      color = ClerkMaterialTheme.colors.background,
+      contentColor = ClerkMaterialTheme.colors.foreground,
+    ) {
+      DevelopmentModeWarningBox(modifier = Modifier.fillMaxSize()) { content() }
+    }
+  }
+}
 
 private data class OrganizationListChrome(
   val clerkTheme: ClerkTheme?,
@@ -169,7 +265,6 @@ private fun OrganizationListScaffold(
         onBackPressed = { chrome.callbacks.onDismissRequest?.invoke() },
         hasLogo = false,
         hasBackButton = chrome.isDismissable && chrome.callbacks.onDismissRequest != null,
-        title = stringResource(R.string.choose_an_account),
         backgroundColor = ClerkMaterialTheme.colors.background,
         clerkTheme = chrome.clerkTheme,
       )

--- a/source/ui/src/main/java/com/clerk/ui/organizationprofile/OrganizationProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/organizationprofile/OrganizationProfileView.kt
@@ -65,6 +65,8 @@ import kotlinx.serialization.Serializable
  * @param customDestination Composable that renders the destination for a given route key. The route
  *   key matches [OrganizationProfileCustomRow.routeKey] of the tapped row.
  * @param onDismiss Callback when the organization profile view is dismissed.
+ * @param onComplete Callback when a destructive organization action completes and the profile can
+ *   no longer be shown.
  */
 @OptIn(ExperimentalAnimationApi::class)
 @SuppressLint("ComposeUnstableReceiver")
@@ -76,6 +78,7 @@ fun OrganizationProfileView(
   customRows: List<OrganizationProfileCustomRow> = emptyList(),
   customDestination: (@Composable (String) -> Unit)? = null,
   onDismiss: () -> Unit = {},
+  onComplete: () -> Unit = onDismiss,
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
     TelemetryProvider {
@@ -87,7 +90,7 @@ fun OrganizationProfileView(
 
       OrganizationProfileEffects(
         organizationId = organization?.id,
-        onDismiss = onDismiss,
+        onComplete = onComplete,
         hasOrganization = organization != null,
       )
 
@@ -102,6 +105,7 @@ fun OrganizationProfileView(
             customRows = customRows,
             customDestination = customDestination,
             onDismiss = onDismiss,
+            onComplete = onComplete,
           )
         } else {
           Box(modifier = Modifier.fillMaxSize())
@@ -109,7 +113,7 @@ fun OrganizationProfileView(
       }
 
       LaunchedEffect(session?.id, user?.id) {
-        if (Clerk.organizationMembership == null && Clerk.organization == null) onDismiss()
+        if (Clerk.organizationMembership == null && Clerk.organization == null) onComplete()
       }
     }
   }
@@ -126,6 +130,7 @@ private fun OrganizationProfileNavDisplay(
   customDestination: (@Composable (String) -> Unit)?,
   modifier: Modifier = Modifier,
   onDismiss: () -> Unit,
+  onComplete: () -> Unit,
 ) {
   var membersRefreshKey by remember { mutableIntStateOf(0) }
 
@@ -159,6 +164,7 @@ private fun OrganizationProfileNavDisplay(
           onInviteMembersComplete = { membersRefreshKey += 1 },
           customRows = customRows,
           customDestination = customDestination,
+          onComplete = onComplete,
         )
       },
   )
@@ -180,14 +186,14 @@ private fun handleOrganizationProfileBack(
 private fun OrganizationProfileEffects(
   organizationId: String?,
   hasOrganization: Boolean,
-  onDismiss: () -> Unit,
+  onComplete: () -> Unit,
 ) {
   val telemetry = LocalTelemetryCollector.current
   LaunchedEffect(organizationId) {
     if (hasOrganization) {
       telemetry.record(TelemetryEvents.viewDidAppear("OrganizationProfileView"))
     } else {
-      onDismiss()
+      onComplete()
     }
   }
 }
@@ -203,6 +209,7 @@ private fun EntryProviderScope<NavKey>.organizationProfileEntries(
   onInviteMembersComplete: () -> Unit,
   customRows: List<OrganizationProfileCustomRow>,
   customDestination: (@Composable (String) -> Unit)?,
+  onComplete: () -> Unit,
 ) {
   entry<OrganizationProfileDestination.Root> {
     OrganizationProfileRootView(
@@ -268,7 +275,7 @@ private fun EntryProviderScope<NavKey>.organizationProfileEntries(
       organization = organization,
       membership = membership,
       onBackPressed = { backStack.removeLastOrNull() },
-      onSuccess = onDismiss,
+      onSuccess = onComplete,
     )
   }
 
@@ -278,7 +285,7 @@ private fun EntryProviderScope<NavKey>.organizationProfileEntries(
       organization = organization,
       membership = membership,
       onBackPressed = { backStack.removeLastOrNull() },
-      onSuccess = onDismiss,
+      onSuccess = onComplete,
     )
   }
 

--- a/source/ui/src/main/java/com/clerk/ui/organizationswitcher/OrganizationSwitcher.kt
+++ b/source/ui/src/main/java/com/clerk/ui/organizationswitcher/OrganizationSwitcher.kt
@@ -164,6 +164,62 @@ fun OrganizationSwitcher(
 }
 
 /**
+ * Self-contained active organization switcher with a custom trigger.
+ *
+ * Use [triggerContent] when an app wants Clerk to own the switcher sheets while rendering its own
+ * clickable trigger content.
+ *
+ * @param clerkTheme Optional theme customization for the switcher UI.
+ * @param onOrganizationChanged Optional callback invoked after a successful organization or
+ *   personal-account switch.
+ * @param hidePersonal Hides personal account selection when the instance does not force
+ *   organization selection.
+ * @param displayMode Stored for parity with the default switcher configuration. Custom trigger
+ *   content is rendered as provided.
+ * @param triggerContent Custom clickable trigger content.
+ * @param onManageOrganization Called when the active organization overview's manage action is
+ *   selected. When `null`, the switcher opens [OrganizationProfileView].
+ * @param onCreateOrganization Called when the create-organization row is selected from the switch
+ *   account sheet. When `null`, the switcher opens the default organization creation flow.
+ * @param organizationProfileCustomRows Custom rows forwarded to the switcher's default
+ *   [OrganizationProfileView].
+ * @param organizationProfileCustomDestination Custom destination builder forwarded to the
+ *   switcher's default [OrganizationProfileView].
+ */
+@Composable
+fun OrganizationSwitcher(
+  modifier: Modifier = Modifier,
+  clerkTheme: ClerkTheme? = null,
+  onOrganizationChanged: (() -> Unit)? = null,
+  hidePersonal: Boolean = false,
+  displayMode: OrganizationSwitcherDisplayMode = OrganizationSwitcherDisplayMode.Normal,
+  triggerContent: @Composable () -> Unit,
+  onManageOrganization: ((OrganizationMembership) -> Unit)? = null,
+  onCreateOrganization: ((OrganizationCreationDefaults?) -> Unit)? = null,
+  organizationProfileCustomRows: List<OrganizationProfileCustomRow> = emptyList(),
+  organizationProfileCustomDestination: (@Composable (String) -> Unit)? = null,
+) {
+  ClerkThemeOverrideProvider(clerkTheme) {
+    ClerkMaterialTheme {
+      TelemetryProvider {
+        OrganizationSwitcherImpl(
+          modifier = modifier,
+          clerkTheme = clerkTheme,
+          onOrganizationChanged = onOrganizationChanged,
+          hidePersonal = hidePersonal,
+          displayMode = displayMode,
+          triggerContent = triggerContent,
+          onManageOrganization = onManageOrganization,
+          onCreateOrganization = onCreateOrganization,
+          organizationProfileCustomRows = organizationProfileCustomRows,
+          organizationProfileCustomDestination = organizationProfileCustomDestination,
+        )
+      }
+    }
+  }
+}
+
+/**
  * Self-contained organization switcher sheet.
  *
  * Use this when an app owns the trigger and only wants Clerk's account-switching sheet UI. Render
@@ -231,6 +287,7 @@ internal fun OrganizationSwitcherImpl(
   onOrganizationChanged: (() -> Unit)? = null,
   hidePersonal: Boolean = false,
   displayMode: OrganizationSwitcherDisplayMode = OrganizationSwitcherDisplayMode.Normal,
+  triggerContent: (@Composable () -> Unit)? = null,
   onManageOrganization: ((OrganizationMembership) -> Unit)? = null,
   onCreateOrganization: ((OrganizationCreationDefaults?) -> Unit)? = null,
   organizationProfileCustomRows: List<OrganizationProfileCustomRow> = emptyList(),
@@ -305,6 +362,7 @@ internal fun OrganizationSwitcherImpl(
         showPersonalAccount = showPersonalAccount,
         isLoading = state.isLoading && activeMembership == null && !showPersonalAccount,
         displayMode = displayMode,
+        triggerContent = triggerContent,
         onOpenSheet = { sheetDestination = it },
       )
 
@@ -460,6 +518,7 @@ private fun OrganizationSwitcherHeaderIfNeeded(
   showPersonalAccount: Boolean,
   isLoading: Boolean,
   displayMode: OrganizationSwitcherDisplayMode,
+  triggerContent: (@Composable () -> Unit)?,
   onOpenSheet: (OrganizationSwitcherSheetDestination) -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -472,6 +531,7 @@ private fun OrganizationSwitcherHeaderIfNeeded(
     showPersonalAccount = showPersonalAccount,
     isLoading = isLoading,
     displayMode = displayMode,
+    triggerContent = triggerContent,
     onClick = {
       onOpenSheet(
         if (activeMembership == null) {
@@ -684,9 +744,20 @@ private fun OrganizationSwitcherHeader(
   showPersonalAccount: Boolean,
   isLoading: Boolean,
   displayMode: OrganizationSwitcherDisplayMode,
+  triggerContent: (@Composable () -> Unit)?,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
+  if (triggerContent != null) {
+    OrganizationSwitcherCustomTrigger(
+      modifier = modifier.fillMaxWidth(),
+      isLoading = isLoading,
+      onClick = onClick,
+      content = triggerContent,
+    )
+    return
+  }
+
   Row(
     modifier = modifier.fillMaxWidth(),
     verticalAlignment = Alignment.CenterVertically,
@@ -704,6 +775,24 @@ private fun OrganizationSwitcherHeader(
     if (displayMode.isCompact) {
       Spacer(modifier = Modifier.weight(1f))
     }
+  }
+}
+
+@Composable
+internal fun OrganizationSwitcherCustomTrigger(
+  isLoading: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  val openOrganizationSwitcherDescription = stringResource(R.string.open_organization_switcher)
+  Box(
+    modifier =
+      modifier.clickable(enabled = !isLoading, onClick = onClick).semantics {
+        contentDescription = openOrganizationSwitcherDescription
+      }
+  ) {
+    content()
   }
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/organizationswitcher/OrganizationSwitcher.kt
+++ b/source/ui/src/main/java/com/clerk/ui/organizationswitcher/OrganizationSwitcher.kt
@@ -219,34 +219,9 @@ fun OrganizationSwitcher(
   }
 }
 
-/**
- * Self-contained organization switcher sheet.
- *
- * Use this when an app owns the trigger and only wants Clerk's account-switching sheet UI. Render
- * this composable while your trigger's sheet state is open and remove it from composition from
- * [onDismissRequest].
- *
- * @param onDismissRequest Called when the sheet, or any default full-screen follow-up flow, should
- *   be dismissed.
- * @param clerkTheme Optional theme customization for the sheet UI.
- * @param showCreateOrganization Shows the create-organization row when organization creation is
- *   enabled for the current user.
- * @param onOrganizationChanged Optional callback invoked after a successful organization or
- *   personal-account switch.
- * @param hidePersonal Hides personal account selection when the instance does not force
- *   organization selection.
- * @param onManageOrganization Called when the active organization overview's manage action is
- *   selected. When `null`, the sheet opens the default [OrganizationProfileView].
- * @param onCreateOrganization Called when the create-organization row is selected. When `null`, the
- *   sheet opens the default organization creation flow.
- * @param organizationProfileCustomRows Custom rows forwarded to the default
- *   [OrganizationProfileView].
- * @param organizationProfileCustomDestination Custom destination builder forwarded to the default
- *   [OrganizationProfileView].
- */
 @Composable
 @Suppress("LongParameterList")
-fun OrganizationSwitcherSheet(
+internal fun OrganizationSwitcherSheet(
   onDismissRequest: () -> Unit,
   modifier: Modifier = Modifier,
   clerkTheme: ClerkTheme? = null,

--- a/source/ui/src/main/java/com/clerk/ui/organizationswitcher/OrganizationSwitcher.kt
+++ b/source/ui/src/main/java/com/clerk/ui/organizationswitcher/OrganizationSwitcher.kt
@@ -359,6 +359,12 @@ internal fun OrganizationSwitcherImpl(
         onDismissActiveSheet = dismissActiveSheet,
         onShowAccountList = { sheetDestination = OrganizationSwitcherSheetDestination.AccountList },
         onDismissOrganizationProfile = { showOrganizationProfile = false },
+        onOrganizationProfileComplete = {
+          showOrganizationProfile = false
+          viewModel.reset()
+          viewModel.load()
+          sheetDestination = OrganizationSwitcherSheetDestination.AccountList
+        },
         onDismissOrganizationCreate = {
           showOrganizationCreate = false
           organizationCreateDefaults = null
@@ -472,6 +478,7 @@ private fun OrganizationSwitcherSheetImpl(
     onDismissActiveSheet = onDismissRequest,
     onShowAccountList = { sheetDestination = OrganizationSwitcherSheetDestination.AccountList },
     onDismissOrganizationProfile = onDismissRequest,
+    onOrganizationProfileComplete = onDismissRequest,
     onDismissOrganizationCreate = onDismissRequest,
     onShowPostCreateInvitations = { organization ->
       showOrganizationCreate = false
@@ -538,6 +545,7 @@ private fun OrganizationSwitcherSheets(
   onDismissActiveSheet: () -> Unit,
   onShowAccountList: () -> Unit,
   onDismissOrganizationProfile: () -> Unit,
+  onOrganizationProfileComplete: () -> Unit,
   onDismissOrganizationCreate: () -> Unit,
   onShowPostCreateInvitations: (Organization) -> Unit,
   onDismissPostCreateInvitations: () -> Unit,
@@ -569,6 +577,7 @@ private fun OrganizationSwitcherSheets(
         customRows = organizationProfileCustomRows,
         customDestination = organizationProfileCustomDestination,
         onDismiss = onDismissOrganizationProfile,
+        onComplete = onOrganizationProfileComplete,
       )
     }
 
@@ -644,6 +653,7 @@ private fun OrganizationSwitcherProfilePage(
   customRows: List<OrganizationProfileCustomRow>,
   customDestination: (@Composable (String) -> Unit)?,
   onDismiss: () -> Unit,
+  onComplete: () -> Unit,
 ) {
   OrganizationSwitcherFullScreenPage(onDismiss = onDismiss, showDevelopmentModeWarning = false) {
     OrganizationProfileView(
@@ -652,6 +662,7 @@ private fun OrganizationSwitcherProfilePage(
       customRows = customRows,
       customDestination = customDestination,
       onDismiss = onDismiss,
+      onComplete = onComplete,
     )
   }
 }

--- a/source/ui/src/test/java/com/clerk/snapshot/organizationswitcher/OrganizationSwitcherSnapshotTest.kt
+++ b/source/ui/src/test/java/com/clerk/snapshot/organizationswitcher/OrganizationSwitcherSnapshotTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.clerk.api.Clerk
@@ -14,6 +15,7 @@ import com.clerk.ui.organizationlist.OrganizationAccountListActions
 import com.clerk.ui.organizationlist.OrganizationAccountListState
 import com.clerk.ui.organizationswitcher.OrganizationSwitcherAccountListSheetContent
 import com.clerk.ui.organizationswitcher.OrganizationSwitcherButton
+import com.clerk.ui.organizationswitcher.OrganizationSwitcherCustomTrigger
 import com.clerk.ui.organizationswitcher.OrganizationSwitcherDisplayMode
 import com.clerk.ui.organizationswitcher.OrganizationSwitcherOverviewSheetContent
 import com.clerk.ui.organizationswitcher.previewOrganizationMembership
@@ -81,6 +83,18 @@ class OrganizationSwitcherSnapshotTest : BaseSnapshotTest() {
           isLoading = false,
           onClick = {},
         )
+      }
+    }
+  }
+
+  @Test
+  fun organizationSwitcherCustomTrigger() {
+    Clerk.customTheme = ClerkTheme(DefaultColors.light)
+    paparazzi.snapshot {
+      SwitcherSnapshotSurface {
+        OrganizationSwitcherCustomTrigger(isLoading = false, onClick = {}) {
+          Text(text = "Switch account", color = ClerkMaterialTheme.colors.foreground)
+        }
       }
     }
   }

--- a/workbench/src/main/java/com/clerk/workbench/UiActivity2.kt
+++ b/workbench/src/main/java/com/clerk/workbench/UiActivity2.kt
@@ -9,23 +9,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.compose.ui.unit.dp
-import com.clerk.api.Clerk
+import com.clerk.ui.organizationlist.OrganizationListView
 import com.clerk.ui.organizationswitcher.OrganizationSwitcher
 import com.clerk.workbench.ui.theme.Background
 import com.clerk.workbench.ui.theme.BackgroundDark
 import com.clerk.workbench.ui.theme.WorkbenchTheme
-import kotlinx.coroutines.launch
 
 class UiActivity2 : ComponentActivity() {
 
@@ -38,24 +32,14 @@ class UiActivity2 : ComponentActivity() {
     )
     setContent {
       val backgroundColor = if (isSystemInDarkTheme()) BackgroundDark else Background
-      val scope = rememberCoroutineScope()
       WorkbenchTheme {
         Column(modifier = Modifier.fillMaxSize().background(color = Color(0xFFF9F9F9))) {
           WorkbenchAuthGate(persistIdentifiers = false) {
             Column(
               modifier =
-                Modifier.background(color = backgroundColor)
-                  .fillMaxSize()
-                  .statusBarsPadding()
-                  .padding(24.dp)
+                Modifier.background(color = backgroundColor).fillMaxSize().statusBarsPadding()
             ) {
               OrganizationSwitcher()
-              Button(
-                modifier = Modifier.padding(top = 16.dp),
-                onClick = { scope.launch { Clerk.auth.signOut() } },
-              ) {
-                Text("Sign out")
-              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- Add a source-compatible `OrganizationSwitcher` overload for custom trigger content while keeping Clerk-owned sheets and account switching flows intact.
- Make the standalone `OrganizationSwitcherSheet` internal so apps use the switcher trigger slot instead of depending on the sheet as public API.
- Make `OrganizationListView` open Clerk's default create-organization flow when no app-owned `onCreateOrganization` callback is supplied, including the optional post-create invite step.
- Avoid duplicate “Choose an account” text by keeping the title in the account-list header instead of also rendering it in the app bar.
- Split `OrganizationProfileView` normal dismissal from destructive-action completion, then have the switcher refresh and reopen the account list after leave/delete so stale organizations do not remain visible.
- Update `UiActivity2` to exercise the standalone organization list flow.

## Testing
- `./gradlew :source:ui:spotlessCheck`
- `./gradlew :source:ui:testDebug --tests "com.clerk.snapshot.organizationswitcher.OrganizationSwitcherSnapshotTest" --tests "com.clerk.snapshot.organizationprofile.OrganizationProfileSnapshotTest"`
- `./gradlew :source:ui:testDebug --tests "com.clerk.snapshot.organizationlist.OrganizationListSnapshotTest"`
- `./gradlew :workbench:assembleDebug`

## Notes
- `./gradlew :source:ui:detekt` still reports existing unrelated issues in phone/sign-up UI files (`ClerkPhoneNumberField`, `SignUpCollectFieldView`, `SignUpCompleteProfileView`).