### PR TITLE
fix(signup): skip optional mobile signup fields

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
@@ -562,13 +562,19 @@ data class SignUp(
 /**
  * Helper property to get the first field that needs to be collected.
  *
- * This property returns the name of the first field in the `missingFields` list, sorted by
- * priority. The priority order is defined by [SignUp.fieldPriority].
+ * This property returns the name of the first required field in the `missingFields` list, sorted by
+ * priority. Optional missing fields are intentionally skipped by mobile sign-up flows. The priority
+ * order is defined by [SignUp.fieldPriority].
  *
- * @return The name of the first field to collect, or `null` if there are no missing fields.
+ * @return The name of the first required field to collect, or `null` if there are no required
+ *   missing fields.
  */
 val SignUp.firstFieldToCollect: String?
-  get() = missingFields.sortedByPriority(SignUp.fieldPriority).firstOrNull()
+  get() =
+    missingFields
+      .filter { requiredFields.contains(it) }
+      .sortedByPriority(SignUp.fieldPriority)
+      .firstOrNull()
 
 /**
  * Helper property to get the first field that needs to be verified.

--- a/source/api/src/test/java/com/clerk/api/signup/SignUpFieldCollectionTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signup/SignUpFieldCollectionTest.kt
@@ -1,0 +1,49 @@
+package com.clerk.api.signup
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SignUpFieldCollectionTest {
+
+  @Test
+  fun `firstFieldToCollect ignores optional missing fields`() {
+    val signUp =
+      signUp(
+        requiredFields = listOf("email_address", "password"),
+        optionalFields = listOf("first_name", "last_name"),
+        missingFields = listOf("first_name", "password", "last_name"),
+      )
+
+    assertEquals("password", signUp.firstFieldToCollect)
+  }
+
+  @Test
+  fun `firstFieldToCollect returns null when only optional fields are missing`() {
+    val signUp =
+      signUp(
+        requiredFields = listOf("email_address"),
+        optionalFields = listOf("first_name", "last_name"),
+        missingFields = listOf("first_name", "last_name"),
+      )
+
+    assertNull(signUp.firstFieldToCollect)
+  }
+
+  private fun signUp(
+    requiredFields: List<String>,
+    optionalFields: List<String>,
+    missingFields: List<String>,
+  ): SignUp {
+    return SignUp(
+      id = "sua_123",
+      status = SignUp.Status.MISSING_REQUIREMENTS,
+      requiredFields = requiredFields,
+      optionalFields = optionalFields,
+      missingFields = missingFields,
+      unverifiedFields = emptyList(),
+      verifications = emptyMap(),
+      passwordEnabled = false,
+    )
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/CompleteProfileViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/CompleteProfileViewModel.kt
@@ -63,5 +63,5 @@ internal fun SignUp.completeProfileUpdateParams(
 }
 
 internal fun SignUp.supportsField(field: String): Boolean {
-  return requiredFields.contains(field) || optionalFields.contains(field)
+  return requiredFields.contains(field)
 }

--- a/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
@@ -81,9 +81,12 @@ private fun SignUpCompleteProfileImpl(
   val firstEnabled = firstNameEnabled || signUp?.supportsField(FIRST_NAME_FIELD) == true
   val lastEnabled = lastNameEnabled || signUp?.supportsField(LAST_NAME_FIELD) == true
 
-  // Check if legal_accepted is in missing fields
+  // Check if legal_accepted is required and missing. Mobile signup intentionally skips optional
+  // fields.
   val legalConsentRequired =
-    legalConsentMissing || (signUp?.missingFields?.contains(LEGAL_ACCEPTED_FIELD) == true)
+    legalConsentMissing ||
+      (signUp?.requiredFields?.contains(LEGAL_ACCEPTED_FIELD) == true &&
+        signUp.missingFields.contains(LEGAL_ACCEPTED_FIELD))
   val termsUrl = Clerk.termsUrl
   val privacyPolicyUrl = Clerk.privacyPolicyUrl
   val hasLegalUrls = termsUrl != null || privacyPolicyUrl != null

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthStateSignUpRoutingTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthStateSignUpRoutingTest.kt
@@ -104,18 +104,37 @@ class AuthStateSignUpRoutingTest {
     }
   }
 
+  @Test
+  fun setToStepForStatusDoesNotCollectOptionalMissingFields() {
+    val signUp =
+      signUp(
+        verifications = emptyMap(),
+        requiredFields = listOf("email_address"),
+        optionalFields = listOf("first_name", "last_name"),
+        missingFields = listOf("first_name", "last_name"),
+        unverifiedFields = emptyList(),
+      )
+
+    authState.setToStepForStatus(signUp) {}
+
+    verify(exactly = 0) { backStack.add(any()) }
+  }
+
   private fun signUp(
     verifications: Map<String, Verification?>,
     missingFields: List<String> = emptyList(),
+    requiredFields: List<String> = listOf("email_address", "password"),
+    optionalFields: List<String> = emptyList(),
+    unverifiedFields: List<String> = listOf("email_address"),
   ): SignUp {
     every { backStack.add(any()) } returns true
     return SignUp(
       id = "sign_up_123",
       status = SignUp.Status.MISSING_REQUIREMENTS,
-      requiredFields = listOf("email_address", "password"),
-      optionalFields = emptyList(),
+      requiredFields = requiredFields,
+      optionalFields = optionalFields,
       missingFields = missingFields,
-      unverifiedFields = listOf("email_address"),
+      unverifiedFields = unverifiedFields,
       verifications = verifications,
       emailAddress = "sam@clerk.dev",
       passwordEnabled = false,

--- a/source/ui/src/test/java/com/clerk/ui/signup/completeprofile/CompleteProfileViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signup/completeprofile/CompleteProfileViewModelTest.kt
@@ -24,9 +24,12 @@ class CompleteProfileViewModelTest {
   }
 
   @Test
-  fun `completeProfileUpdateParams keeps supported non blank name fields`() {
+  fun `completeProfileUpdateParams keeps required non blank name fields`() {
     val signUp =
-      signUp(requiredFields = listOf(FIRST_NAME_FIELD), optionalFields = listOf(LAST_NAME_FIELD))
+      signUp(
+        requiredFields = listOf(FIRST_NAME_FIELD, LAST_NAME_FIELD),
+        optionalFields = emptyList(),
+      )
 
     val params =
       signUp.completeProfileUpdateParams(
@@ -37,6 +40,26 @@ class CompleteProfileViewModelTest {
 
     assertEquals("Sam", params.firstName)
     assertEquals("McTest", params.lastName)
+    assertNull(params.legalAccepted)
+  }
+
+  @Test
+  fun `completeProfileUpdateParams omits optional name fields`() {
+    val signUp =
+      signUp(
+        requiredFields = emptyList(),
+        optionalFields = listOf(FIRST_NAME_FIELD, LAST_NAME_FIELD),
+      )
+
+    val params =
+      signUp.completeProfileUpdateParams(
+        firstName = "Sam",
+        lastName = "McTest",
+        legalAccepted = null,
+      )
+
+    assertNull(params.firstName)
+    assertNull(params.lastName)
     assertNull(params.legalAccepted)
   }
 


### PR DESCRIPTION
### Motivation
- Mobile sign-up flows should not collect optional fields to avoid adding extra, unnecessary steps during the stepped mobile sign-up experience. 
- Ensure the SDK only advances to required missing fields and only submits required profile fields so mobile behavior intentionally differs from web. 

### Description
- Limit `SignUp.firstFieldToCollect` to only consider fields that are in `requiredFields` and sort by `SignUp.fieldPriority`. 
- Change `SignUp.supportsField` so it returns `true` only for `requiredFields` (so complete-profile submission ignores optional fields). 
- Update `SignUpCompleteProfileView` legal-consent check to require the field be both required and missing before showing consent UI. 
- Add regression tests: `SignUpFieldCollectionTest` and updates to `AuthStateSignUpRoutingTest` and `CompleteProfileViewModelTest` to cover optional-field behavior and complete-profile params. 

### Testing
- Ran formatting: `./gradlew spotlessApply` and `./gradlew spotlessCheck` completed successfully. 
- Static analysis: `./gradlew detekt` / module `:source:api:detekt :source:ui:detekt` failed in this environment due to missing Java toolchain configuration. 
- Unit tests for the new/updated cases could not be run here: `:source:api:testDebugUnitTest` and `:source:ui:testDebugUnitTest` were blocked due to missing Android SDK (`ANDROID_HOME`) and required Java toolchain (Java 21) in the runner. 
- Added and committed tests for local/CI execution; they should pass in CI where the Android SDK and Java toolchains are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a206acebc3c8322b83459139764ee03)