### PR TITLE
Fix docs publishing and organization task navigation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,6 @@ jobs:
       with:
         ref: docs
         path: docs
-        token: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}
     - uses: actions/setup-java@v5
       with:
         distribution: zulu
@@ -70,7 +69,6 @@ jobs:
       with:
         ref: docs
         path: docs
-        token: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}
     - uses: actions/download-artifact@v8
       with:
         name: docs-zip

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -248,15 +248,26 @@ private fun authEntryProvider(backStack: NavBackStack<NavKey>, options: AuthNavO
       val authState = LocalAuthState.current
       SessionTaskChooseOrganizationView(
         onAuthComplete = options.onAuthComplete,
-        onCreateOrganization = {
-          authState.navigateTo(AuthDestination.SessionTaskCreateOrganization(it))
+        onCreateOrganization = { creationDefaults, replaceChooser ->
+          if (
+            replaceChooser &&
+              backStack.lastOrNull() == AuthDestination.SessionTaskChooseOrganization
+          ) {
+            backStack.removeLastOrNull()
+          }
+          authState.navigateTo(
+            AuthDestination.SessionTaskCreateOrganization(
+              creationDefaults = creationDefaults,
+              showBackButton = !replaceChooser,
+            )
+          )
         },
       )
     }
     entry<AuthDestination.SessionTaskCreateOrganization> {
       SessionTaskCreateOrganizationView(
         creationDefaults = it.creationDefaults,
-        showBackButton = true,
+        showBackButton = it.showBackButton,
         onAuthComplete = options.onAuthComplete,
       )
     }
@@ -388,7 +399,8 @@ internal object AuthDestination {
 
   @Serializable
   data class SessionTaskCreateOrganization(
-    val creationDefaults: OrganizationCreationDefaults? = null
+    val creationDefaults: OrganizationCreationDefaults? = null,
+    val showBackButton: Boolean = true,
   ) : NavKey
 
   @Serializable data class SignInFactorTwoUseAnotherMethod(val currentFactor: Factor) : NavKey

--- a/source/ui/src/main/java/com/clerk/ui/organizationlist/OrganizationAccountListState.kt
+++ b/source/ui/src/main/java/com/clerk/ui/organizationlist/OrganizationAccountListState.kt
@@ -44,6 +44,10 @@ internal data class OrganizationAccountListState(
     get() =
       !isLoading && hasLoadedInitialResources && !hasExistingResources && !canCreateOrganization
 
+  val canOnlyCreateOrganization: Boolean
+    get() =
+      !isLoading && hasLoadedInitialResources && !hasExistingResources && canCreateOrganization
+
   val membershipsHasNextPage: Boolean
     get() = memberships.size < membershipsTotalCount
 

--- a/source/ui/src/main/java/com/clerk/ui/sessiontask/organization/SessionTaskChooseOrganizationView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/sessiontask/organization/SessionTaskChooseOrganizationView.kt
@@ -64,7 +64,7 @@ import com.clerk.ui.theme.ClerkMaterialTheme
 @Composable
 internal fun SessionTaskChooseOrganizationView(
   onAuthComplete: () -> Unit,
-  onCreateOrganization: (OrganizationCreationDefaults?) -> Unit,
+  onCreateOrganization: (OrganizationCreationDefaults?, Boolean) -> Unit,
   modifier: Modifier = Modifier,
   viewModel: SessionTaskChooseOrganizationViewModel = viewModel(),
 ) {
@@ -80,6 +80,11 @@ internal fun SessionTaskChooseOrganizationView(
       viewModel.clearCompletedSession()
     }
   }
+  LaunchedEffect(state.canOnlyCreateOrganization, state.creationDefaults) {
+    if (state.canOnlyCreateOrganization) {
+      onCreateOrganization(state.creationDefaults, true)
+    }
+  }
 
   when {
     state.canShowNoOrganizationHelp -> SignInGetHelpView(modifier = modifier)
@@ -89,7 +94,7 @@ internal fun SessionTaskChooseOrganizationView(
         state = state,
         onErrorShown = viewModel::clearError,
         onRetryInitialLoad = viewModel::retryLoad,
-        onCreateOrganization = { onCreateOrganization(state.creationDefaults) },
+        onCreateOrganization = { onCreateOrganization(state.creationDefaults, false) },
         onLoadMoreMemberships = viewModel::loadMoreMemberships,
         onLoadMoreInvitations = viewModel::loadMoreInvitations,
         onLoadMoreSuggestions = viewModel::loadMoreSuggestions,

--- a/source/ui/src/test/java/com/clerk/ui/sessiontask/organization/OrganizationSessionTaskUtilsTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/sessiontask/organization/OrganizationSessionTaskUtilsTest.kt
@@ -38,7 +38,7 @@ class OrganizationSessionTaskUtilsTest {
   }
 
   @Test
-  fun `successful empty initial load with creation enabled stays on chooser`() {
+  fun `successful empty initial load with creation enabled can only create organization`() {
     val state =
       SessionTaskChooseOrganizationState(
         isLoading = false,
@@ -49,6 +49,7 @@ class OrganizationSessionTaskUtilsTest {
 
     assertFalse(state.initialLoadFailed)
     assertFalse(state.canShowNoOrganizationHelp)
+    assertTrue(state.canOnlyCreateOrganization)
   }
 
   @Test
@@ -76,5 +77,6 @@ class OrganizationSessionTaskUtilsTest {
 
     assertTrue(state.hasExistingResources)
     assertFalse(state.canShowNoOrganizationHelp)
+    assertFalse(state.canOnlyCreateOrganization)
   }
 }


### PR DESCRIPTION
## Summary
- Revert the docs workflow to the default checkout credentials so the publish job can push with `GITHUB_TOKEN` again.
- Update organization task navigation to auto-enter create-organization when it is the only available path, while preserving the back button for the manual flow.
- Add state coverage for the new `canOnlyCreateOrganization` condition.

## Testing
- Not run (not requested)