### PR TITLE
Bump compileSdk to 37 and reference explicit targetSdk in samples

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,8 @@ jdk = "17"
 jvmTarget = "17"
 kotlin = "2.4.0"
 minSdk = "24"
-compileSdk = "36"
+targetSdk = "36"
+compileSdk = "37"
 
 
 [libraries]

--- a/samples/custom-flows/build.gradle.kts
+++ b/samples/custom-flows/build.gradle.kts
@@ -14,7 +14,7 @@ android {
   defaultConfig {
     applicationId = "com.clerk.customflows"
     minSdk = libs.versions.minSdk.get().toInt()
-    targetSdk = libs.versions.compileSdk.get().toInt()
+    targetSdk = libs.versions.targetSdk.get().toInt()
 
     val isCI = System.getenv("CI")?.toBoolean() == true
     val clerkPublishableKey = project.findProperty(customFlowsKey) as String?

--- a/samples/linear-clone/build.gradle.kts
+++ b/samples/linear-clone/build.gradle.kts
@@ -15,7 +15,7 @@ android {
   defaultConfig {
     applicationId = "com.clerk.linearclone"
     minSdk = libs.versions.minSdk.get().toInt()
-    targetSdk = libs.versions.compileSdk.get().toInt()
+    targetSdk = libs.versions.targetSdk.get().toInt()
 
     val isCI = System.getenv("CI")?.toBoolean() == true
     val clerkPublishableKey = project.findProperty(linearCloneKey) as String?

--- a/samples/prebuilt-ui/build.gradle.kts
+++ b/samples/prebuilt-ui/build.gradle.kts
@@ -15,7 +15,7 @@ android {
   defaultConfig {
     applicationId = "com.clerk.prebuiltui"
     minSdk = libs.versions.minSdk.get().toInt()
-    targetSdk = libs.versions.compileSdk.get().toInt()
+    targetSdk = libs.versions.targetSdk.get().toInt()
 
     val isCI = System.getenv("CI")?.toBoolean() == true
     val clerkPublishableKey = project.findProperty(prebuiltUiKey) as String?

--- a/samples/quickstart/build.gradle.kts
+++ b/samples/quickstart/build.gradle.kts
@@ -12,7 +12,7 @@ android {
   defaultConfig {
     applicationId = "com.clerk.quickstart"
     minSdk = libs.versions.minSdk.get().toInt()
-    targetSdk = libs.versions.compileSdk.get().toInt()
+    targetSdk = libs.versions.targetSdk.get().toInt()
     compileSdk = libs.versions.compileSdk.get().toInt()
 
     val isCI = System.getenv("CI")?.toBoolean() == true


### PR DESCRIPTION
### Motivation
- Separate `targetSdk` from `compileSdk` and bump `compileSdk` to 37 to allow explicit target SDK configuration across modules.
- Update sample projects to reference the new `targetSdk` variable instead of reusing `compileSdk` to avoid accidental coupling between the two values.

### Description
- Updated `gradle/libs.versions.toml` to add `targetSdk = "36"` and change `compileSdk` to `"37"`.
- Modified sample modules (`samples/custom-flows`, `samples/linear-clone`, `samples/prebuilt-ui`, and `samples/quickstart`) to set `targetSdk = libs.versions.targetSdk.get().toInt()` instead of using `libs.versions.compileSdk.get().toInt()`.
- Adjusted the `samples/quickstart` Gradle file to keep an explicit `compileSdk` assignment after the `targetSdk` change.

### Testing
- No automated tests or CI builds were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a387c47a6e88322ad29b11c58a6d983)