### PR TITLE
Use server RP ID for Android passkey auth

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
@@ -25,7 +25,10 @@ import com.clerk.api.sso.GoogleCredentialManagerImpl
 import com.clerk.api.sso.GoogleSignInService
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import kotlinx.serialization.json.Json
-import org.json.JSONObject
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Service responsible for authenticating users with Google credentials and passkeys.
@@ -290,12 +293,14 @@ internal object GoogleCredentialAuthenticationService {
    *   Android Credential Manager.
    * @throws IllegalArgumentException If the nonce is null or contains invalid JSON.
    */
-  private fun createWebAuthnRequest(
+  @VisibleForTesting
+  internal fun createWebAuthnRequest(
     nonce: String?,
     allowedCredentialIds: List<String> = emptyList(),
   ): GetPasskeyRequest {
-    val requestJson = JSONObject(requireNotNull(nonce))
-    val challenge = requestJson.get("challenge") as String
+    val requestJson = Json.parseToJsonElement(requireNotNull(nonce)).jsonObject
+    val challenge = requestJson.getValue("challenge").jsonPrimitive.content
+    val rpId = requestJson.passkeyRpId() ?: PasskeyHelper.getDomain()
 
     val allowCredentials =
       allowedCredentialIds.map { credentialId ->
@@ -307,7 +312,7 @@ internal object GoogleCredentialAuthenticationService {
       allowCredentials = allowCredentials,
       timeout = 1800000,
       userVerification = "required",
-      rpId = PasskeyHelper.getDomain(),
+      rpId = rpId,
     )
   }
 
@@ -455,4 +460,17 @@ internal object GoogleCredentialAuthenticationService {
       }
     }
   }
+}
+
+private fun JsonObject.passkeyRpId(): String? {
+  val topLevelRpId =
+    listOf("rpId", "rp_id").firstNotNullOfOrNull { key ->
+      this[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+    }
+
+  return topLevelRpId
+    ?: runCatching {
+        this["rp"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+      }
+      .getOrNull()
 }

--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
@@ -27,6 +27,7 @@ import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -301,11 +302,8 @@ internal object GoogleCredentialAuthenticationService {
     val requestJson = Json.parseToJsonElement(requireNotNull(nonce)).jsonObject
     val challenge = requestJson.getValue("challenge").jsonPrimitive.content
     val rpId = requestJson.passkeyRpId() ?: PasskeyHelper.getDomain()
-
     val allowCredentials =
-      allowedCredentialIds.map { credentialId ->
-        mapOf("type" to "public-key", "id" to credentialId)
-      }
+      allowedCredentialIds.toAllowCredentials().ifEmpty { requestJson.passkeyAllowCredentials() }
 
     return GetPasskeyRequest(
       challenge = challenge,
@@ -473,4 +471,26 @@ private fun JsonObject.passkeyRpId(): String? {
         this["rp"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
       }
       .getOrNull()
+}
+
+private fun JsonObject.passkeyAllowCredentials(): List<Map<String, String>> {
+  return runCatching {
+      this["allowCredentials"]?.jsonArray?.mapNotNull { credential ->
+        val credentialJson = credential.jsonObject
+        val credentialId =
+          credentialJson["id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+            ?: return@mapNotNull null
+        val credentialType =
+          credentialJson["type"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+            ?: "public-key"
+
+        mapOf("type" to credentialType, "id" to credentialId)
+      }
+    }
+    .getOrNull()
+    .orEmpty()
+}
+
+private fun List<String>.toAllowCredentials(): List<Map<String, String>> {
+  return map { credentialId -> mapOf("type" to "public-key", "id" to credentialId) }
 }

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyWebAuthnRequestTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyWebAuthnRequestTest.kt
@@ -1,0 +1,50 @@
+package com.clerk.api.passkeys
+
+import com.clerk.api.Clerk
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PasskeyWebAuthnRequestTest {
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `createWebAuthnRequest uses nested server relying party id`() {
+    val request =
+      GoogleCredentialAuthenticationService.createWebAuthnRequest(
+        nonce = """{"challenge":"test-challenge","rp":{"id":"passkeys.example.com"}}"""
+      )
+
+    assertEquals("passkeys.example.com", request.rpId)
+  }
+
+  @Test
+  fun `createWebAuthnRequest uses top level server relying party id`() {
+    val request =
+      GoogleCredentialAuthenticationService.createWebAuthnRequest(
+        nonce = """{"challenge":"test-challenge","rpId":"passkeys.example.com"}"""
+      )
+
+    assertEquals("passkeys.example.com", request.rpId)
+  }
+
+  @Test
+  fun `createWebAuthnRequest falls back to Clerk domain without server relying party id`() {
+    mockkObject(Clerk)
+    every { Clerk.baseUrl } returns "https://www.fapi.example.com/v1"
+
+    val request =
+      GoogleCredentialAuthenticationService.createWebAuthnRequest(
+        nonce = """{"challenge":"test-challenge"}"""
+      )
+
+    assertEquals("fapi.example.com", request.rpId)
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyWebAuthnRequestTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyWebAuthnRequestTest.kt
@@ -36,6 +36,74 @@ class PasskeyWebAuthnRequestTest {
   }
 
   @Test
+  fun `createWebAuthnRequest uses server allowed credentials`() {
+    val request =
+      GoogleCredentialAuthenticationService.createWebAuthnRequest(
+        nonce =
+          """
+          {
+            "challenge": "test-challenge",
+            "rpId": "passkeys.example.com",
+            "allowCredentials": [
+              {
+                "type": "public-key",
+                "id": "credential-1",
+                "transports": ["internal", "hybrid"]
+              },
+              {
+                "type": "public-key",
+                "id": "credential-2"
+              },
+              {
+                "type": "public-key"
+              },
+              {
+                "type": "public-key",
+                "id": ""
+              }
+            ]
+          }
+          """
+            .trimIndent()
+      )
+
+    assertEquals(
+      listOf(
+        mapOf("type" to "public-key", "id" to "credential-1"),
+        mapOf("type" to "public-key", "id" to "credential-2"),
+      ),
+      request.allowCredentials,
+    )
+  }
+
+  @Test
+  fun `createWebAuthnRequest prefers explicit allowed credential ids over server list`() {
+    val request =
+      GoogleCredentialAuthenticationService.createWebAuthnRequest(
+        nonce =
+          """
+          {
+            "challenge": "test-challenge",
+            "rpId": "passkeys.example.com",
+            "allowCredentials": [
+              {
+                "type": "public-key",
+                "id": "server-credential"
+              }
+            ]
+          }
+          """
+            .trimIndent(),
+        allowedCredentialIds = listOf("explicit-credential"),
+      )
+
+    assertEquals(
+      listOf(mapOf("type" to "public-key", "id" to "explicit-credential")),
+      request.allowCredentials,
+    )
+  }
+
+  @Test
   fun `createWebAuthnRequest falls back to Clerk domain without server relying party id`() {
     mockkObject(Clerk)
     every { Clerk.baseUrl } returns "https://www.fapi.example.com/v1"


### PR DESCRIPTION
## Summary
- Parse the WebAuthn nonce with Kotlinx Serialization and prefer the server-provided RP ID for Android passkey sign-in requests
- Use server-provided `allowCredentials` when the caller does not pass explicit credential IDs
- Keep the existing Clerk domain fallback and explicit `allowedCredentialIds` override for older responses and current Android API behavior
- Add unit coverage for nested `rp.id`, top-level `rpId`, server `allowCredentials`, explicit credential overrides, and fallback behavior

## Context
Passkeys are scoped to the WebAuthn relying party ID. Android Credential Manager needs the assertion request to use the same RP ID that the passkey was registered against, otherwise the platform looks in the wrong credential scope.

The Android SDK was already passing the full server nonce through during passkey creation, so registration could use the backend-provided `rp.id`. Sign-in was different: it rebuilt the assertion request locally and always set `rpId` from `PasskeyHelper.getDomain()`, which derives from the Clerk frontend API host. That only works when the frontend host is also the WebAuthn RP ID.

For web-to-mobile passkey interoperability, the backend can return WebAuthn options for a different RP ID. Registration commonly uses nested `rp.id`, while assertion can use top-level `rpId`. The assertion options can also include `allowCredentials`, which narrows the credential IDs the platform should offer. If Android ignores those server assertion options during sign-in, web-created passkeys may not appear on mobile, Android may look in the wrong credential scope, or the platform may present credentials outside the server-provided assertion list.

This matches the iOS fix in clerk/clerk-ios#475: trust the RP ID and allowed credential IDs from the WebAuthn nonce when present, while preserving the existing Clerk-domain fallback and Android's explicit credential-ID override for older or caller-filtered flows.

## Testing
- `PasskeyWebAuthnRequestTest` covers the new RP ID and allowed-credential parsing paths
- `:source:api:testDebugUnitTest --tests com.clerk.api.passkeys.PasskeyWebAuthnRequestTest` passed
- `:source:api:spotlessCheck` passed
- `:source:api:detekt` passed
