### PR TITLE
ci: use docs publish token

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         ref: docs
         path: docs
+        token: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}
     - uses: actions/setup-java@v5
       with:
         distribution: zulu
@@ -69,6 +70,7 @@ jobs:
       with:
         ref: docs
         path: docs
+        token: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}
     - uses: actions/download-artifact@v8
       with:
         name: docs-zip


### PR DESCRIPTION
## Summary

- Configure docs branch checkouts in the docs workflow to use `secrets.OPEN_EXPO_PR_GH_TOKEN`.
- Keeps the persisted checkout credentials aligned with the token needed for publishing docs updates.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs.yml"); puts "YAML OK"'`