### PR TITLE
Fix auth back navigation from reopening pending email verification

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
@@ -108,7 +108,11 @@ internal class AuthState(
   }
 
   override fun navigateBack() {
+    if (backStack.size <= 1) return
     backStack.removeLastOrNull()
+    if (backStack.size == 1) {
+      shouldResumeInProgressAuthAttempt = false
+    }
   }
 
   override fun clearBackStack() {

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -189,6 +189,7 @@ private fun AuthNavDisplay(
   options: AuthNavOptions,
   modifier: Modifier = Modifier,
 ) {
+  val authState = LocalAuthState.current
   NavDisplay(
     modifier = modifier,
     backStack = backStack,
@@ -206,11 +207,7 @@ private fun AuthNavDisplay(
       slideInHorizontally(initialOffsetX = { -distance }) togetherWith
         slideOutHorizontally(targetOffsetX = { distance })
     },
-    onBack = {
-      if (backStack.size > 1) {
-        backStack.removeLastOrNull()
-      }
-    },
+    onBack = { authState.navigateBack() },
     entryProvider = authEntryProvider(backStack = backStack, options = options),
   )
 }

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewPendingAuthRoutingTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewPendingAuthRoutingTest.kt
@@ -6,10 +6,13 @@ import androidx.navigation3.runtime.NavKey
 import androidx.test.core.app.ApplicationProvider
 import com.clerk.api.Constants
 import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.signin.SignIn
+import com.clerk.api.signup.SignUp
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -118,6 +121,51 @@ class AuthViewPendingAuthRoutingTest {
 
     assertTrue(completed)
     verify(exactly = 0) { backStack.add(any()) }
+  }
+
+  @Test
+  fun `navigateBack from sign up email link does not reroute to pending verification`() {
+    val realBackStack =
+      NavBackStack<NavKey>(
+        AuthDestination.AuthStart,
+        AuthDestination.SignUpEmailLink(emailAddress = "sam@clerk.dev"),
+      )
+    val realAuthState =
+      AuthState(
+        mode = AuthMode.SignInOrUp,
+        backStack = realBackStack,
+        sharedPreferences = preferences(),
+      )
+    val signUp =
+      SignUp(
+        id = "sign_up_123",
+        status = SignUp.Status.MISSING_REQUIREMENTS,
+        requiredFields = listOf("email_address", "password"),
+        optionalFields = emptyList(),
+        missingFields = emptyList(),
+        unverifiedFields = listOf("email_address"),
+        verifications =
+          mapOf(
+            "email_address" to
+              Verification(
+                status = Verification.Status.UNVERIFIED,
+                strategy = Constants.Strategy.EMAIL_LINK,
+              )
+          ),
+        emailAddress = "sam@clerk.dev",
+        passwordEnabled = false,
+      )
+
+    realAuthState.navigateBack()
+    resumeInProgressAuthAttempt(
+      authState = realAuthState,
+      top = realBackStack.lastOrNull(),
+      signIn = null,
+      signUp = signUp,
+      onAuthComplete = {},
+    )
+
+    assertEquals(listOf(AuthDestination.AuthStart), realBackStack.toList())
   }
 
   private fun preferences() =


### PR DESCRIPTION
## Summary
- Route auth back actions through `AuthState` so the shared navigation behavior is used for both UI back buttons and system back.
- Stop auto-resuming an in-progress auth attempt when back returns to the auth start screen.
- Add a regression test covering the sign-up email-link flow.

## Testing
- `./gradlew :source:ui:testDebugUnitTest --tests "com.clerk.ui.auth.AuthViewPendingAuthRoutingTest"`
- `./gradlew :source:ui:spotlessKotlinCheck`