### PR TITLE
ci(release): use Expo PR token

### DIFF
--- a/.github/workflows/expo-android-release-pr.yml
+++ b/.github/workflows/expo-android-release-pr.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
     secrets:
-      CLERK_JAVASCRIPT_RELEASE_TOKEN:
+      OPEN_EXPO_PR_GH_TOKEN:
         required: true
 
 permissions:
@@ -103,12 +103,12 @@ jobs:
       - name: Check target repository token
         if: steps.release.outputs.should_open == 'true'
         env:
-          JAVASCRIPT_RELEASE_TOKEN: ${{ secrets.CLERK_JAVASCRIPT_RELEASE_TOKEN }}
+          JAVASCRIPT_RELEASE_TOKEN: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}
         run: |
           set -euo pipefail
 
           if [ -z "${JAVASCRIPT_RELEASE_TOKEN:-}" ]; then
-            echo "::error::Set CLERK_JAVASCRIPT_RELEASE_TOKEN with access to push branches and open PRs in clerk/javascript."
+            echo "::error::Set OPEN_EXPO_PR_GH_TOKEN with access to push branches and open PRs in clerk/javascript."
             exit 1
           fi
 
@@ -118,7 +118,7 @@ jobs:
         with:
           repository: clerk/javascript
           ref: main
-          token: ${{ secrets.CLERK_JAVASCRIPT_RELEASE_TOKEN }}
+          token: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}
           path: javascript
           fetch-depth: 0
 
@@ -127,6 +127,6 @@ jobs:
         env:
           CLERK_ANDROID_VERSION: ${{ steps.release.outputs.version }}
           CLERK_ANDROID_RELEASE_URL: ${{ steps.release.outputs.release_url }}
-          GH_TOKEN: ${{ secrets.CLERK_JAVASCRIPT_RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}
           JAVASCRIPT_DIR: ${{ github.workspace }}/javascript
         run: bash android-release/.github/scripts/open-expo-android-release-pr.sh

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -248,4 +248,4 @@ jobs:
       release_tag: ${{ needs.publish.outputs.tag_name }}
       release_url: ${{ needs.publish.outputs.release_url }}
     secrets:
-      CLERK_JAVASCRIPT_RELEASE_TOKEN: ${{ secrets.CLERK_JAVASCRIPT_RELEASE_TOKEN }}
+      OPEN_EXPO_PR_GH_TOKEN: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace the Expo Android release PR workflow secret from `CLERK_JAVASCRIPT_RELEASE_TOKEN` to `OPEN_EXPO_PR_GH_TOKEN`.
- Update the reusable workflow caller in `manual-release.yml` to pass the new secret name.
- Update the preflight error message so missing-secret failures point maintainers at the correct token.

## Root cause

The `Open clerk/javascript PR` job for `v1.0.27` failed while pushing `sam/expo-android-1.0.27` to `clerk/javascript` because the current token was rejected as a classic PAT:

```text
remote: Personal access tokens (classic) are forbidden from accessing this repository.
fatal: unable to access 'https://github.com/clerk/javascript/': The requested URL returned error: 403
```

## Validation

- `ruby -e 'require "yaml"; %w[.github/workflows/expo-android-release-pr.yml .github/workflows/manual-release.yml].each { |f| YAML.load_file(f); puts "#{f} parsed" }'`
- `git diff --cached --check`