### PR TITLE
feat(api): add clear device token API

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -859,6 +859,19 @@ object Clerk {
     configurationManager.updateDeviceToken(deviceToken)
 
   /**
+   * Clears the stored device token and refreshes the native Clerk state.
+   *
+   * This is the supported way to mirror another Clerk SDK runtime clearing its device token after
+   * [initialize] has already run. The token is removed before forcing a fresh client/environment
+   * fetch, and that refresh intentionally omits the current in-memory client id header so a stale
+   * anonymous client cannot conflict with the cleared token state.
+   *
+   * @return A [ClerkResult] indicating whether the token clear and refresh succeeded.
+   */
+  suspend fun clearDeviceToken(): ClerkResult<Unit, ClerkErrorResponse> =
+    configurationManager.clearDeviceToken()
+
+  /**
    * Returns the current device token from encrypted storage, or null if unavailable.
    *
    * This is used by the Expo bridge to sync the native client token with the JS SDK.
@@ -906,8 +919,9 @@ object Clerk {
   }
 
   private fun Client.withResolvedActiveSession(previousSession: Session?): Client {
-    val currentActiveSessionId =
-      lastActiveSessionId?.takeIf { activeSessionId -> sessions.any { it.id == activeSessionId } }
+    val currentActiveSessionId = lastActiveSessionId?.takeIf { activeSessionId ->
+      sessions.any { it.id == activeSessionId }
+    }
     val resolvedActiveSessionId =
       currentActiveSessionId
         ?: previousSession?.id?.takeIf { previousSessionId ->
@@ -1012,8 +1026,9 @@ fun Map<String, UserSettings.SocialConfig>.toOAuthProvidersList(): List<OAuthPro
     .filter { it.enabled && it.authenticatable }
     .map { OAuthProvider.fromStrategy(it.strategy) }
 
-fun SignIn.identifyingFirstFactor(strategy: String): Factor? =
-  supportedFirstFactors?.firstOrNull { it.strategy == strategy && it.safeIdentifier == identifier }
+fun SignIn.identifyingFirstFactor(strategy: String): Factor? = supportedFirstFactors?.firstOrNull {
+  it.strategy == strategy && it.safeIdentifier == identifier
+}
 
 val SignIn.resetPasswordFactor: Factor?
   get() =

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
@@ -222,31 +222,30 @@ internal class ConfigurationManager {
   private fun launchInitialization(
     options: ClerkConfigurationOptions?,
     configuredVersion: Int,
-  ): Job =
-    scope.launch {
-      val attempt =
-        RefreshAttempt(
-          options = options,
-          retryCount = 0,
-          expectedConfigurationVersion = configuredVersion,
-        )
-      val deviceIdInitJob = async { DeviceIdGenerator.initialize() }
-      val dataRefreshJob = async {
-        refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
-      }
+  ): Job = scope.launch {
+    val attempt =
+      RefreshAttempt(
+        options = options,
+        retryCount = 0,
+        expectedConfigurationVersion = configuredVersion,
+      )
+    val deviceIdInitJob = async { DeviceIdGenerator.initialize() }
+    val dataRefreshJob = async {
+      refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+    }
 
-      deviceIdInitJob.await()
-      AppLifecycleListener.configure {
-        if (hasConfigured) {
-          scope.launch {
-            deferForegroundRefreshDuringPendingSso()
-            refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
-            startTokenRefresh()
-          }
+    deviceIdInitJob.await()
+    AppLifecycleListener.configure {
+      if (hasConfigured) {
+        scope.launch {
+          deferForegroundRefreshDuringPendingSso()
+          refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+          startTokenRefresh()
         }
       }
-      dataRefreshJob.await()
     }
+    dataRefreshJob.await()
+  }
 
   fun isConfigured(): Boolean = hasConfigured
 
@@ -281,29 +280,28 @@ internal class ConfigurationManager {
 
     // Cancel any ongoing jobs
     refreshJob?.cancel()
-    refreshJob =
-      scope.launch {
-        while (isActive) {
-          try {
-            val session = Clerk.session
-            if (session != null) {
-              if (Clerk.debugMode) {
-                ClerkLog.d("Refreshing token for session: ${session.id}")
-              }
-              // Use async to avoid blocking the refresh loop
-              async { session.fetchToken(GetTokenOptions(skipCache = false)) }
-            } else {
-              if (Clerk.debugMode) {
-                ClerkLog.d("No session available for token refresh")
-              }
+    refreshJob = scope.launch {
+      while (isActive) {
+        try {
+          val session = Clerk.session
+          if (session != null) {
+            if (Clerk.debugMode) {
+              ClerkLog.d("Refreshing token for session: ${session.id}")
             }
-          } catch (e: Exception) {
-            ClerkLog.w("Token refresh failed: ${e.message}")
+            // Use async to avoid blocking the refresh loop
+            async { session.fetchToken(GetTokenOptions(skipCache = false)) }
+          } else {
+            if (Clerk.debugMode) {
+              ClerkLog.d("No session available for token refresh")
+            }
           }
-
-          delay(REFRESH_TOKEN_INTERVAL.seconds)
+        } catch (e: Exception) {
+          ClerkLog.w("Token refresh failed: ${e.message}")
         }
+
+        delay(REFRESH_TOKEN_INTERVAL.seconds)
       }
+    }
   }
 
   suspend fun updateDeviceToken(deviceToken: String): ClerkResult<Unit, ClerkErrorResponse> {
@@ -312,6 +310,22 @@ internal class ConfigurationManager {
 
     ensureStorageInitialized()
     StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, deviceToken)
+
+    return refreshClientAndEnvironment(
+      attempt = currentRefreshAttempt(),
+      mode = RefreshMode.DEVICE_TOKEN_UPDATE,
+      skipClientId = true,
+    )
+  }
+
+  suspend fun clearDeviceToken(): ClerkResult<Unit, ClerkErrorResponse> {
+    val validationError = validateDeviceTokenClear()
+    if (validationError != null) return validationError
+
+    ensureStorageInitialized()
+    StorageHelper.deleteValue(StorageKey.DEVICE_TOKEN)
+    Clerk.updateClient(Client())
+    Clerk.clearSessionAndUserState()
 
     return refreshClientAndEnvironment(
       attempt = currentRefreshAttempt(),
@@ -357,6 +371,16 @@ internal class ConfigurationManager {
       !hasConfigured ->
         ClerkResult.unknownFailure(
           IllegalStateException("Clerk must be initialized before updating the device token")
+        )
+      else -> null
+    }
+  }
+
+  private fun validateDeviceTokenClear(): ClerkResult<Unit, ClerkErrorResponse>? {
+    return when {
+      !hasConfigured ->
+        ClerkResult.unknownFailure(
+          IllegalStateException("Clerk must be initialized before clearing the device token")
         )
       else -> null
     }

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
@@ -20,6 +20,7 @@ import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.fold
 import com.clerk.api.session.GetTokenOptions
+import com.clerk.api.session.SessionTokensCache
 import com.clerk.api.session.fetchToken
 import com.clerk.api.sso.SSOService
 import com.clerk.api.storage.StorageHelper
@@ -222,30 +223,31 @@ internal class ConfigurationManager {
   private fun launchInitialization(
     options: ClerkConfigurationOptions?,
     configuredVersion: Int,
-  ): Job = scope.launch {
-    val attempt =
-      RefreshAttempt(
-        options = options,
-        retryCount = 0,
-        expectedConfigurationVersion = configuredVersion,
-      )
-    val deviceIdInitJob = async { DeviceIdGenerator.initialize() }
-    val dataRefreshJob = async {
-      refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
-    }
+  ): Job =
+    scope.launch {
+      val attempt =
+        RefreshAttempt(
+          options = options,
+          retryCount = 0,
+          expectedConfigurationVersion = configuredVersion,
+        )
+      val deviceIdInitJob = async { DeviceIdGenerator.initialize() }
+      val dataRefreshJob = async {
+        refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+      }
 
-    deviceIdInitJob.await()
-    AppLifecycleListener.configure {
-      if (hasConfigured) {
-        scope.launch {
-          deferForegroundRefreshDuringPendingSso()
-          refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
-          startTokenRefresh()
+      deviceIdInitJob.await()
+      AppLifecycleListener.configure {
+        if (hasConfigured) {
+          scope.launch {
+            deferForegroundRefreshDuringPendingSso()
+            refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+            startTokenRefresh()
+          }
         }
       }
+      dataRefreshJob.await()
     }
-    dataRefreshJob.await()
-  }
 
   fun isConfigured(): Boolean = hasConfigured
 
@@ -280,28 +282,29 @@ internal class ConfigurationManager {
 
     // Cancel any ongoing jobs
     refreshJob?.cancel()
-    refreshJob = scope.launch {
-      while (isActive) {
-        try {
-          val session = Clerk.session
-          if (session != null) {
-            if (Clerk.debugMode) {
-              ClerkLog.d("Refreshing token for session: ${session.id}")
+    refreshJob =
+      scope.launch {
+        while (isActive) {
+          try {
+            val session = Clerk.session
+            if (session != null) {
+              if (Clerk.debugMode) {
+                ClerkLog.d("Refreshing token for session: ${session.id}")
+              }
+              // Use async to avoid blocking the refresh loop
+              async { session.fetchToken(GetTokenOptions(skipCache = false)) }
+            } else {
+              if (Clerk.debugMode) {
+                ClerkLog.d("No session available for token refresh")
+              }
             }
-            // Use async to avoid blocking the refresh loop
-            async { session.fetchToken(GetTokenOptions(skipCache = false)) }
-          } else {
-            if (Clerk.debugMode) {
-              ClerkLog.d("No session available for token refresh")
-            }
+          } catch (e: Exception) {
+            ClerkLog.w("Token refresh failed: ${e.message}")
           }
-        } catch (e: Exception) {
-          ClerkLog.w("Token refresh failed: ${e.message}")
-        }
 
-        delay(REFRESH_TOKEN_INTERVAL.seconds)
+          delay(REFRESH_TOKEN_INTERVAL.seconds)
+        }
       }
-    }
   }
 
   suspend fun updateDeviceToken(deviceToken: String): ClerkResult<Unit, ClerkErrorResponse> {
@@ -326,12 +329,16 @@ internal class ConfigurationManager {
     StorageHelper.deleteValue(StorageKey.DEVICE_TOKEN)
     Clerk.updateClient(Client())
     Clerk.clearSessionAndUserState()
+    SessionTokensCache.clear()
 
-    return refreshClientAndEnvironment(
-      attempt = currentRefreshAttempt(),
-      mode = RefreshMode.DEVICE_TOKEN_UPDATE,
-      skipClientId = true,
-    )
+    val result =
+      refreshClientAndEnvironment(
+        attempt = currentRefreshAttempt(),
+        mode = RefreshMode.DEVICE_TOKEN_UPDATE,
+        skipClientId = true,
+      )
+    StorageHelper.deleteValue(StorageKey.DEVICE_TOKEN)
+    return result
   }
 
   /**

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkDeviceTokenUpdateTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkDeviceTokenUpdateTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -78,6 +79,18 @@ class ClerkDeviceTokenUpdateTest {
     assertEquals("Device token must not be blank", result.throwable?.message)
   }
 
+  @Test
+  fun `clearDeviceToken fails when Clerk has not been initialized`() = runTest {
+    val result = Clerk.clearDeviceToken()
+
+    assertTrue(result is ClerkResult.Failure)
+    result as ClerkResult.Failure
+    assertEquals(
+      "Clerk must be initialized before clearing the device token",
+      result.throwable?.message,
+    )
+  }
+
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun `updateDeviceToken persists token and refreshes client state without default client lookup`() =
@@ -115,6 +128,38 @@ class ClerkDeviceTokenUpdateTest {
       assertEquals("client_real", Clerk.client.id)
       assertEquals(refreshedSession, Clerk.session)
       assertEquals(refreshedUser, Clerk.user)
+      assertEquals("After Refresh", Clerk.applicationName)
+      coVerify(exactly = 1) { Client.getSkippingClientId() }
+      coVerify(exactly = 0) { Client.get() }
+    }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun `clearDeviceToken removes token and refreshes client state without default client lookup`() =
+    runTest {
+      configureClerkForDeviceTokenUpdate()
+
+      val staleClient = Client(id = "client_anon")
+      val staleEnvironment = testEnvironment(applicationName = "Before Refresh")
+      val refreshedClient = Client(id = "client_refreshed")
+      val refreshedEnvironment = testEnvironment(applicationName = "After Refresh")
+
+      StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "device_token_123")
+      Clerk.updateClient(staleClient)
+      Clerk.updateEnvironment(staleEnvironment)
+
+      coEvery { Client.getSkippingClientId() } returns ClerkResult.success(refreshedClient)
+      coEvery { Client.get() } returns
+        ClerkResult.unknownFailure(IllegalStateException("Client.get() should not be called"))
+      coEvery { Environment.get() } returns ClerkResult.success(refreshedEnvironment)
+
+      val result = Clerk.clearDeviceToken()
+
+      assertTrue(result is ClerkResult.Success)
+      assertNull(StorageHelper.loadValue(StorageKey.DEVICE_TOKEN))
+      assertEquals("client_refreshed", Clerk.client.id)
+      assertNull(Clerk.session)
+      assertNull(Clerk.user)
       assertEquals("After Refresh", Clerk.applicationName)
       coVerify(exactly = 1) { Client.getSkippingClientId() }
       coVerify(exactly = 0) { Client.get() }

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkDeviceTokenUpdateTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkDeviceTokenUpdateTest.kt
@@ -9,8 +9,10 @@ import com.clerk.api.network.model.environment.AuthConfig
 import com.clerk.api.network.model.environment.DisplayConfig
 import com.clerk.api.network.model.environment.Environment
 import com.clerk.api.network.model.environment.UserSettings
+import com.clerk.api.network.model.token.TokenResource
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
+import com.clerk.api.session.SessionTokensCache
 import com.clerk.api.storage.StorageHelper
 import com.clerk.api.storage.StorageKey
 import com.clerk.api.user.User
@@ -145,10 +147,15 @@ class ClerkDeviceTokenUpdateTest {
       val refreshedEnvironment = testEnvironment(applicationName = "After Refresh")
 
       StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "device_token_123")
+      SessionTokensCache.setToken("sess_123", TokenResource(jwt = "jwt_123"))
       Clerk.updateClient(staleClient)
       Clerk.updateEnvironment(staleEnvironment)
 
-      coEvery { Client.getSkippingClientId() } returns ClerkResult.success(refreshedClient)
+      coEvery { Client.getSkippingClientId() } coAnswers
+        {
+          StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "device_token_refreshed")
+          ClerkResult.success(refreshedClient)
+        }
       coEvery { Client.get() } returns
         ClerkResult.unknownFailure(IllegalStateException("Client.get() should not be called"))
       coEvery { Environment.get() } returns ClerkResult.success(refreshedEnvironment)
@@ -157,6 +164,7 @@ class ClerkDeviceTokenUpdateTest {
 
       assertTrue(result is ClerkResult.Success)
       assertNull(StorageHelper.loadValue(StorageKey.DEVICE_TOKEN))
+      assertEquals(0, SessionTokensCache.size)
       assertEquals("client_refreshed", Clerk.client.id)
       assertNull(Clerk.session)
       assertNull(Clerk.user)


### PR DESCRIPTION
## Summary
- Expose `Clerk.clearDeviceToken()`.
- Delete the stored device token, clear stale runtime client/session/user state, and refresh client/environment without the current client id.
- Add focused unit coverage for the clear-token refresh path.

## Motivation
Expo needs a native primitive for mirroring JS-originated device-token clears. JS can clear its token cache today, but native SDKs only exposed token update paths, which could leave stale native token/client state around.

## Testing
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" rtk ./gradlew :source:api:testDebugUnitTest --tests "com.clerk.api.sdk.ClerkDeviceTokenUpdateTest"`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" rtk ./gradlew :source:api:spotlessCheck :source:api:detekt`