### PR TITLE
Run Expo PR automation from Android release workflow

### DIFF
--- a/.github/workflows/expo-android-release-pr.yml
+++ b/.github/workflows/expo-android-release-pr.yml
@@ -1,20 +1,31 @@
 name: Open Expo Android Release PR
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       clerk_android_version:
         description: "clerk-android version to pin in @clerk/expo. Defaults to gradle.properties."
         required: false
         type: string
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Release tag that published clerk-android."
+        required: true
+        type: string
+      release_url:
+        description: "URL for the clerk-android release."
+        required: true
+        type: string
+    secrets:
+      CLERK_JAVASCRIPT_RELEASE_TOKEN:
+        required: true
 
 permissions:
   contents: read
 
 concurrency:
-  group: expo-android-release-pr-${{ github.event.release.tag_name || github.event.inputs.clerk_android_version || github.run_id }}
+  group: expo-android-release-pr-${{ inputs.release_tag || inputs.clerk_android_version || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -24,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout release source
-        if: github.event_name == 'release'
+        if: github.event_name == 'workflow_call'
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.release_tag }}
           path: android-release
 
       - name: Checkout release source
@@ -40,9 +51,9 @@ jobs:
         id: release
         working-directory: android-release
         env:
-          INPUT_VERSION: ${{ github.event.inputs.clerk_android_version }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
+          INPUT_VERSION: ${{ inputs.clerk_android_version }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_URL: ${{ inputs.release_url }}
         run: |
           set -euo pipefail
 
@@ -55,6 +66,12 @@ jobs:
           fi
 
           if [ -n "${RELEASE_TAG:-}" ]; then
+            if [[ ! "$RELEASE_TAG" =~ ^v ]]; then
+              echo "::notice::Skipping Expo PR because release ${RELEASE_TAG} is not a clerk-android SDK release."
+              echo "should_open=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
             version="${RELEASE_TAG#v}"
             release_url="${RELEASE_URL:-https://github.com/clerk/clerk-android/releases/tag/${RELEASE_TAG}}"
 

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -239,3 +239,13 @@ jobs:
             --header "Content-type: application/json" \
             --data "$PAYLOAD" \
             "$SLACK_WEBHOOK_URL"
+
+  open-expo-android-release-pr:
+    needs: publish
+    if: needs.publish.result == 'success' && (github.event_name == 'release' || (github.event.inputs.publish_api == 'true' && github.event.inputs.publish_ui == 'true'))
+    uses: ./.github/workflows/expo-android-release-pr.yml
+    with:
+      release_tag: ${{ needs.publish.outputs.tag_name }}
+      release_url: ${{ needs.publish.outputs.release_url }}
+    secrets:
+      CLERK_JAVASCRIPT_RELEASE_TOKEN: ${{ secrets.CLERK_JAVASCRIPT_RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary
- Make the Expo release PR workflow reusable via `workflow_call` so it can be invoked from the Android release pipeline.
- Add a post-publish job in `manual-release.yml` that opens or updates the Expo PR after successful SDK releases.
- Skip Expo PR creation for non-SDK release tags.

## Testing
- Not run (not requested)
- Validated the workflow structure with `actionlint` against the updated GitHub Actions files