### PR TITLE
Port session reverification support to Android

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/network/ApiPaths.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ApiPaths.kt
@@ -29,6 +29,11 @@ internal object ApiPaths {
       internal const val TOKENS = "${WITH_ID}/tokens"
       internal const val TOKEN_TEMPLATE = "${TOKENS}/{template}"
       internal const val SET_ACTIVE = "${WITH_ID}/touch"
+      internal const val VERIFY = "${WITH_ID}/verify"
+      internal const val PREPARE_FIRST_FACTOR = "${VERIFY}/prepare_first_factor"
+      internal const val ATTEMPT_FIRST_FACTOR = "${VERIFY}/attempt_first_factor"
+      internal const val PREPARE_SECOND_FACTOR = "${VERIFY}/prepare_second_factor"
+      internal const val ATTEMPT_SECOND_FACTOR = "${VERIFY}/attempt_second_factor"
     }
 
     /** Sign-in endpoints */

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/SessionApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/SessionApi.kt
@@ -7,7 +7,10 @@ import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.token.TokenResource
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
+import com.clerk.api.session.SessionVerification
 import retrofit2.http.DELETE
+import retrofit2.http.FieldMap
+import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -23,6 +26,7 @@ import retrofit2.http.Query
  * This is an internal API interface used by the Clerk SDK and should not be used directly by
  * application code.
  */
+@Suppress("TooManyFunctions")
 internal interface SessionApi {
   /**
    * Retrieves all sessions for the current client.
@@ -92,6 +96,46 @@ internal interface SessionApi {
     @Path(ApiParams.ID) userId: String,
     @Path("template") templateType: String,
   ): ClerkResult<TokenResource, ClerkErrorResponse>
+
+  /** Starts an in-session reverification flow. */
+  @FormUrlEncoded
+  @POST(ApiPaths.Client.Sessions.VERIFY)
+  suspend fun startVerification(
+    @Path(ApiParams.ID) sessionId: String,
+    @FieldMap params: Map<String, String>,
+  ): ClerkResult<SessionVerification, ClerkErrorResponse>
+
+  /** Prepares the first factor of an in-session reverification flow. */
+  @FormUrlEncoded
+  @POST(ApiPaths.Client.Sessions.PREPARE_FIRST_FACTOR)
+  suspend fun prepareFirstFactorVerification(
+    @Path(ApiParams.ID) sessionId: String,
+    @FieldMap params: Map<String, String>,
+  ): ClerkResult<SessionVerification, ClerkErrorResponse>
+
+  /** Attempts the first factor of an in-session reverification flow. */
+  @FormUrlEncoded
+  @POST(ApiPaths.Client.Sessions.ATTEMPT_FIRST_FACTOR)
+  suspend fun attemptFirstFactorVerification(
+    @Path(ApiParams.ID) sessionId: String,
+    @FieldMap params: Map<String, String>,
+  ): ClerkResult<SessionVerification, ClerkErrorResponse>
+
+  /** Prepares the second factor of an in-session reverification flow. */
+  @FormUrlEncoded
+  @POST(ApiPaths.Client.Sessions.PREPARE_SECOND_FACTOR)
+  suspend fun prepareSecondFactorVerification(
+    @Path(ApiParams.ID) sessionId: String,
+    @FieldMap params: Map<String, String>,
+  ): ClerkResult<SessionVerification, ClerkErrorResponse>
+
+  /** Attempts the second factor of an in-session reverification flow. */
+  @FormUrlEncoded
+  @POST(ApiPaths.Client.Sessions.ATTEMPT_SECOND_FACTOR)
+  suspend fun attemptSecondFactorVerification(
+    @Path(ApiParams.ID) sessionId: String,
+    @FieldMap params: Map<String, String>,
+  ): ClerkResult<SessionVerification, ClerkErrorResponse>
 
   /**
    * Revokes a specific session.

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/factor/Factor.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/factor/Factor.kt
@@ -21,11 +21,20 @@ data class Factor(
   /** The ID of the Web3 wallet that will be used to sign a message. */
   val web3WalletId: String? = null,
 
+  /** The ID of the enterprise connection that will be used for SSO. */
+  @SerialName("enterprise_connection_id") val enterpriseConnectionId: String? = null,
+
+  /** The display name of the enterprise connection that will be used for SSO. */
+  @SerialName("enterprise_connection_name") val enterpriseConnectionName: String? = null,
+
   /** The safe identifier of the factor. */
   @SerialName("safe_identifier") val safeIdentifier: String? = null,
 
   /** Whether the factor is the primary factor. */
   val primary: Boolean? = null,
+
+  /** Whether the factor is the default second factor. */
+  @SerialName("default") val default: Boolean? = null,
 )
 
 fun Factor.isResetFactor() =

--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
@@ -189,17 +189,40 @@ internal object GoogleCredentialAuthenticationService {
     allowedCredentialIds: List<String>,
   ): ClerkResult<SessionVerification, ClerkErrorResponse> {
     val prepareResult = session.prepareFirstFactorVerification(PasskeyHelper.passkeyStrategy)
-    if (prepareResult is ClerkResult.Failure) {
-      ClerkLog.e("Failed to prepare passkey session reverification: ${prepareResult.error}")
-      return prepareResult
+    return when (prepareResult) {
+      is ClerkResult.Failure -> {
+        ClerkLog.e("Failed to prepare passkey session reverification: ${prepareResult.error}")
+        prepareResult
+      }
+      is ClerkResult.Success -> {
+        val nonce = prepareResult.value.firstFactorVerification?.nonce
+        if (nonce == null) {
+          missingPreparedVerificationNonceFailure()
+        } else {
+          attemptSessionPasskeyVerification(activity, session, allowedCredentialIds, nonce)
+        }
+      }
     }
+  }
 
-    val preparedVerification = (prepareResult as ClerkResult.Success).value
+  private fun missingPreparedVerificationNonceFailure(): ClerkResult.Failure<Nothing> {
+    ClerkLog.e("Missing nonce in preparedVerification.firstFactorVerification")
+    return ClerkResult.unknownFailure(
+      IllegalStateException("Missing nonce in prepared verification")
+    )
+  }
+
+  private suspend fun attemptSessionPasskeyVerification(
+    activity: android.app.Activity,
+    session: Session,
+    allowedCredentialIds: List<String>,
+    nonce: String,
+  ): ClerkResult<SessionVerification, ClerkErrorResponse> {
     return try {
       val credential =
         getCredentialFromManager(
           activity = activity,
-          nonce = preparedVerification.firstFactorVerification?.nonce,
+          nonce = nonce,
           allowedCredentialIds = allowedCredentialIds,
           credentialRequestTypes = listOf(SignIn.CredentialType.PASSKEY),
         )

--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
@@ -19,6 +19,10 @@ import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
+import com.clerk.api.session.SessionVerification
+import com.clerk.api.session.attemptFirstFactorVerification
+import com.clerk.api.session.prepareFirstFactorVerification
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signin.attemptFirstFactor
 import com.clerk.api.sso.GoogleCredentialManagerImpl
@@ -48,6 +52,7 @@ import org.json.JSONObject
  * @see PasskeyCredentialManager
  * @see GoogleSignInService
  */
+@Suppress("TooManyFunctions")
 internal object GoogleCredentialAuthenticationService {
 
   /** The credential manager used for passkey operations. */
@@ -131,7 +136,12 @@ internal object GoogleCredentialAuthenticationService {
             val signIn = createResult.value
             try {
               val credential =
-                getCredentialFromManager(activity, signIn, allowedCredentialIds, credentialTypes)
+                getCredentialFromManager(
+                  activity = activity,
+                  nonce = signIn.firstFactorVerification?.nonce,
+                  allowedCredentialIds = allowedCredentialIds,
+                  credentialRequestTypes = credentialTypes,
+                )
               handleCredential(credential, signIn)
             } catch (e: GetCredentialException) {
               ClerkLog.e("Passkey sign-in failed: ${e.message}")
@@ -150,6 +160,74 @@ internal object GoogleCredentialAuthenticationService {
           }
         }
       }
+    }
+  }
+
+  /**
+   * Initiates and completes an in-session passkey reverification flow.
+   *
+   * This uses the session verification nonce as the WebAuthn request challenge, then submits the
+   * selected public key credential to the session verification endpoint.
+   */
+  suspend fun verifySessionWithPasskey(
+    session: Session,
+    allowedCredentialIds: List<String> = emptyList(),
+  ): ClerkResult<SessionVerification, ClerkErrorResponse> {
+    ClerkLog.d("Starting passkey session reverification")
+    val activity =
+      Clerk.credentialActivity()
+        ?: return ClerkResult.unknownFailure(CredentialFlowException.MissingActivity()).also {
+          ClerkLog.e("Passkey session reverification requires an active Activity")
+        }
+
+    return verifySessionWithPasskey(activity, session, allowedCredentialIds)
+  }
+
+  private suspend fun verifySessionWithPasskey(
+    activity: android.app.Activity,
+    session: Session,
+    allowedCredentialIds: List<String>,
+  ): ClerkResult<SessionVerification, ClerkErrorResponse> {
+    val prepareResult = session.prepareFirstFactorVerification(PasskeyHelper.passkeyStrategy)
+    if (prepareResult is ClerkResult.Failure) {
+      ClerkLog.e("Failed to prepare passkey session reverification: ${prepareResult.error}")
+      return prepareResult
+    }
+
+    val preparedVerification = (prepareResult as ClerkResult.Success).value
+    return try {
+      val credential =
+        getCredentialFromManager(
+          activity = activity,
+          nonce = preparedVerification.firstFactorVerification?.nonce,
+          allowedCredentialIds = allowedCredentialIds,
+          credentialRequestTypes = listOf(SignIn.CredentialType.PASSKEY),
+        )
+
+      if (credential is PublicKeyCredential) {
+        ClerkLog.d("Attempting passkey session reverification")
+        val result =
+          session.attemptFirstFactorVerification(
+            Session.AttemptFirstFactorParams.Passkey(credential.authenticationResponseJson)
+          )
+
+        if (result is ClerkResult.Failure) {
+          ClerkLog.e("Passkey session reverification failed: ${result.error}")
+        }
+
+        result
+      } else {
+        ClerkResult.unknownFailure(IllegalStateException("Unsupported credential type"))
+      }
+    } catch (e: GetCredentialException) {
+      ClerkLog.e("Passkey session reverification failed: ${e.message}")
+      classifyGetCredentialFailure(e, listOf(SignIn.CredentialType.PASSKEY))
+    } catch (e: CredentialFlowException) {
+      ClerkLog.e("Passkey session reverification cannot start: ${e.message}")
+      ClerkResult.unknownFailure(e)
+    } catch (e: Exception) {
+      ClerkLog.e("Passkey session reverification failed: ${e.message}")
+      ClerkResult.unknownFailure(e)
     }
   }
 
@@ -188,8 +266,8 @@ internal object GoogleCredentialAuthenticationService {
    * - Handle user selection and return the chosen credential
    * - Throw appropriate exceptions if no credentials are available or accessible
    *
-   * @param context Android context required for credential manager operations.
-   * @param signIn The sign-in session containing the WebAuthn challenge and authentication data.
+   * @param activity Android activity required for credential manager operations.
+   * @param nonce The JSON-encoded WebAuthn challenge metadata.
    * @param allowedCredentialIds Optional list of allowed credential IDs to filter results. If
    *   empty, all available credentials of the requested types will be presented.
    * @param credentialRequestTypes List of credential types to request from the system.
@@ -200,12 +278,12 @@ internal object GoogleCredentialAuthenticationService {
    */
   private suspend fun getCredentialFromManager(
     activity: android.app.Activity,
-    signIn: SignIn,
+    nonce: String?,
     allowedCredentialIds: List<String> = emptyList(),
     credentialRequestTypes: List<SignIn.CredentialType>,
   ): Credential {
     val credentialRequest =
-      buildCredentialRequest(signIn, allowedCredentialIds, credentialRequestTypes)
+      buildCredentialRequest(nonce, allowedCredentialIds, credentialRequestTypes)
 
     val result =
       try {
@@ -233,8 +311,7 @@ internal object GoogleCredentialAuthenticationService {
    * The credential manager will present all available credentials matching the requested types and
    * allow the user to select their preferred authentication method.
    *
-   * @param signIn The sign-in session containing the WebAuthn challenge and authentication
-   *   metadata.
+   * @param nonce The JSON-encoded WebAuthn challenge metadata.
    * @param allowedCredentialIds Optional list of credential IDs to restrict selection to specific
    *   credentials. If empty, all available credentials of the requested types will be included.
    * @param credentialRequestTypes List of credential types to include in the request. Each type
@@ -243,7 +320,7 @@ internal object GoogleCredentialAuthenticationService {
    *   specified types and restrictions.
    */
   private fun buildCredentialRequest(
-    signIn: SignIn,
+    nonce: String?,
     allowedCredentialIds: List<String> = emptyList(),
     credentialRequestTypes: List<SignIn.CredentialType>,
   ): GetCredentialRequest {
@@ -252,8 +329,7 @@ internal object GoogleCredentialAuthenticationService {
     credentialRequestTypes.forEach {
       when (it) {
         SignIn.CredentialType.PASSKEY -> {
-          val webAuthnRequest =
-            createWebAuthnRequest(signIn.firstFactorVerification?.nonce, allowedCredentialIds)
+          val webAuthnRequest = createWebAuthnRequest(nonce, allowedCredentialIds)
           requestOptions.add(buildPublicKeyCredentialOption(webAuthnRequest))
         }
         SignIn.CredentialType.PASSWORD -> requestOptions.add(GetPasswordOption())

--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/PasskeyService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/PasskeyService.kt
@@ -2,6 +2,8 @@ package com.clerk.api.passkeys
 
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
+import com.clerk.api.session.SessionVerification
 import com.clerk.api.signin.SignIn
 
 /**
@@ -24,6 +26,23 @@ internal object PasskeyService {
   ): ClerkResult<SignIn, ClerkErrorResponse> {
     return GoogleCredentialAuthenticationService.signInWithGoogleCredential(
       credentialTypes = listOf(SignIn.CredentialType.PASSKEY),
+      allowedCredentialIds = allowedCredentialIds,
+    )
+  }
+
+  /**
+   * Completes an in-session reverification flow using passkeys.
+   *
+   * @param session The session that should be reverified.
+   * @param allowedCredentialIds Optional list of credential IDs to filter available passkeys.
+   * @return A [ClerkResult] containing the resulting [SessionVerification] on success, or an error.
+   */
+  suspend fun verifySessionWithPasskey(
+    session: Session,
+    allowedCredentialIds: List<String> = emptyList(),
+  ): ClerkResult<SessionVerification, ClerkErrorResponse> {
+    return GoogleCredentialAuthenticationService.verifySessionWithPasskey(
+      session = session,
       allowedCredentialIds = allowedCredentialIds,
     )
   }

--- a/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
@@ -78,12 +78,12 @@ data class Session(
   }
 
   /** Parameters for starting an in-session reverification flow. */
-  @Serializable @AutoMap data class StartVerificationParams(val level: String)
+  @Serializable @AutoMap internal data class StartVerificationParams(val level: String)
 
   /** Parameters for preparing a first factor in an in-session reverification flow. */
   @Serializable
   @AutoMap
-  data class PrepareFirstFactorParams(
+  internal data class PrepareFirstFactorParams(
     val strategy: String,
     @SerialName("email_address_id") val emailAddressId: String? = null,
     @SerialName("phone_number_id") val phoneNumberId: String? = null,
@@ -92,7 +92,7 @@ data class Session(
   )
 
   /** Parameters for attempting a first factor in an in-session reverification flow. */
-  sealed interface AttemptFirstFactorParams {
+  internal sealed interface AttemptFirstFactorParams {
     val strategy: String
 
     @Serializable
@@ -115,7 +115,7 @@ data class Session(
   /** Parameters for preparing a second factor in an in-session reverification flow. */
   @Serializable
   @AutoMap
-  data class PrepareSecondFactorParams(
+  internal data class PrepareSecondFactorParams(
     val strategy: String,
     @SerialName("phone_number_id") val phoneNumberId: String? = null,
   )
@@ -123,7 +123,7 @@ data class Session(
   /** Parameters for attempting a second factor in an in-session reverification flow. */
   @Serializable
   @AutoMap
-  data class AttemptSecondFactorParams(val strategy: String, val code: String)
+  internal data class AttemptSecondFactorParams(val strategy: String, val code: String)
 }
 
 @Serializable data class SessionTask(val key: String)

--- a/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
@@ -1,6 +1,8 @@
 package com.clerk.api.session
 
 import com.clerk.api.Clerk
+import com.clerk.api.Constants.Strategy.PASSKEY
+import com.clerk.api.Constants.Strategy.PASSWORD
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.ClerkErrorResponse
@@ -8,6 +10,7 @@ import com.clerk.api.network.model.token.TokenResource
 import com.clerk.api.network.model.userdata.PublicUserData
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.user.User
+import com.clerk.automap.annotations.AutoMap
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -73,6 +76,54 @@ data class Session(
     @SerialName("unknown") UNKNOWN,
     @SerialName("pending") PENDING,
   }
+
+  /** Parameters for starting an in-session reverification flow. */
+  @Serializable @AutoMap data class StartVerificationParams(val level: String)
+
+  /** Parameters for preparing a first factor in an in-session reverification flow. */
+  @Serializable
+  @AutoMap
+  data class PrepareFirstFactorParams(
+    val strategy: String,
+    @SerialName("email_address_id") val emailAddressId: String? = null,
+    @SerialName("phone_number_id") val phoneNumberId: String? = null,
+    @SerialName("enterprise_connection_id") val enterpriseConnectionId: String? = null,
+    @SerialName("redirect_url") val redirectUrl: String? = null,
+  )
+
+  /** Parameters for attempting a first factor in an in-session reverification flow. */
+  sealed interface AttemptFirstFactorParams {
+    val strategy: String
+
+    @Serializable
+    @AutoMap
+    data class Password(val password: String, override val strategy: String = PASSWORD) :
+      AttemptFirstFactorParams
+
+    @Serializable
+    @AutoMap
+    data class Passkey(
+      @SerialName("public_key_credential") val publicKeyCredential: String,
+      override val strategy: String = PASSKEY,
+    ) : AttemptFirstFactorParams
+
+    @Serializable
+    @AutoMap
+    data class Code(val code: String, override val strategy: String) : AttemptFirstFactorParams
+  }
+
+  /** Parameters for preparing a second factor in an in-session reverification flow. */
+  @Serializable
+  @AutoMap
+  data class PrepareSecondFactorParams(
+    val strategy: String,
+    @SerialName("phone_number_id") val phoneNumberId: String? = null,
+  )
+
+  /** Parameters for attempting a second factor in an in-session reverification flow. */
+  @Serializable
+  @AutoMap
+  data class AttemptSecondFactorParams(val strategy: String, val code: String)
 }
 
 @Serializable data class SessionTask(val key: String)

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionVerification.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionVerification.kt
@@ -1,0 +1,52 @@
+package com.clerk.api.session
+
+import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.network.model.verification.Verification
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Represents the state of an in-session reverification (step-up) flow. */
+@Serializable
+data class SessionVerification(
+  /** The unique identifier for the verification attempt. */
+  val id: String? = null,
+
+  /** The current status of the verification. */
+  val status: Status = Status.UNKNOWN,
+
+  /** The required verification level. */
+  val level: Level = Level.UNKNOWN,
+
+  /** The session associated with the verification. */
+  val session: Session? = null,
+
+  /** First factors supported for this verification. */
+  @SerialName("supported_first_factors") val supportedFirstFactors: List<Factor>? = null,
+
+  /** Second factors supported for this verification. */
+  @SerialName("supported_second_factors") val supportedSecondFactors: List<Factor>? = null,
+
+  /** The state of the first-factor verification. */
+  @SerialName("first_factor_verification") val firstFactorVerification: Verification? = null,
+
+  /** The state of the second-factor verification. */
+  @SerialName("second_factor_verification") val secondFactorVerification: Verification? = null,
+) {
+  /** The status of a session verification attempt. */
+  @Serializable
+  enum class Status {
+    @SerialName("needs_first_factor") NEEDS_FIRST_FACTOR,
+    @SerialName("needs_second_factor") NEEDS_SECOND_FACTOR,
+    @SerialName("complete") COMPLETE,
+    @SerialName("unknown") UNKNOWN,
+  }
+
+  /** The required level of verification. */
+  @Serializable
+  enum class Level(val value: String) {
+    @SerialName("first_factor") FIRST_FACTOR("first_factor"),
+    @SerialName("second_factor") SECOND_FACTOR("second_factor"),
+    @SerialName("multi_factor") MULTI_FACTOR("multi_factor"),
+    @SerialName("unknown") UNKNOWN("unknown"),
+  }
+}

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationConvenienceExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationConvenienceExtensions.kt
@@ -1,0 +1,35 @@
+package com.clerk.api.session
+
+import com.clerk.api.Constants.Strategy.BACKUP_CODE
+import com.clerk.api.Constants.Strategy.TOTP
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.passkeys.PasskeyService
+
+/** Verifies the current session by asking the user to re-enter their password. */
+suspend fun Session.verifyWithPassword(
+  password: String
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return attemptFirstFactorVerification(Session.AttemptFirstFactorParams.Password(password))
+}
+
+/** Verifies the current session with a TOTP code. */
+suspend fun Session.verifyWithTOTP(
+  code: String
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return attemptSecondFactorVerification(strategy = TOTP, code = code)
+}
+
+/** Verifies the current session with a backup code. */
+suspend fun Session.verifyWithBackupCode(
+  code: String
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return attemptSecondFactorVerification(strategy = BACKUP_CODE, code = code)
+}
+
+/** Verifies the current session with a passkey via Android Credential Manager. */
+suspend fun Session.verifyWithPasskey(
+  allowedCredentialIds: List<String> = emptyList()
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return PasskeyService.verifySessionWithPasskey(this, allowedCredentialIds)
+}

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationConvenienceExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationConvenienceExtensions.kt
@@ -1,16 +1,78 @@
+@file:Suppress("unused", "TooManyFunctions")
+
 package com.clerk.api.session
 
 import com.clerk.api.Constants.Strategy.BACKUP_CODE
+import com.clerk.api.Constants.Strategy.EMAIL_CODE
+import com.clerk.api.Constants.Strategy.ENTERPRISE_SSO
+import com.clerk.api.Constants.Strategy.PHONE_CODE
 import com.clerk.api.Constants.Strategy.TOTP
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.passkeys.PasskeyService
+import com.clerk.api.sso.RedirectConfiguration
+
+/** Sends a verification code to the email address for first-factor reverification. */
+suspend fun Session.sendEmailCode(
+  emailAddressId: String
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return prepareFirstFactorVerification(strategy = EMAIL_CODE, emailAddressId = emailAddressId)
+}
+
+/** Sends a verification code to the phone number for first-factor reverification. */
+suspend fun Session.sendPhoneCode(
+  phoneNumberId: String
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return prepareFirstFactorVerification(strategy = PHONE_CODE, phoneNumberId = phoneNumberId)
+}
+
+/** Verifies the current session with an email code. */
+suspend fun Session.verifyWithEmailCode(
+  code: String
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return attemptFirstFactorVerification(strategy = EMAIL_CODE, code = code)
+}
+
+/** Verifies the current session with a phone code as a first factor. */
+suspend fun Session.verifyWithPhoneCode(
+  code: String
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return attemptFirstFactorVerification(strategy = PHONE_CODE, code = code)
+}
 
 /** Verifies the current session by asking the user to re-enter their password. */
 suspend fun Session.verifyWithPassword(
   password: String
 ): ClerkResult<SessionVerification, ClerkErrorResponse> {
   return attemptFirstFactorVerification(Session.AttemptFirstFactorParams.Password(password))
+}
+
+/** Starts Enterprise SSO for first-factor reverification. */
+suspend fun Session.startEnterpriseSso(
+  emailAddressId: String? = null,
+  enterpriseConnectionId: String? = null,
+  redirectUrl: String? = null,
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return prepareFirstFactorVerification(
+    strategy = ENTERPRISE_SSO,
+    emailAddressId = emailAddressId,
+    enterpriseConnectionId = enterpriseConnectionId,
+    redirectUrl = redirectUrl ?: RedirectConfiguration.DEFAULT_REDIRECT_URL,
+  )
+}
+
+/** Sends an MFA code to the phone number for second-factor reverification. */
+suspend fun Session.sendMfaPhoneCode(
+  phoneNumberId: String
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return prepareSecondFactorVerification(strategy = PHONE_CODE, phoneNumberId = phoneNumberId)
+}
+
+/** Verifies the current session with a phone code as a second factor. */
+suspend fun Session.verifyWithMfaPhoneCode(
+  code: String
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return attemptSecondFactorVerification(strategy = PHONE_CODE, code = code)
 }
 
 /** Verifies the current session with a TOTP code. */

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationExtensions.kt
@@ -1,0 +1,90 @@
+package com.clerk.api.session
+
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+
+/** Starts an in-session reverification flow. */
+suspend fun Session.startVerification(
+  level: SessionVerification.Level
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return ClerkApi.session.startVerification(
+    sessionId = id,
+    params = Session.StartVerificationParams(level = level.value).toMap(),
+  )
+}
+
+/** Prepares the first factor of an in-session reverification flow. */
+suspend fun Session.prepareFirstFactorVerification(
+  strategy: String,
+  emailAddressId: String? = null,
+  phoneNumberId: String? = null,
+  enterpriseConnectionId: String? = null,
+  redirectUrl: String? = null,
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return prepareFirstFactorVerification(
+    Session.PrepareFirstFactorParams(
+      strategy = strategy,
+      emailAddressId = emailAddressId,
+      phoneNumberId = phoneNumberId,
+      enterpriseConnectionId = enterpriseConnectionId,
+      redirectUrl = redirectUrl,
+    )
+  )
+}
+
+/** Prepares the first factor of an in-session reverification flow. */
+suspend fun Session.prepareFirstFactorVerification(
+  params: Session.PrepareFirstFactorParams
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return ClerkApi.session.prepareFirstFactorVerification(sessionId = id, params = params.toMap())
+}
+
+/** Attempts the first factor of an in-session reverification flow. */
+suspend fun Session.attemptFirstFactorVerification(
+  params: Session.AttemptFirstFactorParams
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return ClerkApi.session.attemptFirstFactorVerification(sessionId = id, params = params.toMap())
+}
+
+/** Attempts the first factor of an in-session reverification flow. */
+suspend fun Session.attemptFirstFactorVerification(
+  strategy: String,
+  code: String? = null,
+  password: String? = null,
+  publicKeyCredential: String? = null,
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  val params =
+    when {
+      password != null -> Session.AttemptFirstFactorParams.Password(password = password)
+      publicKeyCredential != null ->
+        Session.AttemptFirstFactorParams.Passkey(publicKeyCredential = publicKeyCredential)
+      code != null -> Session.AttemptFirstFactorParams.Code(strategy = strategy, code = code)
+      else -> error("One of code, password, or publicKeyCredential is required")
+    }
+
+  return attemptFirstFactorVerification(params)
+}
+
+/** Prepares the second factor of an in-session reverification flow. */
+suspend fun Session.prepareSecondFactorVerification(
+  strategy: String,
+  phoneNumberId: String? = null,
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return ClerkApi.session.prepareSecondFactorVerification(
+    sessionId = id,
+    params =
+      Session.PrepareSecondFactorParams(strategy = strategy, phoneNumberId = phoneNumberId).toMap(),
+  )
+}
+
+/** Attempts the second factor of an in-session reverification flow. */
+suspend fun Session.attemptSecondFactorVerification(
+  strategy: String,
+  code: String,
+): ClerkResult<SessionVerification, ClerkErrorResponse> {
+  return ClerkApi.session.attemptSecondFactorVerification(
+    sessionId = id,
+    params = Session.AttemptSecondFactorParams(strategy = strategy, code = code).toMap(),
+  )
+}

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationExtensions.kt
@@ -15,7 +15,7 @@ suspend fun Session.startVerification(
 }
 
 /** Prepares the first factor of an in-session reverification flow. */
-suspend fun Session.prepareFirstFactorVerification(
+internal suspend fun Session.prepareFirstFactorVerification(
   strategy: String,
   emailAddressId: String? = null,
   phoneNumberId: String? = null,
@@ -34,21 +34,21 @@ suspend fun Session.prepareFirstFactorVerification(
 }
 
 /** Prepares the first factor of an in-session reverification flow. */
-suspend fun Session.prepareFirstFactorVerification(
+internal suspend fun Session.prepareFirstFactorVerification(
   params: Session.PrepareFirstFactorParams
 ): ClerkResult<SessionVerification, ClerkErrorResponse> {
   return ClerkApi.session.prepareFirstFactorVerification(sessionId = id, params = params.toMap())
 }
 
 /** Attempts the first factor of an in-session reverification flow. */
-suspend fun Session.attemptFirstFactorVerification(
+internal suspend fun Session.attemptFirstFactorVerification(
   params: Session.AttemptFirstFactorParams
 ): ClerkResult<SessionVerification, ClerkErrorResponse> {
   return ClerkApi.session.attemptFirstFactorVerification(sessionId = id, params = params.toMap())
 }
 
 /** Attempts the first factor of an in-session reverification flow. */
-suspend fun Session.attemptFirstFactorVerification(
+internal suspend fun Session.attemptFirstFactorVerification(
   strategy: String,
   code: String? = null,
   password: String? = null,
@@ -67,7 +67,7 @@ suspend fun Session.attemptFirstFactorVerification(
 }
 
 /** Prepares the second factor of an in-session reverification flow. */
-suspend fun Session.prepareSecondFactorVerification(
+internal suspend fun Session.prepareSecondFactorVerification(
   strategy: String,
   phoneNumberId: String? = null,
 ): ClerkResult<SessionVerification, ClerkErrorResponse> {
@@ -79,7 +79,7 @@ suspend fun Session.prepareSecondFactorVerification(
 }
 
 /** Attempts the second factor of an in-session reverification flow. */
-suspend fun Session.attemptSecondFactorVerification(
+internal suspend fun Session.attemptSecondFactorVerification(
   strategy: String,
   code: String,
 ): ClerkResult<SessionVerification, ClerkErrorResponse> {

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
@@ -11,11 +11,14 @@ import androidx.credentials.exceptions.NoCredentialException
 import com.clerk.api.Clerk
 import com.clerk.api.credentials.CredentialFlowException
 import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.api.SessionApi
 import com.clerk.api.network.api.SignInApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
+import com.clerk.api.session.SessionVerification
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signin.attemptFirstFactor
 import io.mockk.coEvery
@@ -65,7 +68,9 @@ class PasskeyAuthenticationServiceTest {
     // Mock ClerkApi and its nested objects
     mockkObject(ClerkApi)
     val mockSignInApi = mockk<SignInApi>(relaxed = true)
+    val mockSessionApi = mockk<SessionApi>(relaxed = true)
     every { ClerkApi.signIn } returns mockSignInApi
+    every { ClerkApi.session } returns mockSessionApi
 
     // Set up the mock credential manager in the service
     GoogleCredentialAuthenticationService.setCredentialManager(mockCredentialManager)
@@ -235,5 +240,41 @@ class PasskeyAuthenticationServiceTest {
     // Then
     assertTrue(result is ClerkResult.Failure)
     assertEquals(ClerkResult.Failure.ErrorType.UNKNOWN, (result as ClerkResult.Failure).errorType)
+  }
+
+  @Test
+  fun `verifySessionWithPasskey returns clear error when prepared verification nonce is missing`() =
+    runTest {
+      val session = testSession()
+      val preparedVerification =
+        SessionVerification(
+          id = "ver_123",
+          status = SessionVerification.Status.NEEDS_FIRST_FACTOR,
+          level = SessionVerification.Level.FIRST_FACTOR,
+        )
+
+      coEvery {
+        ClerkApi.session.prepareFirstFactorVerification("sess_123", mapOf("strategy" to "passkey"))
+      } returns ClerkResult.success(preparedVerification)
+
+      val result = GoogleCredentialAuthenticationService.verifySessionWithPasskey(session)
+
+      assertTrue(result is ClerkResult.Failure)
+      val failure = result as ClerkResult.Failure
+      assertEquals(ClerkResult.Failure.ErrorType.UNKNOWN, failure.errorType)
+      assertTrue(failure.throwable is IllegalStateException)
+      assertEquals("Missing nonce in prepared verification", failure.throwable?.message)
+      coVerify(exactly = 0) { mockCredentialManager.getCredential(any(), any()) }
+    }
+
+  private fun testSession(): Session {
+    return Session(
+      id = "sess_123",
+      status = Session.SessionStatus.ACTIVE,
+      expireAt = 0L,
+      lastActiveAt = 0L,
+      createdAt = 0L,
+      updatedAt = 0L,
+    )
   }
 }

--- a/source/api/src/test/java/com/clerk/api/session/SessionVerificationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/SessionVerificationTest.kt
@@ -193,8 +193,6 @@ class SessionVerificationTest {
     val sessionApi = mockk<SessionApi>()
     val session = testSession()
     val verification = testVerification(status = SessionVerification.Status.NEEDS_FIRST_FACTOR)
-    val originalApplicationId = Clerk.applicationId
-    Clerk.applicationId = "com.clerk.test"
     val params =
       mapOf(
         "strategy" to "enterprise_sso",
@@ -203,23 +201,18 @@ class SessionVerificationTest {
         "redirect_url" to "clerk://com.clerk.test.callback",
       )
     mockkObject(ClerkApi)
+    mockkObject(Clerk)
     every { ClerkApi.session } returns sessionApi
+    every { Clerk.applicationId } returns "com.clerk.test"
     coEvery { sessionApi.prepareFirstFactorVerification("sess_123", params) } returns
       ClerkResult.success(verification)
 
-    try {
-      val result =
-        session.startEnterpriseSso(
-          emailAddressId = "idn_email",
-          enterpriseConnectionId = "econn_123",
-        )
+    val result =
+      session.startEnterpriseSso(emailAddressId = "idn_email", enterpriseConnectionId = "econn_123")
 
-      assertTrue(result is ClerkResult.Success)
-      assertSame(verification, (result as ClerkResult.Success).value)
-      coVerify(exactly = 1) { sessionApi.prepareFirstFactorVerification("sess_123", params) }
-    } finally {
-      Clerk.applicationId = originalApplicationId
-    }
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.prepareFirstFactorVerification("sess_123", params) }
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/session/SessionVerificationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/SessionVerificationTest.kt
@@ -1,0 +1,190 @@
+package com.clerk.api.session
+
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.api.SessionApi
+import com.clerk.api.network.serialization.ClerkResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionVerificationTest {
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `session verification decodes supported factor metadata`() {
+    val json =
+      """
+      {
+        "id": "ver_123",
+        "status": "needs_first_factor",
+        "level": "first_factor",
+        "supported_first_factors": [
+          {
+            "strategy": "enterprise_sso",
+            "enterprise_connection_id": "econn_123",
+            "enterprise_connection_name": "Acme"
+          }
+        ],
+        "supported_second_factors": [
+          {
+            "strategy": "phone_code",
+            "phone_number_id": "idn_123",
+            "safe_identifier": "+15555550123",
+            "primary": true,
+            "default": true
+          }
+        ]
+      }
+      """
+        .trimIndent()
+
+    val verification = ClerkApi.json.decodeFromString<SessionVerification>(json)
+    val firstFactor = verification.supportedFirstFactors!!.first()
+    val secondFactor = verification.supportedSecondFactors!!.first()
+
+    assertEquals(SessionVerification.Status.NEEDS_FIRST_FACTOR, verification.status)
+    assertEquals(SessionVerification.Level.FIRST_FACTOR, verification.level)
+    assertEquals("enterprise_sso", firstFactor.strategy)
+    assertEquals("econn_123", firstFactor.enterpriseConnectionId)
+    assertEquals("Acme", firstFactor.enterpriseConnectionName)
+    assertEquals("phone_code", secondFactor.strategy)
+    assertEquals("idn_123", secondFactor.phoneNumberId)
+    assertEquals("+15555550123", secondFactor.safeIdentifier)
+    assertEquals(true, secondFactor.primary)
+    assertEquals(true, secondFactor.default)
+  }
+
+  @Test
+  fun `start verification forwards level to session api`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.NEEDS_FIRST_FACTOR)
+    val params = mapOf("level" to "first_factor")
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.startVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    val result = session.startVerification(SessionVerification.Level.FIRST_FACTOR)
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.startVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `prepare first factor forwards enterprise sso params to session api`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.NEEDS_FIRST_FACTOR)
+    val params =
+      mapOf(
+        "strategy" to "enterprise_sso",
+        "email_address_id" to "idn_email",
+        "enterprise_connection_id" to "econn_123",
+        "redirect_url" to "clerk://callback",
+      )
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.prepareFirstFactorVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    val result =
+      session.prepareFirstFactorVerification(
+        strategy = "enterprise_sso",
+        emailAddressId = "idn_email",
+        enterpriseConnectionId = "econn_123",
+        redirectUrl = "clerk://callback",
+      )
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.prepareFirstFactorVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `verify with password attempts first factor`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.COMPLETE)
+    val params = mapOf("password" to "hunter2", "strategy" to "password")
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.attemptFirstFactorVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    val result = session.verifyWithPassword("hunter2")
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.attemptFirstFactorVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `verify with totp attempts second factor`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.COMPLETE)
+    val params = mapOf("strategy" to "totp", "code" to "123456")
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.attemptSecondFactorVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    val result = session.verifyWithTOTP("123456")
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.attemptSecondFactorVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `verify with backup code attempts second factor`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.COMPLETE)
+    val params = mapOf("strategy" to "backup_code", "code" to "abcdef")
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.attemptSecondFactorVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    val result = session.verifyWithBackupCode("abcdef")
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.attemptSecondFactorVerification("sess_123", params) }
+  }
+
+  private fun testSession(): Session {
+    return Session(
+      id = "sess_123",
+      status = Session.SessionStatus.ACTIVE,
+      expireAt = 0L,
+      lastActiveAt = 0L,
+      createdAt = 0L,
+      updatedAt = 0L,
+    )
+  }
+
+  private fun testVerification(status: SessionVerification.Status): SessionVerification {
+    return SessionVerification(
+      id = "ver_123",
+      status = status,
+      level = SessionVerification.Level.FIRST_FACTOR,
+    )
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/session/SessionVerificationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/SessionVerificationTest.kt
@@ -1,8 +1,10 @@
 package com.clerk.api.session
 
+import com.clerk.api.Clerk
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.api.SessionApi
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.passkeys.PasskeyService
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -86,7 +88,79 @@ class SessionVerificationTest {
   }
 
   @Test
-  fun `prepare first factor forwards enterprise sso params to session api`() = runTest {
+  fun `send email code prepares email first factor`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.NEEDS_FIRST_FACTOR)
+    val params = mapOf("strategy" to "email_code", "email_address_id" to "idn_email")
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.prepareFirstFactorVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    val result = session.sendEmailCode(emailAddressId = "idn_email")
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.prepareFirstFactorVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `send phone code prepares phone first factor`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.NEEDS_FIRST_FACTOR)
+    val params = mapOf("strategy" to "phone_code", "phone_number_id" to "idn_phone")
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.prepareFirstFactorVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    val result = session.sendPhoneCode(phoneNumberId = "idn_phone")
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.prepareFirstFactorVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `verify with email code attempts first factor`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.COMPLETE)
+    val params = mapOf("strategy" to "email_code", "code" to "123456")
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.attemptFirstFactorVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    val result = session.verifyWithEmailCode("123456")
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.attemptFirstFactorVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `verify with phone code attempts first factor`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.COMPLETE)
+    val params = mapOf("strategy" to "phone_code", "code" to "123456")
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.attemptFirstFactorVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    val result = session.verifyWithPhoneCode("123456")
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.attemptFirstFactorVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `start enterprise sso prepares first factor`() = runTest {
     val sessionApi = mockk<SessionApi>()
     val session = testSession()
     val verification = testVerification(status = SessionVerification.Status.NEEDS_FIRST_FACTOR)
@@ -103,8 +177,7 @@ class SessionVerificationTest {
       ClerkResult.success(verification)
 
     val result =
-      session.prepareFirstFactorVerification(
-        strategy = "enterprise_sso",
+      session.startEnterpriseSso(
         emailAddressId = "idn_email",
         enterpriseConnectionId = "econn_123",
         redirectUrl = "clerk://callback",
@@ -113,6 +186,40 @@ class SessionVerificationTest {
     assertTrue(result is ClerkResult.Success)
     assertSame(verification, (result as ClerkResult.Success).value)
     coVerify(exactly = 1) { sessionApi.prepareFirstFactorVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `start enterprise sso uses default redirect url`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.NEEDS_FIRST_FACTOR)
+    val originalApplicationId = Clerk.applicationId
+    Clerk.applicationId = "com.clerk.test"
+    val params =
+      mapOf(
+        "strategy" to "enterprise_sso",
+        "email_address_id" to "idn_email",
+        "enterprise_connection_id" to "econn_123",
+        "redirect_url" to "clerk://com.clerk.test.callback",
+      )
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.prepareFirstFactorVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    try {
+      val result =
+        session.startEnterpriseSso(
+          emailAddressId = "idn_email",
+          enterpriseConnectionId = "econn_123",
+        )
+
+      assertTrue(result is ClerkResult.Success)
+      assertSame(verification, (result as ClerkResult.Success).value)
+      coVerify(exactly = 1) { sessionApi.prepareFirstFactorVerification("sess_123", params) }
+    } finally {
+      Clerk.applicationId = originalApplicationId
+    }
   }
 
   @Test
@@ -131,6 +238,58 @@ class SessionVerificationTest {
     assertTrue(result is ClerkResult.Success)
     assertSame(verification, (result as ClerkResult.Success).value)
     coVerify(exactly = 1) { sessionApi.attemptFirstFactorVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `send mfa phone code prepares second factor`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.NEEDS_SECOND_FACTOR)
+    val params = mapOf("strategy" to "phone_code", "phone_number_id" to "idn_phone")
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.prepareSecondFactorVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    val result = session.sendMfaPhoneCode(phoneNumberId = "idn_phone")
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.prepareSecondFactorVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `verify with mfa phone code attempts second factor`() = runTest {
+    val sessionApi = mockk<SessionApi>()
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.COMPLETE)
+    val params = mapOf("strategy" to "phone_code", "code" to "123456")
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+    coEvery { sessionApi.attemptSecondFactorVerification("sess_123", params) } returns
+      ClerkResult.success(verification)
+
+    val result = session.verifyWithMfaPhoneCode("123456")
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { sessionApi.attemptSecondFactorVerification("sess_123", params) }
+  }
+
+  @Test
+  fun `verify with passkey delegates to passkey service`() = runTest {
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.COMPLETE)
+    val allowedCredentialIds = listOf("credential_123")
+    mockkObject(PasskeyService)
+    coEvery { PasskeyService.verifySessionWithPasskey(session, allowedCredentialIds) } returns
+      ClerkResult.success(verification)
+
+    val result = session.verifyWithPasskey(allowedCredentialIds = allowedCredentialIds)
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { PasskeyService.verifySessionWithPasskey(session, allowedCredentialIds) }
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add `SessionVerification` plus session reverification APIs for start, prepare, and attempt flows
- Extend `Session` with reverification convenience methods, including password, TOTP, backup code, and passkey paths
- Add the new `/client/sessions/{id}/verify...` endpoints and factor metadata needed by the flow

## Testing
- Added unit coverage for session verification serialization and API forwarding
- `:source:api:test` passed
- `:source:api:spotlessCheck` passed
- `:source:api:detekt` passed