### PR TITLE
Use active sessions for security devices and tighten spacing

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/userprofile/security/UserProfileSecurityViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/security/UserProfileSecurityViewModel.kt
@@ -6,7 +6,7 @@ import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
 import com.clerk.api.session.Session
-import com.clerk.api.user.allSessions
+import com.clerk.api.user.activeSessions
 import com.clerk.ui.core.common.guardUser
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,7 +26,7 @@ internal class UserProfileSecurityViewModel : ViewModel() {
     guardUser({}) { user ->
       viewModelScope.launch {
         user
-          .allSessions()
+          .activeSessions()
           .onSuccess { _state.value = State.Success(it) }
           .onFailure { _state.value = State.Error(it.errorMessage) }
       }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/security/device/AllDevicesViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/security/device/AllDevicesViewModel.kt
@@ -7,7 +7,7 @@ import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
 import com.clerk.api.session.Session
 import com.clerk.api.session.isThisDevice
-import com.clerk.api.user.allSessions
+import com.clerk.api.user.activeSessions
 import com.clerk.ui.core.common.guardUser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,15 +21,15 @@ internal class AllDevicesViewModel : ViewModel() {
   val state = _state.asStateFlow()
 
   init {
-    allSessions()
+    activeSessions()
   }
 
-  fun allSessions() {
+  fun activeSessions() {
     guardUser(userDoesNotExist = { _state.value = State.Error("User does not exist") }) { user ->
       viewModelScope.launch(Dispatchers.IO) {
         _state.value = State.Loading
         user
-          .allSessions()
+          .activeSessions()
           .onSuccess {
             val sortedSessions = it.sortedForDisplay()
             withContext(Dispatchers.Main) { _state.value = State.Success(sortedSessions) }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/security/device/DeviceViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/security/device/DeviceViewModel.kt
@@ -8,7 +8,7 @@ import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
 import com.clerk.api.session.Session
 import com.clerk.api.session.revoke
-import com.clerk.api.user.allSessions
+import com.clerk.api.user.activeSessions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -25,7 +25,7 @@ internal class DeviceViewModel : ViewModel() {
       session
         .revoke()
         .onSuccess {
-          Clerk.user?.allSessions()
+          Clerk.user?.activeSessions()
           withContext(Dispatchers.Main) { _state.value = State.Success }
         }
         .onFailure { withContext(Dispatchers.Main) { _state.value = State.Error(it.errorMessage) } }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/security/device/UserProfileDeviceSection.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/security/device/UserProfileDeviceSection.kt
@@ -1,7 +1,6 @@
 package com.clerk.ui.userprofile.security.device
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -16,7 +15,6 @@ import com.clerk.ui.R
 import com.clerk.ui.core.dimens.dp16
 import com.clerk.ui.core.dimens.dp24
 import com.clerk.ui.core.extensions.withMediumWeight
-import com.clerk.ui.core.spacers.Spacers
 import com.clerk.ui.theme.ClerkMaterialTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -35,28 +33,22 @@ private fun UserProfileDevicesSectionImpl(
   modifier: Modifier = Modifier,
 ) {
   ClerkMaterialTheme {
-    Box(
+    Column(
       modifier =
         Modifier.fillMaxWidth()
           .background(color = ClerkMaterialTheme.colors.background)
-          .padding(dp16)
+          .padding(top = dp16)
           .then(modifier)
     ) {
+      Text(
+        modifier = Modifier.padding(horizontal = dp24),
+        text = stringResource(R.string.active_devices).uppercase(),
+        color = ClerkMaterialTheme.colors.mutedForeground,
+        style = ClerkMaterialTheme.typography.bodySmall.withMediumWeight(),
+      )
       Column(modifier = Modifier.fillMaxWidth()) {
-        Text(
-          modifier = Modifier.padding(horizontal = dp24),
-          text = stringResource(R.string.active_devices).uppercase(),
-          color = ClerkMaterialTheme.colors.mutedForeground,
-          style = ClerkMaterialTheme.typography.bodySmall.withMediumWeight(),
-        )
-        Spacers.Vertical.Spacer16()
-        Column(modifier = Modifier.fillMaxWidth()) {
-          devices.forEachIndexed { index, session ->
-            UserProfileDeviceRow(session = session, onError = {})
-            if (index < devices.lastIndex) {
-              Spacers.Vertical.Spacer16()
-            }
-          }
+        devices.forEach { session ->
+          UserProfileDeviceRow(session = session, onError = {})
         }
       }
     }

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/UserProfileSecurityViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/UserProfileSecurityViewModelTest.kt
@@ -7,7 +7,7 @@ import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
 import com.clerk.api.user.User
-import com.clerk.api.user.allSessions
+import com.clerk.api.user.activeSessions
 import com.clerk.ui.userprofile.MainDispatcherRule
 import io.mockk.coEvery
 import io.mockk.every
@@ -46,7 +46,7 @@ class UserProfileSecurityViewModelTest {
     val user = mockk<User>()
     val sessions = listOf(mockk<Session>(), mockk())
     every { Clerk.user } returns user
-    coEvery { user.allSessions() } returns ClerkResult.success(sessions)
+    coEvery { user.activeSessions() } returns ClerkResult.success(sessions)
 
     val viewModel = UserProfileSecurityViewModel()
     viewModel.state.test {
@@ -62,7 +62,7 @@ class UserProfileSecurityViewModelTest {
     val user = mockk<User>()
     every { Clerk.user } returns user
     val error = ClerkErrorResponse(errors = listOf(Error(longMessage = "fail")))
-    coEvery { user.allSessions() } returns ClerkResult.Failure(error)
+    coEvery { user.activeSessions() } returns ClerkResult.Failure(error)
 
     val viewModel = UserProfileSecurityViewModel()
     viewModel.state.test {

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/device/AllDevicesViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/device/AllDevicesViewModelTest.kt
@@ -10,7 +10,7 @@ import com.clerk.api.session.Session.SessionStatus
 import com.clerk.api.session.SessionActivity
 import com.clerk.api.session.isThisDevice
 import com.clerk.api.user.User
-import com.clerk.api.user.allSessions
+import com.clerk.api.user.activeSessions
 import com.clerk.ui.userprofile.MainDispatcherRule
 import io.mockk.coEvery
 import io.mockk.every
@@ -48,7 +48,7 @@ class AllDevicesViewModelTest {
   }
 
   @Test
-  fun allSessions_success_sortsDevices() = runTest {
+  fun activeSessions_success_sortsDevices() = runTest {
     val user = mockk<User>()
     val currentSession = session(id = "current", lastActiveAt = 100L)
     val otherRecent = session(id = "other", lastActiveAt = 200L)
@@ -59,7 +59,7 @@ class AllDevicesViewModelTest {
     every { currentSession.isThisDevice } returns true
     every { otherRecent.isThisDevice } returns false
     every { older.isThisDevice } returns false
-    coEvery { user.allSessions() } returns
+    coEvery { user.activeSessions() } returns
       ClerkResult.success(listOf(older, otherRecent, currentSession))
 
     val viewModel = AllDevicesViewModel()
@@ -73,11 +73,11 @@ class AllDevicesViewModelTest {
   }
 
   @Test
-  fun allSessions_failure_setsErrorState() = runTest {
+  fun activeSessions_failure_setsErrorState() = runTest {
     val user = mockk<User>()
     every { Clerk.user } returns user
     val error = ClerkErrorResponse(errors = listOf(Error(longMessage = "bad")))
-    coEvery { user.allSessions() } returns ClerkResult.Failure(error)
+    coEvery { user.activeSessions() } returns ClerkResult.Failure(error)
 
     val viewModel = AllDevicesViewModel()
     viewModel.state.test {

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/device/DeviceViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/device/DeviceViewModelTest.kt
@@ -8,7 +8,7 @@ import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
 import com.clerk.api.session.revoke
 import com.clerk.api.user.User
-import com.clerk.api.user.allSessions
+import com.clerk.api.user.activeSessions
 import com.clerk.ui.userprofile.MainDispatcherRule
 import io.mockk.coEvery
 import io.mockk.every
@@ -50,7 +50,7 @@ class DeviceViewModelTest {
     val user = mockk<User>()
     every { Clerk.user } returns user
     coEvery { session.revoke() } returns ClerkResult.success(session)
-    coEvery { user.allSessions() } returns ClerkResult.success(emptyList())
+    coEvery { user.activeSessions() } returns ClerkResult.success(emptyList())
 
     val viewModel = DeviceViewModel()
     viewModel.state.test {

--- a/workbench/src/main/java/com/clerk/workbench/UiActivity2.kt
+++ b/workbench/src/main/java/com/clerk/workbench/UiActivity2.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.clerk.ui.organizationlist.OrganizationListView
 import com.clerk.ui.organizationswitcher.OrganizationSwitcher
+import com.clerk.ui.userbutton.UserButton
 import com.clerk.workbench.ui.theme.Background
 import com.clerk.workbench.ui.theme.BackgroundDark
 import com.clerk.workbench.ui.theme.WorkbenchTheme
@@ -39,7 +40,7 @@ class UiActivity2 : ComponentActivity() {
               modifier =
                 Modifier.background(color = backgroundColor).fillMaxSize().statusBarsPadding()
             ) {
-              OrganizationSwitcher()
+              UserButton()
             }
           }
         }


### PR DESCRIPTION
## Summary
- Switch the user profile security/device flows to `activeSessions()` so device rows are backed by the activity-enriched session endpoint.
- Tighten the active devices section layout to match the spacing pattern used by the other profile sections.
- Update the focused unit tests to cover the new data source.

## Testing
- `./gradlew :source:ui:testDebugUnitTest --tests "com.clerk.ui.userprofile.security.UserProfileSecurityViewModelTest" --tests "com.clerk.ui.userprofile.security.device.AllDevicesViewModelTest" --tests "com.clerk.ui.userprofile.security.device.DeviceViewModelTest"`
- `./gradlew :source:ui:compileDebugKotlin :source:ui:testDebugUnitTest --tests "com.clerk.ui.userprofile.security.UserProfileSecurityViewModelTest" --tests "com.clerk.ui.userprofile.security.device.AllDevicesViewModelTest" --tests "com.clerk.ui.userprofile.security.device.DeviceViewModelTest"`