### PR TITLE
feat(api): support custom request headers

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -990,12 +990,23 @@ object Clerk {
  * @property proxyUrl Optional proxy URL for network requests Your Clerk app's proxy URL. Required
  *   for applications that run behind a reverse proxy. Must be a full URL (for example,
  *   https://proxy.example.com/__clerk).
+ * @property telemetryEnabled Whether to enable telemetry for this SDK instance.
  */
 data class ClerkConfigurationOptions(
   val enableDebugMode: Boolean = false,
   val proxyUrl: String? = null,
   val telemetryEnabled: Boolean = true,
-)
+) {
+  private var _customHeaders: Map<String, String> = emptyMap()
+
+  /** Additional headers to append to outgoing Clerk API requests. */
+  val customHeaders: Map<String, String>
+    get() = _customHeaders
+
+  /** Returns a copy of these options with additional outgoing request headers configured. */
+  fun withCustomHeaders(customHeaders: Map<String, String>): ClerkConfigurationOptions =
+    copy().also { it._customHeaders = customHeaders.toMap() }
+}
 
 /**
  * Extension function to convert a map of social provider configurations into a list of

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
@@ -213,7 +213,11 @@ internal class ConfigurationManager {
     Clerk.applicationId = context.applicationContext.packageName
 
     ensureStorageInitialized()
-    ClerkApi.configure(Clerk.baseUrl, context.applicationContext)
+    ClerkApi.configure(
+      baseUrl = Clerk.baseUrl,
+      context = context.applicationContext,
+      customHeaders = options?.customHeaders.orEmpty(),
+    )
     hasConfigured = true
     configureConnectivityMonitor(context.applicationContext)
     return configuredVersion

--- a/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
@@ -81,11 +81,20 @@ internal object ClerkApi {
   internal var configuredUrlWithVersion: String? = null
     private set
 
+  internal var configuredCustomHeaders: Map<String, String> = emptyMap()
+    private set
+
   /** Initializes the API client with the given [baseUrl]. */
   @Suppress("UnusedParameter")
-  fun configure(baseUrl: String, context: Context) {
+  fun configure(
+    baseUrl: String,
+    context: Context,
+    customHeaders: Map<String, String> = emptyMap(),
+  ) {
+    val effectiveCustomHeaders = customHeaders.toMap()
     configuredBaseUrl = baseUrl
-    val retrofit = buildRetrofit(baseUrl)
+    configuredCustomHeaders = effectiveCustomHeaders
+    val retrofit = buildRetrofit(baseUrl, effectiveCustomHeaders)
     _client = retrofit.create(ClientApi::class.java)
     _environment = retrofit.create(EnvironmentApi::class.java)
     _session = retrofit.create(SessionApi::class.java)
@@ -109,10 +118,11 @@ internal object ClerkApi {
     _organization = null
     configuredBaseUrl = null
     configuredUrlWithVersion = null
+    configuredCustomHeaders = emptyMap()
   }
 
   /** Builds and configures the Retrofit instance. */
-  private fun buildRetrofit(baseUrl: String): Retrofit {
+  private fun buildRetrofit(baseUrl: String, customHeaders: Map<String, String>): Retrofit {
     val urlWithVersion = "$baseUrl/v1/"
     configuredUrlWithVersion = urlWithVersion
 
@@ -120,7 +130,7 @@ internal object ClerkApi {
       OkHttpClient.Builder()
         .apply {
           addInterceptor(ClientSyncingMiddleware(json = json))
-          addInterceptor(VersioningUserAgentMiddleware())
+          addInterceptor(VersioningUserAgentMiddleware(customHeaders = customHeaders))
           addInterceptor(DeviceTokenSavingMiddleware())
           addInterceptor(UrlAppendingMiddleware())
 

--- a/source/api/src/main/kotlin/com/clerk/api/network/middleware/outgoing/VersioningUserAgentMiddleware.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/middleware/outgoing/VersioningUserAgentMiddleware.kt
@@ -18,7 +18,10 @@ internal const val INTERNAL_HEADER_TRUE = "1"
  *
  * This is never intended to be used directly by the user.
  */
-internal class VersioningUserAgentMiddleware : Interceptor {
+internal class VersioningUserAgentMiddleware(customHeaders: Map<String, String> = emptyMap()) :
+  Interceptor {
+  private val customHeaders = customHeaders.toMap()
+
   override fun intercept(chain: Interceptor.Chain): Response {
     val request = chain.request()
     val skipClientId = request.header(INTERNAL_HEADER_SKIP_CLIENT_ID) == INTERNAL_HEADER_TRUE
@@ -48,6 +51,8 @@ internal class VersioningUserAgentMiddleware : Interceptor {
     if (request.url.encodedPath.contains(ApiPaths.User.PROFILE_IMAGE)) {
       newRequestBuilder.removeHeader("Content-Type")
     }
+
+    customHeaders.forEach { (name, value) -> newRequestBuilder.addHeader(name, value) }
 
     return chain.proceed(newRequestBuilder.build())
   }

--- a/source/api/src/main/kotlin/com/clerk/api/network/middleware/outgoing/VersioningUserAgentMiddleware.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/middleware/outgoing/VersioningUserAgentMiddleware.kt
@@ -52,7 +52,7 @@ internal class VersioningUserAgentMiddleware(customHeaders: Map<String, String> 
       newRequestBuilder.removeHeader("Content-Type")
     }
 
-    customHeaders.forEach { (name, value) -> newRequestBuilder.addHeader(name, value) }
+    customHeaders.forEach { (name, value) -> newRequestBuilder.header(name, value) }
 
     return chain.proceed(newRequestBuilder.build())
   }

--- a/source/api/src/test/java/com/clerk/api/network/middleware/outgoing/VersioningUserAgentMiddlewareTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/middleware/outgoing/VersioningUserAgentMiddlewareTest.kt
@@ -73,13 +73,28 @@ class VersioningUserAgentMiddlewareTest {
     assertEquals("device_token_123", capturedRequest.header("Authorization"))
   }
 
-  private fun captureRequest(request: Request): Request {
+  @Test
+  fun `intercept appends custom headers`() {
+    val capturedRequest =
+      captureRequest(
+        request = Request.Builder().url(TEST_URL).get().build(),
+        customHeaders = mapOf("x-clerk-host-sdk" to "expo", "x-clerk-host-sdk-version" to "3.4.3"),
+      )
+
+    assertEquals("expo", capturedRequest.header("x-clerk-host-sdk"))
+    assertEquals("3.4.3", capturedRequest.header("x-clerk-host-sdk-version"))
+  }
+
+  private fun captureRequest(
+    request: Request,
+    customHeaders: Map<String, String> = emptyMap(),
+  ): Request {
     val chain = mockk<Interceptor.Chain>()
     val requestSlot = slot<Request>()
     every { chain.request() } returns request
     every { chain.proceed(capture(requestSlot)) } answers { buildResponse(requestSlot.captured) }
 
-    VersioningUserAgentMiddleware().intercept(chain)
+    VersioningUserAgentMiddleware(customHeaders = customHeaders).intercept(chain)
 
     return requestSlot.captured
   }

--- a/source/api/src/test/java/com/clerk/api/network/middleware/outgoing/VersioningUserAgentMiddlewareTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/middleware/outgoing/VersioningUserAgentMiddlewareTest.kt
@@ -74,7 +74,7 @@ class VersioningUserAgentMiddlewareTest {
   }
 
   @Test
-  fun `intercept appends custom headers`() {
+  fun `intercept sets custom headers`() {
     val capturedRequest =
       captureRequest(
         request = Request.Builder().url(TEST_URL).get().build(),
@@ -83,6 +83,20 @@ class VersioningUserAgentMiddlewareTest {
 
     assertEquals("expo", capturedRequest.header("x-clerk-host-sdk"))
     assertEquals("3.4.3", capturedRequest.header("x-clerk-host-sdk-version"))
+  }
+
+  @Test
+  fun `intercept custom headers replace existing header values`() {
+    StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "device_token_123")
+    val capturedRequest =
+      captureRequest(
+        request = Request.Builder().url(TEST_URL).get().build(),
+        customHeaders =
+          mapOf("authorization" to "custom_token_123", "X-Clerk-Client-Id" to "custom_client_123"),
+      )
+
+    assertEquals(listOf("custom_token_123"), capturedRequest.headers("Authorization"))
+    assertEquals(listOf("custom_client_123"), capturedRequest.headers("x-clerk-client-id"))
   }
 
   private fun captureRequest(

--- a/source/api/src/test/java/com/clerk/api/sdk/ProxyUrlConfigurationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ProxyUrlConfigurationTest.kt
@@ -63,6 +63,20 @@ class ProxyUrlConfigurationTest {
   }
 
   @Test
+  fun `customHeaders are passed from options and used for api configuration`() {
+    // Given
+    val proxyUrl = "https://proxy.example.com/__clerk"
+    val customHeaders = mapOf("x-clerk-host-sdk" to "expo", "x-clerk-host-sdk-version" to "3.4.3")
+    val options = ClerkConfigurationOptions(proxyUrl = proxyUrl).withCustomHeaders(customHeaders)
+
+    // When: configure using a fresh ConfigurationManager
+    configure("pk_test_dummy", options)
+
+    // Then
+    assertEquals(customHeaders, ClerkApi.configuredCustomHeaders)
+  }
+
+  @Test
   fun `fallback to publishableKey extraction when proxyUrl is not provided`() {
     // Given
     val domain = "clerk.example.com"


### PR DESCRIPTION
## Summary

- add an options-owned API for configuring additional Clerk API request headers
- thread those headers through `ConfigurationManager` and `ClerkApi` into the outgoing request middleware
- add focused coverage for option propagation and request header appending

## Why

`@clerk/expo` needs to identify itself when it configures the native Android SDK, in addition to the existing Android SDK headers. The motivating headers are:

- `x-clerk-host-sdk: expo`
- `x-clerk-host-sdk-version: <expo package version>`

This mirrors the direction available on iOS, where request customization lives in `Clerk.Options` middleware.

## Approach

This keeps the new capability part of `ClerkConfigurationOptions`, but adds it as an additive method:

```kotlin
ClerkConfigurationOptions()
  .withCustomHeaders(
    mapOf(
      "x-clerk-host-sdk" to "expo",
      "x-clerk-host-sdk-version" to "3.4.3",
    )
  )
```

The configured headers are snapshotted with `toMap()` and appended by `VersioningUserAgentMiddleware` after the built-in Clerk headers. Existing headers like `x-android-sdk-version`, `x-mobile`, auth, client id, and device id are left intact.

## Compatibility and tradeoffs

I intentionally did not add `customHeaders` as a new primary-constructor property on `ClerkConfigurationOptions`. Even with a default value, changing a Kotlin data-class primary constructor can be source-compatible while still being binary-risky for already-compiled consumers because constructor/default-arg/copy signatures change.

The tradeoff is that `customHeaders` is not part of the data class generated `copy()`, `equals()`, or `hashCode()` semantics in this non-major version. That keeps the change additive and minor-safe while still making headers option-owned. In a future major, we can move `customHeaders` into the primary constructor for the cleaner Kotlin data-class shape.

## Testing

- `./gradlew :source:api:spotlessCheck`
- `./gradlew :source:api:compileDebugKotlin :source:api:compileDebugUnitTestKotlin`

Focused Robolectric test execution was attempted, but this local machine only has Java 17 installed and Robolectric selected Android SDK 36, which requires Java 21. The changed source and test Kotlin compile successfully.
