### PR TITLE
Thread Expo PR notification under Android release message

### DIFF
--- a/.github/scripts/open-expo-android-release-pr.sh
+++ b/.github/scripts/open-expo-android-release-pr.sh
@@ -15,6 +15,15 @@ PR_TITLE="chore(expo): Bump clerk-android to ${CLERK_ANDROID_VERSION}"
 version_slug="${CLERK_ANDROID_VERSION//./-}"
 CHANGESET_FILE=".changeset/expo-bump-clerk-android-${version_slug}.md"
 
+write_github_output() {
+  local name="$1"
+  local value="$2"
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "${name}=${value}" >>"$GITHUB_OUTPUT"
+  fi
+}
+
 wait_for_maven_artifacts() {
   local version="$1"
   local urls=(
@@ -77,6 +86,7 @@ write_changeset() {
 open_or_update_pr() {
   local body_file="$1"
   local existing_pr
+  local pr_url
 
   existing_pr=$(
     gh pr list \
@@ -94,15 +104,19 @@ open_or_update_pr() {
       --title "$PR_TITLE" \
       --body-file "$body_file"
     echo "Updated existing PR: ${existing_pr}"
+    write_github_output "pr_url" "$existing_pr"
     return 0
   fi
 
-  gh pr create \
+  pr_url=$(gh pr create \
     --repo "$TARGET_REPO" \
     --base main \
     --head "$BRANCH" \
     --title "$PR_TITLE" \
-    --body-file "$body_file"
+    --body-file "$body_file")
+
+  echo "$pr_url"
+  write_github_output "pr_url" "$pr_url"
 }
 
 main() {

--- a/.github/workflows/expo-android-release-pr.yml
+++ b/.github/workflows/expo-android-release-pr.yml
@@ -20,6 +20,10 @@ on:
     secrets:
       OPEN_EXPO_PR_GH_TOKEN:
         required: true
+    outputs:
+      pr_url:
+        description: "URL of the opened or updated clerk/javascript Expo PR."
+        value: ${{ jobs.open-pr.outputs.pr_url }}
 
 permissions:
   contents: read
@@ -32,6 +36,8 @@ jobs:
   open-pr:
     name: Open clerk/javascript PR
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      pr_url: ${{ steps.open_expo_pr.outputs.pr_url }}
 
     steps:
       - name: Checkout release source
@@ -123,6 +129,7 @@ jobs:
           fetch-depth: 0
 
       - name: Open or update Expo Android release PR
+        id: open_expo_pr
         if: steps.release.outputs.should_open == 'true'
         env:
           CLERK_ANDROID_VERSION: ${{ steps.release.outputs.version }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -196,23 +196,26 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: publish
     if: needs.publish.result == 'success'
+    outputs:
+      channel_id: ${{ steps.post_release_message.outputs.channel_id }}
+      thread_ts: ${{ steps.post_release_message.outputs.thread_ts }}
 
     steps:
       - name: Notify Slack
+        id: post_release_message
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           RELEASE_TAG: ${{ needs.publish.outputs.tag_name }}
           RELEASE_URL: ${{ needs.publish.outputs.release_url }}
         run: |
-          if [ -z "$SLACK_WEBHOOK_URL" ]; then
-            echo "::warning::SLACK_WEBHOOK_URL is not configured; skipping Slack notification"
-            exit 0
-          fi
-
           PAYLOAD=$(jq -n \
+            --arg channel "$SLACK_CHANNEL_ID" \
             --arg tag "$RELEASE_TAG" \
             --arg release_url "$RELEASE_URL" \
             '{
+              channel: $channel,
               text: "Clerk Android SDK \($tag) has been released",
               blocks: [
                 {
@@ -234,11 +237,54 @@ jobs:
               ]
             }')
 
-          curl --fail-with-body \
-            --request POST \
-            --header "Content-type: application/json" \
-            --data "$PAYLOAD" \
-            "$SLACK_WEBHOOK_URL"
+          if [ -n "$SLACK_BOT_TOKEN" ] && [ -n "$SLACK_CHANNEL_ID" ]; then
+            response=$(
+              curl --silent --show-error --fail-with-body \
+                --request POST \
+                --header "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+                --header "Content-type: application/json" \
+                --data "$PAYLOAD" \
+                "https://slack.com/api/chat.postMessage"
+            ) || {
+              echo "::warning::Failed to post Slack release notification; skipping threaded Expo PR notification"
+              exit 0
+            }
+
+            if [ "$(jq -r '.ok' <<<"$response")" != "true" ]; then
+              echo "::warning::Slack rejected release notification: $(jq -r '.error // "unknown_error"' <<<"$response")"
+              exit 0
+            fi
+
+            thread_ts=$(jq -r '.ts // ""' <<<"$response")
+            channel_id=$(jq -r --arg fallback "$SLACK_CHANNEL_ID" '.channel // $fallback' <<<"$response")
+
+            if [ -z "$thread_ts" ]; then
+              echo "::warning::Slack release notification did not return a thread timestamp"
+              exit 0
+            fi
+
+            {
+              echo "channel_id=$channel_id"
+              echo "thread_ts=$thread_ts"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$SLACK_WEBHOOK_URL" ]; then
+            echo "::warning::SLACK_BOT_TOKEN and SLACK_CHANNEL_ID are required for threaded Expo PR notifications; falling back to webhook release notification"
+            webhook_payload=$(jq 'del(.channel)' <<<"$PAYLOAD")
+            curl --silent --show-error --fail-with-body \
+              --request POST \
+              --header "Content-type: application/json" \
+              --data "$webhook_payload" \
+              "$SLACK_WEBHOOK_URL" || {
+                echo "::warning::Failed to post Slack release notification with webhook"
+                exit 0
+              }
+            exit 0
+          fi
+
+          echo "::warning::Slack notification secrets are not configured; skipping Slack notification"
 
   open-expo-android-release-pr:
     needs: publish
@@ -249,3 +295,62 @@ jobs:
       release_url: ${{ needs.publish.outputs.release_url }}
     secrets:
       OPEN_EXPO_PR_GH_TOKEN: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}
+
+  notify-expo-android-release-pr:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - publish
+      - notify-slack
+      - open-expo-android-release-pr
+    if: always() && needs.publish.result == 'success' && needs.notify-slack.result == 'success' && needs.open-expo-android-release-pr.result == 'success' && needs.notify-slack.outputs.thread_ts != '' && needs.open-expo-android-release-pr.outputs.pr_url != ''
+
+    steps:
+      - name: Notify Slack about Expo PR
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ needs.notify-slack.outputs.channel_id }}
+          SLACK_THREAD_TS: ${{ needs.notify-slack.outputs.thread_ts }}
+          EXPO_PR_URL: ${{ needs.open-expo-android-release-pr.outputs.pr_url }}
+          RELEASE_TAG: ${{ needs.publish.outputs.tag_name }}
+        run: |
+          if [ -z "$SLACK_BOT_TOKEN" ] || [ -z "$SLACK_CHANNEL_ID" ] || [ -z "$SLACK_THREAD_TS" ]; then
+            echo "::warning::Slack thread details are not configured; skipping Expo PR Slack notification"
+            exit 0
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg channel "$SLACK_CHANNEL_ID" \
+            --arg thread_ts "$SLACK_THREAD_TS" \
+            --arg pr_url "$EXPO_PR_URL" \
+            --arg tag "$RELEASE_TAG" \
+            '{
+              channel: $channel,
+              thread_ts: $thread_ts,
+              reply_broadcast: true,
+              text: "Expo Android SDK update PR for \($tag): \($pr_url)",
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: "*Expo Android SDK update PR for \($tag)*\n<\($pr_url)|View the clerk/javascript PR>"
+                  }
+                }
+              ]
+            }')
+
+          response=$(
+            curl --silent --show-error --fail-with-body \
+              --request POST \
+              --header "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              --header "Content-type: application/json" \
+              --data "$PAYLOAD" \
+              "https://slack.com/api/chat.postMessage"
+          ) || {
+            echo "::warning::Failed to post Expo PR Slack notification"
+            exit 0
+          }
+
+          if [ "$(jq -r '.ok' <<<"$response")" != "true" ]; then
+            echo "::warning::Slack rejected Expo PR notification: $(jq -r '.error // "unknown_error"' <<<"$response")"
+          fi


### PR DESCRIPTION
## Summary

- switch the Android release Slack notification to `chat.postMessage` when `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` are configured so the workflow can capture the release message thread timestamp
- expose the Expo Android release PR URL from the reusable workflow and helper script
- post the Expo PR link as a broadcasted reply in the Android SDK release thread

## Notes

The existing webhook notification remains as a fallback for the release message, but threaded Expo PR notifications require the Slack bot token and channel ID secrets.

## Validation

- `bash -n .github/scripts/open-expo-android-release-pr.sh`
- YAML parse for `.github/workflows/manual-release.yml` and `.github/workflows/expo-android-release-pr.yml`
- `git diff --check -- .github/workflows/manual-release.yml .github/workflows/expo-android-release-pr.yml .github/scripts/open-expo-android-release-pr.sh`

`actionlint` was not installed locally, so that check was not run.