### PR TITLE
feat(api): emit client changed auth event

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -12,6 +12,8 @@ import com.clerk.api.Clerk.session
 import com.clerk.api.Clerk.user
 import com.clerk.api.attestation.DeviceAttestationHelper
 import com.clerk.api.auth.Auth
+import com.clerk.api.client.ClientChanged
+import com.clerk.api.client.ClientEvent
 import com.clerk.api.configuration.ConfigurationManager
 import com.clerk.api.configuration.PublishableKeyHelper
 import com.clerk.api.externalaccount.ExternalAccountService
@@ -40,8 +42,11 @@ import com.clerk.api.ui.ClerkTheme
 import com.clerk.api.user.User
 import com.clerk.sdk.BuildConfig
 import java.lang.ref.WeakReference
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
@@ -155,6 +160,15 @@ object Clerk {
   /** Internal property to check if the client has been initialized. */
   internal val clientInitialized: Boolean
     get() = ::client.isInitialized
+
+  private val _clientEvents = MutableSharedFlow<ClientEvent>(extraBufferCapacity = 64)
+
+  /**
+   * Flow of client events.
+   *
+   * Subscribe to this flow to receive notifications about client state changes.
+   */
+  val clientEvents: Flow<ClientEvent> = _clientEvents.asSharedFlow()
 
   /**
    * Reactive state indicating whether the Clerk SDK has completed initialization.
@@ -882,7 +896,14 @@ object Clerk {
     }
 
     if (previousClient != updatedClient) {
-      auth.send(com.clerk.api.auth.AuthEvent.ClientChanged(updatedClient))
+      sendClientEvent(ClientChanged(updatedClient))
+    }
+  }
+
+  private fun sendClientEvent(event: ClientEvent) {
+    val emitted = _clientEvents.tryEmit(event)
+    if (!emitted) {
+      ClerkLog.w("Dropped client event due to backpressure: ${event::class.simpleName}")
     }
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -870,12 +870,19 @@ object Clerk {
    * @param client The updated client configuration.
    */
   internal fun updateClient(client: Client) {
-    this.client = client.withResolvedActiveSession(previousSession = _session.value)
+    val previousClient = if (::client.isInitialized) this.client else null
+    val updatedClient = client.withResolvedActiveSession(previousSession = _session.value)
+
+    this.client = updatedClient
     // Only update state if flows are initialized (not during static initialization)
     try {
       updateSessionAndUserState()
     } catch (e: Exception) {
       ClerkLog.e("${e.message}")
+    }
+
+    if (previousClient != updatedClient) {
+      auth.send(com.clerk.api.auth.AuthEvent.ClientChanged(updatedClient))
     }
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/auth/AuthEvent.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/AuthEvent.kt
@@ -1,5 +1,6 @@
 package com.clerk.api.auth
 
+import com.clerk.api.network.model.client.Client
 import com.clerk.api.session.Session
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
@@ -21,6 +22,17 @@ sealed interface AuthEvent {
 
   /** Emitted when a user signs out. */
   data object SignedOut : AuthEvent
+
+  /**
+   * Emitted when the current client changes.
+   *
+   * This event fires whenever Clerk receives a new [Client] value that differs from the previously
+   * stored client. Because [Client] is a data class, nested changes such as a session or user
+   * property update also trigger this event.
+   *
+   * @property client The updated client.
+   */
+  data class ClientChanged(val client: Client) : AuthEvent
 
   /**
    * Emitted when the current session changes.

--- a/source/api/src/main/kotlin/com/clerk/api/auth/AuthEvent.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/AuthEvent.kt
@@ -1,6 +1,5 @@
 package com.clerk.api.auth
 
-import com.clerk.api.network.model.client.Client
 import com.clerk.api.session.Session
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
@@ -22,17 +21,6 @@ sealed interface AuthEvent {
 
   /** Emitted when a user signs out. */
   data object SignedOut : AuthEvent
-
-  /**
-   * Emitted when the current client changes.
-   *
-   * This event fires whenever Clerk receives a new [Client] value that differs from the previously
-   * stored client. Because [Client] is a data class, nested changes such as a session or user
-   * property update also trigger this event.
-   *
-   * @property client The updated client.
-   */
-  data class ClientChanged(val client: Client) : AuthEvent
 
   /**
    * Emitted when the current session changes.

--- a/source/api/src/main/kotlin/com/clerk/api/client/ClientEvent.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/client/ClientEvent.kt
@@ -1,0 +1,22 @@
+package com.clerk.api.client
+
+import com.clerk.api.network.model.client.Client
+
+/**
+ * Represents client events emitted by Clerk.
+ *
+ * Subscribe to [com.clerk.api.Clerk.clientEvents] to receive notifications about client state
+ * changes.
+ */
+sealed interface ClientEvent
+
+/**
+ * Emitted when the current client changes.
+ *
+ * This event fires whenever Clerk receives a new [Client] value that differs from the previously
+ * stored client. Because [Client] is a data class, nested changes such as a session or user
+ * property update also trigger this event.
+ *
+ * @property client The updated client.
+ */
+data class ClientChanged(val client: Client) : ClientEvent

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -162,6 +163,38 @@ class ClerkTest {
     } catch (_: Exception) {
       // Ignore reflection errors - they mean the fields weren't accessible
     }
+  }
+
+  private fun clientWithUser(firstName: String): Client {
+    val user =
+      User(
+        id = "user_123",
+        imageUrl = "",
+        hasImage = false,
+        passkeys = emptyList(),
+        passwordEnabled = false,
+        phoneNumbers = emptyList(),
+        totpEnabled = false,
+        twoFactorEnabled = false,
+        updatedAt = 0L,
+        firstName = firstName,
+      )
+    val session =
+      Session(
+        id = "session_123",
+        status = Session.SessionStatus.ACTIVE,
+        expireAt = 10_000,
+        lastActiveAt = 1_000,
+        user = user,
+        createdAt = 1_000,
+        updatedAt = 1_000,
+      )
+
+    return Client(
+      id = "client_123",
+      sessions = listOf(session),
+      lastActiveSessionId = session.id,
+    )
   }
 
   private fun initializeClerkWithClient(client: Client) {
@@ -643,6 +676,56 @@ class ClerkTest {
     assertTrue(events[1] is AuthEvent.SignedIn)
     assertEquals(mockSession, (events[1] as AuthEvent.SignedIn).session)
     assertEquals(mockUser, (events[1] as AuthEvent.SignedIn).user)
+  }
+
+  @Test
+  fun `updateClient emits ClientChanged when client changes`() = runTest {
+    val client = Client(id = "client_123")
+    val events = mutableListOf<AuthEvent>()
+    val eventJob =
+      launch(start = CoroutineStart.UNDISPATCHED) { Clerk.auth.events.take(1).toList(events) }
+
+    Clerk.updateClient(client)
+
+    withTimeout(1_000) { eventJob.join() }
+
+    assertTrue(events.single() is AuthEvent.ClientChanged)
+    assertEquals(client, (events.single() as AuthEvent.ClientChanged).client)
+  }
+
+  @Test
+  fun `updateClient does not emit ClientChanged when client is unchanged`() = runTest {
+    val client = Client(id = "client_123")
+    Clerk.updateClient(client)
+
+    val events = mutableListOf<AuthEvent>()
+    val eventJob =
+      launch(start = CoroutineStart.UNDISPATCHED) { Clerk.auth.events.take(1).toList(events) }
+
+    Clerk.updateClient(client)
+
+    withTimeoutOrNull(100) { eventJob.join() }
+    eventJob.cancel()
+
+    assertTrue(events.isEmpty())
+  }
+
+  @Test
+  fun `updateClient emits ClientChanged when nested user property changes`() = runTest {
+    val initialClient = clientWithUser(firstName = "Jane")
+    val updatedClient = clientWithUser(firstName = "Janet")
+    Clerk.updateClient(initialClient)
+
+    val events = mutableListOf<AuthEvent>()
+    val eventJob =
+      launch(start = CoroutineStart.UNDISPATCHED) { Clerk.auth.events.take(2).toList(events) }
+
+    Clerk.updateClient(updatedClient)
+
+    withTimeout(1_000) { eventJob.join() }
+
+    val clientChanged = events.single { it is AuthEvent.ClientChanged } as AuthEvent.ClientChanged
+    assertEquals(updatedClient, clientChanged.client)
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -3,6 +3,8 @@ package com.clerk.api.sdk
 import android.content.Context
 import com.clerk.api.Clerk
 import com.clerk.api.auth.AuthEvent
+import com.clerk.api.client.ClientChanged
+import com.clerk.api.client.ClientEvent
 import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.environment.AuthConfig
 import com.clerk.api.network.model.environment.DisplayConfig
@@ -190,11 +192,7 @@ class ClerkTest {
         updatedAt = 1_000,
       )
 
-    return Client(
-      id = "client_123",
-      sessions = listOf(session),
-      lastActiveSessionId = session.id,
-    )
+    return Client(id = "client_123", sessions = listOf(session), lastActiveSessionId = session.id)
   }
 
   private fun initializeClerkWithClient(client: Client) {
@@ -679,28 +677,28 @@ class ClerkTest {
   }
 
   @Test
-  fun `updateClient emits ClientChanged when client changes`() = runTest {
+  fun `updateClient emits ClientChanged client event when client changes`() = runTest {
     val client = Client(id = "client_123")
-    val events = mutableListOf<AuthEvent>()
+    val events = mutableListOf<ClientEvent>()
     val eventJob =
-      launch(start = CoroutineStart.UNDISPATCHED) { Clerk.auth.events.take(1).toList(events) }
+      launch(start = CoroutineStart.UNDISPATCHED) { Clerk.clientEvents.take(1).toList(events) }
 
     Clerk.updateClient(client)
 
     withTimeout(1_000) { eventJob.join() }
 
-    assertTrue(events.single() is AuthEvent.ClientChanged)
-    assertEquals(client, (events.single() as AuthEvent.ClientChanged).client)
+    assertTrue(events.single() is ClientChanged)
+    assertEquals(client, (events.single() as ClientChanged).client)
   }
 
   @Test
-  fun `updateClient does not emit ClientChanged when client is unchanged`() = runTest {
+  fun `updateClient does not emit ClientChanged client event when client is unchanged`() = runTest {
     val client = Client(id = "client_123")
     Clerk.updateClient(client)
 
-    val events = mutableListOf<AuthEvent>()
+    val events = mutableListOf<ClientEvent>()
     val eventJob =
-      launch(start = CoroutineStart.UNDISPATCHED) { Clerk.auth.events.take(1).toList(events) }
+      launch(start = CoroutineStart.UNDISPATCHED) { Clerk.clientEvents.take(1).toList(events) }
 
     Clerk.updateClient(client)
 
@@ -711,22 +709,23 @@ class ClerkTest {
   }
 
   @Test
-  fun `updateClient emits ClientChanged when nested user property changes`() = runTest {
-    val initialClient = clientWithUser(firstName = "Jane")
-    val updatedClient = clientWithUser(firstName = "Janet")
-    Clerk.updateClient(initialClient)
+  fun `updateClient emits ClientChanged client event when nested user property changes`() =
+    runTest {
+      val initialClient = clientWithUser(firstName = "Jane")
+      val updatedClient = clientWithUser(firstName = "Janet")
+      Clerk.updateClient(initialClient)
 
-    val events = mutableListOf<AuthEvent>()
-    val eventJob =
-      launch(start = CoroutineStart.UNDISPATCHED) { Clerk.auth.events.take(2).toList(events) }
+      val events = mutableListOf<ClientEvent>()
+      val eventJob =
+        launch(start = CoroutineStart.UNDISPATCHED) { Clerk.clientEvents.take(1).toList(events) }
 
-    Clerk.updateClient(updatedClient)
+      Clerk.updateClient(updatedClient)
 
-    withTimeout(1_000) { eventJob.join() }
+      withTimeout(1_000) { eventJob.join() }
 
-    val clientChanged = events.single { it is AuthEvent.ClientChanged } as AuthEvent.ClientChanged
-    assertEquals(updatedClient, clientChanged.client)
-  }
+      val clientChanged = events.single() as ClientChanged
+      assertEquals(updatedClient, clientChanged.client)
+    }
 
   @Test
   fun `clearSessionAndUserState emits SessionChanged and SignedOut when session is cleared`() =


### PR DESCRIPTION
### Motivation
- Provide a public event so consumers can observe when the entire `Client` value changes (including nested updates such as Session → User → first name) and refresh downstream state or bridges that rely on native client state.

### Description
- Add a new `AuthEvent.ClientChanged(val client: Client)` event to the auth event types in `source/api/src/main/kotlin/com/clerk/api/auth/AuthEvent.kt`.
- Update `Clerk.updateClient` to compute the resolved client, compare it with the previous stored client using data-class equality, and emit `AuthEvent.ClientChanged` only when they differ in `source/api/src/main/kotlin/com/clerk/api/Clerk.kt`.
- Add regression unit tests covering: emitting on initial client change, not emitting when the client is unchanged, and emitting when a nested user property changes (tests added to `source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt`).

### Testing
- Ran `git diff --check` which passed with no whitespace errors.
- Added unit tests exercising the new `ClientChanged` event, but running the JVM/Android unit test task in this environment failed because no Android SDK is configured (Gradle reported missing `ANDROID_HOME` / `sdk.dir`).
- Attempted to run code formatting (`spotlessApply`) but it failed in this environment due to remote dependency resolution returning HTTP 403 for `com.facebook:ktfmt:0.61`, so spotless/format checks could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20783e52f08323b7cff9df32f74577)