### PR TITLE
Expose auth mode on AuthView

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -75,6 +75,7 @@ import kotlinx.serialization.Serializable
  * @param onDismiss Called when the user presses the close affordance. When omitted, the close
  *   affordance falls back to the system back dispatcher.
  * @param onAuthComplete Called when authentication completes.
+ * @param mode Determines whether the flow starts as sign-in, sign-up, or sign-in-or-up.
  */
 @Composable
 fun AuthView(
@@ -88,6 +89,7 @@ fun AuthView(
   isDismissible: Boolean = true,
   onDismiss: (() -> Unit)? = null,
   onAuthComplete: () -> Unit = {},
+  mode: AuthMode = AuthMode.SignInOrUp,
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
     val fullScreenModifier = Modifier.fillMaxSize().then(modifier)
@@ -100,7 +102,7 @@ fun AuthView(
           unsafeMetadata = unsafeMetadata,
         )
       }
-    AuthStateProvider(backStack = backStack, identifierConfig = identifierConfig) {
+    AuthStateProvider(backStack = backStack, mode = mode, identifierConfig = identifierConfig) {
       ObservePendingSessionTaskRouting(backStack = backStack)
       ObserveInProgressAuthRouting(backStack = backStack, onAuthComplete = onAuthComplete)
       TrackScreenLoaded(LocalAuthState.current.mode.name)

--- a/source/ui/src/main/java/com/clerk/ui/core/composition/CompositionLocals.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/composition/CompositionLocals.kt
@@ -14,6 +14,7 @@ import com.clerk.telemetry.ClerkTelemetryEnvironment
 import com.clerk.telemetry.TelemetryCollector
 import com.clerk.telemetry.TelemetryModule
 import com.clerk.ui.auth.AuthIdentifierConfig
+import com.clerk.ui.auth.AuthMode
 import com.clerk.ui.auth.AuthState
 import com.clerk.ui.auth.authSharedPreferences
 
@@ -44,14 +45,16 @@ internal fun TelemetryProvider(
 @Composable
 internal fun AuthStateProvider(
   backStack: NavBackStack<NavKey>,
+  mode: AuthMode = AuthMode.SignInOrUp,
   identifierConfig: AuthIdentifierConfig = AuthIdentifierConfig(),
   content: @Composable () -> Unit,
 ) {
   val context = LocalContext.current.applicationContext
   val sharedPreferences = remember(context) { authSharedPreferences(context) }
   val authState =
-    remember(backStack, sharedPreferences) {
+    remember(backStack, sharedPreferences, mode) {
       AuthState(
+        mode = mode,
         backStack = backStack,
         sharedPreferences = sharedPreferences,
         identifierConfig = identifierConfig,

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthStateSignUpRoutingTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthStateSignUpRoutingTest.kt
@@ -11,6 +11,7 @@ import com.clerk.ui.signup.collectfield.CollectField
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,6 +34,21 @@ class AuthStateSignUpRoutingTest {
         backStack = backStack,
         sharedPreferences = preferences(),
       )
+  }
+
+  @Test
+  fun authStateDefaultsToSignInOrUpMode() {
+    val defaultAuthState = AuthState(backStack = backStack, sharedPreferences = preferences())
+
+    assertEquals(AuthMode.SignInOrUp, defaultAuthState.mode)
+  }
+
+  @Test
+  fun authStateKeepsExplicitMode() {
+    val signUpAuthState =
+      AuthState(mode = AuthMode.SignUp, backStack = backStack, sharedPreferences = preferences())
+
+    assertEquals(AuthMode.SignUp, signUpAuthState.mode)
   }
 
   @Test

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -307,6 +307,13 @@ class AuthViewModelTest {
   }
 
   @Test
+  fun authModeTransferabilityShouldMatchFlowMode() {
+    assertEquals(false, AuthMode.SignIn.transferable)
+    assertEquals(true, AuthMode.SignUp.transferable)
+    assertEquals(true, AuthMode.SignInOrUp.transferable)
+  }
+
+  @Test
   fun emailRegexPatternShouldWorkCorrectly() {
     // Test email validation regex pattern (same as used in the ViewModel)
     val emailRegex = Regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")


### PR DESCRIPTION
## Summary
- Add a public `mode: AuthMode` parameter to `AuthView` with a backward-compatible default of `SignInOrUp`
- Thread the selected mode through `AuthStateProvider` into `AuthState`
- Add unit coverage for default mode handling and transferability semantics

## Testing
- `./gradlew :source:ui:spotlessApply :source:ui:testDebugUnitTest --tests "com.clerk.ui.auth.AuthViewModelTest" --tests "com.clerk.ui.auth.AuthStateSignUpRoutingTest"`