### PR TITLE
feat(ui): prefill and lock sign-up names

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -206,6 +206,8 @@ internal fun AuthStartViewImpl(
             showPhoneBadge = lastUsedAuth?.showsPhoneBadge == true,
             showEmailUsernameBadge = lastUsedAuth?.showsEmailUsernameBadge == true,
             onSubmit = onSubmit,
+            identifierLocked = authState.authStartIdentifierLocked,
+            phoneNumberLocked = authState.authStartPhoneNumberLocked,
           )
 
           ClerkButton(
@@ -309,6 +311,8 @@ private fun AuthInputField(
   showPhoneBadge: Boolean,
   showEmailUsernameBadge: Boolean,
   onSubmit: () -> Unit,
+  identifierLocked: Boolean,
+  phoneNumberLocked: Boolean,
 ) {
   if (authViewHelper.phoneNumberIsEnabled && phoneNumberFieldIsActive) {
     LastUsedAuthBadgeOverlay(isVisible = showPhoneBadge) {
@@ -318,6 +322,7 @@ private fun AuthInputField(
         onValueChange = onPhoneNumberChange,
         imeAction = ImeAction.Go,
         keyboardActions = KeyboardActions(onGo = { onSubmit() }),
+        enabled = !phoneNumberLocked,
       )
     }
   } else {
@@ -333,6 +338,7 @@ private fun AuthInputField(
             imeAction = ImeAction.Go,
           ),
         keyboardActions = KeyboardActions(onGo = { onSubmit() }),
+        enabled = !identifierLocked,
       )
     }
   }

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
@@ -368,8 +368,10 @@ internal class AuthState(
     config.initialLastName?.let { signUpLastName = it }
 
     val initialIdentifier = config.initialIdentifier
-    initialIdentifierWasPrefilled = !initialIdentifier.isNullOrBlank() && !initialIdentifier.looksLikePhoneNumber()
-    initialPhoneNumberWasPrefilled = !initialIdentifier.isNullOrBlank() && initialIdentifier.looksLikePhoneNumber()
+    initialIdentifierWasPrefilled =
+      !initialIdentifier.isNullOrBlank() && !initialIdentifier.looksLikePhoneNumber()
+    initialPhoneNumberWasPrefilled =
+      !initialIdentifier.isNullOrBlank() && initialIdentifier.looksLikePhoneNumber()
     when {
       initialIdentifier != null && initialIdentifier.looksLikePhoneNumber() -> {
         updateAuthStartPhoneNumber(initialIdentifier)

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
@@ -56,6 +56,9 @@ internal class AuthState(
   var unsafeMetadata by mutableStateOf(identifierConfig.unsafeMetadata)
     private set
 
+  var lockPrefilledFields by mutableStateOf(identifierConfig.lockPrefilledFields)
+    private set
+
   var identifierConfigVersion by mutableStateOf(0)
     private set
 
@@ -63,6 +66,10 @@ internal class AuthState(
     mutableStateOf(sharedPreferences.getString(AUTH_START_IDENTIFIER_STORAGE_KEY, null).orEmpty())
   private var authStartPhoneNumberState by
     mutableStateOf(sharedPreferences.getString(AUTH_START_PHONE_NUMBER_STORAGE_KEY, null).orEmpty())
+  private var initialIdentifierWasPrefilled by mutableStateOf(false)
+  private var initialPhoneNumberWasPrefilled by mutableStateOf(false)
+  private var initialFirstNameWasPrefilled by mutableStateOf(false)
+  private var initialLastNameWasPrefilled by mutableStateOf(false)
 
   // Auth start fields
   var authStartIdentifier: String
@@ -101,6 +108,18 @@ internal class AuthState(
   var signUpEmail by mutableStateOf("")
   var signUpPhoneNumber by mutableStateOf("")
   var signUpLegalAccepted by mutableStateOf(false)
+
+  val authStartIdentifierLocked: Boolean
+    get() = lockPrefilledFields && initialIdentifierWasPrefilled
+
+  val authStartPhoneNumberLocked: Boolean
+    get() = lockPrefilledFields && initialPhoneNumberWasPrefilled
+
+  val signUpFirstNameLocked: Boolean
+    get() = lockPrefilledFields && initialFirstNameWasPrefilled
+
+  val signUpLastNameLocked: Boolean
+    get() = lockPrefilledFields && initialLastNameWasPrefilled
 
   override fun navigateTo(destination: NavKey) {
     shouldResumeInProgressAuthAttempt = true
@@ -326,10 +345,13 @@ internal class AuthState(
     appliedIdentifierConfig = config
     persistIdentifiers = config.persistIdentifiers
     unsafeMetadata = config.unsafeMetadata
+    lockPrefilledFields = config.lockPrefilledFields
 
     val identifierFieldsChanged =
       previousConfig == null ||
         config.initialIdentifier != previousConfig.initialIdentifier ||
+        config.initialFirstName != previousConfig.initialFirstName ||
+        config.initialLastName != previousConfig.initialLastName ||
         config.persistIdentifiers != previousConfig.persistIdentifiers
     if (!identifierFieldsChanged) return
 
@@ -340,7 +362,14 @@ internal class AuthState(
       LastUsedIdentifierStorage.clear(sharedPreferences)
     }
 
+    initialFirstNameWasPrefilled = !config.initialFirstName.isNullOrBlank()
+    initialLastNameWasPrefilled = !config.initialLastName.isNullOrBlank()
+    config.initialFirstName?.let { signUpFirstName = it }
+    config.initialLastName?.let { signUpLastName = it }
+
     val initialIdentifier = config.initialIdentifier
+    initialIdentifierWasPrefilled = !initialIdentifier.isNullOrBlank() && !initialIdentifier.looksLikePhoneNumber()
+    initialPhoneNumberWasPrefilled = !initialIdentifier.isNullOrBlank() && initialIdentifier.looksLikePhoneNumber()
     when {
       initialIdentifier != null && initialIdentifier.looksLikePhoneNumber() -> {
         updateAuthStartPhoneNumber(initialIdentifier)
@@ -351,6 +380,8 @@ internal class AuthState(
         updateAuthStartPhoneNumber("")
       }
       !config.persistIdentifiers -> {
+        initialIdentifierWasPrefilled = false
+        initialPhoneNumberWasPrefilled = false
         updateAuthStartIdentifier("")
         updateAuthStartPhoneNumber("")
       }
@@ -395,6 +426,9 @@ internal class AuthState(
 
 internal data class AuthIdentifierConfig(
   val initialIdentifier: String? = null,
+  val initialFirstName: String? = null,
+  val initialLastName: String? = null,
+  val lockPrefilledFields: Boolean = false,
   val persistIdentifiers: Boolean = true,
   val unsafeMetadata: Map<String, Any>? = null,
 )

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -65,7 +65,8 @@ import kotlinx.serialization.Serializable
  *   routed to the phone number field automatically.
  * @param initialFirstName Optional initial value for the first name field during sign-up.
  * @param initialLastName Optional initial value for the last name field during sign-up.
- * @param lockPrefilledFields When `true`, prefilled identifier and sign-up name fields are read-only.
+ * @param lockPrefilledFields When `true`, prefilled identifier and sign-up name fields are
+ *   read-only.
  * @param persistIdentifiers When `false`, stored auth-start identifiers are cleared and future
  *   edits are kept in memory only for the lifetime of the current view.
  * @param preferGoogleOneTap When `true`, Google social auth uses native Google One Tap if

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -63,6 +63,9 @@ import kotlinx.serialization.Serializable
  *
  * @param initialIdentifier Optional initial value for the identifier field. Phone-like values are
  *   routed to the phone number field automatically.
+ * @param initialFirstName Optional initial value for the first name field during sign-up.
+ * @param initialLastName Optional initial value for the last name field during sign-up.
+ * @param lockPrefilledFields When `true`, prefilled identifier and sign-up name fields are read-only.
  * @param persistIdentifiers When `false`, stored auth-start identifiers are cleared and future
  *   edits are kept in memory only for the lifetime of the current view.
  * @param preferGoogleOneTap When `true`, Google social auth uses native Google One Tap if
@@ -82,6 +85,9 @@ fun AuthView(
   modifier: Modifier = Modifier,
   clerkTheme: ClerkTheme? = null,
   initialIdentifier: String? = null,
+  initialFirstName: String? = null,
+  initialLastName: String? = null,
+  lockPrefilledFields: Boolean = false,
   persistIdentifiers: Boolean = true,
   preferGoogleOneTap: Boolean = true,
   startSocialOAuthAsSignUp: Boolean = false,
@@ -95,9 +101,19 @@ fun AuthView(
     val fullScreenModifier = Modifier.fillMaxSize().then(modifier)
     val backStack = rememberNavBackStack(AuthDestination.AuthStart)
     val identifierConfig =
-      remember(initialIdentifier, persistIdentifiers, unsafeMetadata) {
+      remember(
+        initialIdentifier,
+        initialFirstName,
+        initialLastName,
+        lockPrefilledFields,
+        persistIdentifiers,
+        unsafeMetadata,
+      ) {
         AuthIdentifierConfig(
           initialIdentifier = initialIdentifier,
+          initialFirstName = initialFirstName,
+          initialLastName = initialLastName,
+          lockPrefilledFields = lockPrefilledFields,
           persistIdentifiers = persistIdentifiers,
           unsafeMetadata = unsafeMetadata,
         )

--- a/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
@@ -105,6 +105,7 @@ private const val DROPDOWN_HEIGHT_DIVISOR = 3
  * @param errorText Optional error message to display below the input field
  * @param value The complete phone number including country code (e.g., "+1 5551234567")
  * @param onValueChange Callback when the complete phone number changes
+ * @param enabled Whether the text field is enabled and accepts user input
  */
 @Composable
 @SuppressLint("ComposeParameterOrder")
@@ -115,6 +116,7 @@ fun ClerkPhoneNumberField(
   onValueChange: (String) -> Unit,
   imeAction: ImeAction = ImeAction.Default,
   keyboardActions: KeyboardActions = KeyboardActions.Default,
+  enabled: Boolean = true,
   clerkTheme: ClerkTheme? = null,
 ) {
   ClerkPhoneNumberFieldImpl(
@@ -124,6 +126,7 @@ fun ClerkPhoneNumberField(
     onValueChange = onValueChange,
     imeAction = imeAction,
     keyboardActions = keyboardActions,
+    enabled = enabled,
     clerkTheme = clerkTheme,
   )
 }
@@ -191,6 +194,7 @@ private fun CountryAutoDetectionEffect(
  * @param value The complete phone number (including country prefix) - this is the source of truth
  * @param errorText Optional error message to display below the input field
  * @param onValueChange Callback when the complete phone number changes
+ * @param enabled Whether the text field is enabled and accepts user input
  */
 @Composable
 internal fun ClerkPhoneNumberFieldImpl(
@@ -200,6 +204,7 @@ internal fun ClerkPhoneNumberFieldImpl(
   errorText: String? = null,
   imeAction: ImeAction = ImeAction.Default,
   keyboardActions: KeyboardActions = KeyboardActions.Default,
+  enabled: Boolean = true,
   clerkTheme: ClerkTheme? = null,
 ) {
   val defaultCountry = PhoneInputUtils.getDefaultCountry()
@@ -228,6 +233,7 @@ internal fun ClerkPhoneNumberFieldImpl(
       Column {
         CountrySelector(
           selectedCountry = selectedCountry,
+          enabled = enabled,
           onSelect = { country ->
             // Extract the phone number part without the country prefix
             val prefix = selectedCountry.getPhonePrefix
@@ -262,6 +268,7 @@ internal fun ClerkPhoneNumberFieldImpl(
           countryCode = selectedCountry.countryShortName,
           imeAction = imeAction,
           keyboardActions = keyboardActions,
+          enabled = enabled,
         )
       }
     }
@@ -292,6 +299,7 @@ private fun PhoneNumberInput(
   errorText: String? = null,
   imeAction: ImeAction = ImeAction.Default,
   keyboardActions: KeyboardActions = KeyboardActions.Default,
+  enabled: Boolean = true,
 ) {
 
   val interactionSource = remember { MutableInteractionSource() }
@@ -338,6 +346,7 @@ private fun PhoneNumberInput(
       keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone, imeAction = imeAction),
       keyboardActions = keyboardActions,
       singleLine = true,
+      enabled = enabled,
     )
     errorText?.let { errorText ->
       Row(
@@ -377,13 +386,16 @@ private fun PhoneNumberInput(
 private fun CountrySelector(
   selectedCountry: CountryInfo,
   modifier: Modifier = Modifier,
+  enabled: Boolean = true,
   onSelect: (CountryInfo) -> Unit,
 ) {
   var isExpanded by remember { mutableStateOf(false) }
 
   Box(
     modifier =
-      Modifier.padding(top = dp8).heightIn(min = dp56).clickable { isExpanded = !isExpanded }
+      Modifier.padding(top = dp8)
+        .heightIn(min = dp56)
+        .clickable(enabled = enabled) { isExpanded = !isExpanded }
   ) {
     TextWithIcon(modifier = modifier, selectedCountry = selectedCountry, isExpanded = isExpanded)
     Text(

--- a/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
@@ -393,9 +393,9 @@ private fun CountrySelector(
 
   Box(
     modifier =
-      Modifier.padding(top = dp8)
-        .heightIn(min = dp56)
-        .clickable(enabled = enabled) { isExpanded = !isExpanded }
+      Modifier.padding(top = dp8).heightIn(min = dp56).clickable(enabled = enabled) {
+        isExpanded = !isExpanded
+      }
   ) {
     TextWithIcon(modifier = modifier, selectedCountry = selectedCountry, isExpanded = isExpanded)
     Text(

--- a/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
@@ -1,6 +1,5 @@
 package com.clerk.ui.core.input
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -101,19 +100,21 @@ private const val DROPDOWN_HEIGHT_DIVISOR = 3
  * }
  * ```
  *
- * @param modifier [Modifier] to be applied to the component
- * @param errorText Optional error message to display below the input field
  * @param value The complete phone number including country code (e.g., "+1 5551234567")
  * @param onValueChange Callback when the complete phone number changes
- * @param enabled Whether the text field is enabled and accepts user input
+ * @param modifier [Modifier] to be applied to the component
+ * @param errorText Optional error message to display below the input field
+ * @param imeAction IME action to show on the keyboard
+ * @param keyboardActions Keyboard action callbacks for IME events
+ * @param enabled Whether the phone input and country selector accept user input
+ * @param clerkTheme Optional Clerk theme override for this component
  */
 @Composable
-@SuppressLint("ComposeParameterOrder")
 fun ClerkPhoneNumberField(
   value: String,
+  onValueChange: (String) -> Unit,
   modifier: Modifier = Modifier,
   errorText: String? = null,
-  onValueChange: (String) -> Unit,
   imeAction: ImeAction = ImeAction.Default,
   keyboardActions: KeyboardActions = KeyboardActions.Default,
   enabled: Boolean = true,
@@ -190,11 +191,14 @@ private fun CountryAutoDetectionEffect(
  * This composable handles the state management for country selection and phone number input,
  * including automatic country detection and formatting.
  *
- * @param modifier [Modifier] to be applied to the component
- * @param value The complete phone number (including country prefix) - this is the source of truth
- * @param errorText Optional error message to display below the input field
  * @param onValueChange Callback when the complete phone number changes
- * @param enabled Whether the text field is enabled and accepts user input
+ * @param value The complete phone number (including country prefix) - this is the source of truth
+ * @param modifier [Modifier] to be applied to the component
+ * @param errorText Optional error message to display below the input field
+ * @param imeAction IME action to show on the keyboard
+ * @param keyboardActions Keyboard action callbacks for IME events
+ * @param enabled Whether the phone input and country selector accept user input
+ * @param clerkTheme Optional Clerk theme override for this component
  */
 @Composable
 internal fun ClerkPhoneNumberFieldImpl(
@@ -235,26 +239,20 @@ internal fun ClerkPhoneNumberFieldImpl(
           selectedCountry = selectedCountry,
           enabled = enabled,
           onSelect = { country ->
-            // Extract the phone number part without the country prefix
             val prefix = selectedCountry.getPhonePrefix
-            val currentNumberWithoutPrefix =
+            val numberWithoutPrefix =
               when {
                 value == prefix -> ""
-                value.startsWith("$prefix ") -> value.substring(prefix.length + 1).trim()
-                value.startsWith(prefix) && value.length > prefix.length ->
-                  value.substring(prefix.length).trim()
-
+                value.startsWith("$prefix ") -> value.drop(prefix.length + 1).trim()
+                value.startsWith(prefix) -> value.drop(prefix.length).trim()
                 else -> value.trim()
               }
-
             selectedCountry = country
-            val newPhoneNumber =
-              if (currentNumberWithoutPrefix.isNotEmpty()) {
-                "${country.getPhonePrefix} $currentNumberWithoutPrefix"
-              } else {
-                country.getPhonePrefix
-              }
-            onValueChange(newPhoneNumber)
+            onValueChange(
+              listOf(country.getPhonePrefix, numberWithoutPrefix)
+                .filter(String::isNotEmpty)
+                .joinToString(" ")
+            )
           },
         )
       }
@@ -289,6 +287,9 @@ internal fun ClerkPhoneNumberFieldImpl(
  * @param onValueChange Callback when phone number changes (receives complete phone number)
  * @param countryCode Selected country code for formatting
  * @param errorText Optional error message to display
+ * @param imeAction IME action to show on the keyboard
+ * @param keyboardActions Keyboard action callbacks for IME events
+ * @param enabled Whether the phone text field accepts user input
  */
 @Composable
 private fun PhoneNumberInput(
@@ -336,8 +337,9 @@ private fun PhoneNumberInput(
             errorText != null -> MaterialTheme.colorScheme.error
             else -> ClerkMaterialTheme.colors.mutedForeground
           }
+
         Text(
-          stringResource(R.string.enter_your_phone_number),
+          text = stringResource(R.string.enter_your_phone_number),
           style = labelStyle,
           color = labelColor,
         )
@@ -348,23 +350,28 @@ private fun PhoneNumberInput(
       singleLine = true,
       enabled = enabled,
     )
-    errorText?.let { errorText ->
-      Row(
-        modifier = Modifier.fillMaxWidth().padding(top = dp8),
-        horizontalArrangement = Arrangement.spacedBy(dp4, alignment = Alignment.Start),
-        verticalAlignment = Alignment.Top,
-      ) {
-        Icon(
-          painter = painterResource(R.drawable.ic_warning),
-          contentDescription = null,
-          tint = ClerkMaterialTheme.colors.danger,
-        )
-        Text(
-          text = errorText,
-          color = ClerkMaterialTheme.colors.danger,
-          style = ClerkMaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Normal),
-        )
-      }
+    PhoneNumberInputError(errorText = errorText)
+  }
+}
+
+@Composable
+private fun PhoneNumberInputError(errorText: String?) {
+  errorText?.let {
+    Row(
+      modifier = Modifier.fillMaxWidth().padding(top = dp8),
+      horizontalArrangement = Arrangement.spacedBy(dp4, alignment = Alignment.Start),
+      verticalAlignment = Alignment.Top,
+    ) {
+      Icon(
+        painter = painterResource(R.drawable.ic_warning),
+        contentDescription = null,
+        tint = ClerkMaterialTheme.colors.danger,
+      )
+      Text(
+        text = it,
+        color = ClerkMaterialTheme.colors.danger,
+        style = ClerkMaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Normal),
+      )
     }
   }
 }
@@ -380,6 +387,7 @@ private fun PhoneNumberInput(
  *
  * @param selectedCountry Currently selected country
  * @param modifier [Modifier] to be applied to the component
+ * @param enabled Whether the selector can be opened and changed
  * @param onSelect Callback when a country is selected
  */
 @Composable

--- a/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedAuthScaffold.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/scaffold/ClerkThemedAuthScaffold.kt
@@ -1,7 +1,9 @@
 package com.clerk.ui.core.scaffold
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -19,6 +21,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -34,6 +37,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -49,6 +53,8 @@ import com.clerk.ui.core.appbar.ClerkTopAppBar
 import com.clerk.ui.core.button.standard.ClerkButton
 import com.clerk.ui.core.button.standard.ClerkButtonConfiguration
 import com.clerk.ui.core.button.standard.ClerkButtonDefaults
+import com.clerk.ui.core.button.standard.buildButtonTokens
+import com.clerk.ui.core.dimens.dp1
 import com.clerk.ui.core.dimens.dp12
 import com.clerk.ui.core.dimens.dp16
 import com.clerk.ui.core.dimens.dp18
@@ -77,6 +83,7 @@ internal fun ClerkThemedAuthScaffold(
   hasBackButton: Boolean = true,
   trailingContent: (@Composable () -> Unit)? = null,
   identifier: String? = null,
+  identifierEditable: Boolean = true,
   onClickIdentifier: () -> Unit = {},
   spacingAfterIdentifier: Dp = dp32,
   showSignedInUserButton: Boolean = true,
@@ -101,6 +108,7 @@ internal fun ClerkThemedAuthScaffold(
       title = title,
       subtitle = subtitle,
       identifier = identifier,
+      identifierEditable = identifierEditable,
       onClickIdentifier = onClickIdentifier,
       spacingAfterIdentifier = spacingAfterIdentifier,
     )
@@ -153,22 +161,10 @@ private fun AuthScaffoldContent(
     }
     config.identifier?.let {
       Spacers.Vertical.Spacer8()
-      ClerkButton(
-        paddingValues = PaddingValues(horizontal = dp8),
-        modifier = Modifier.defaultMinSize(minWidth = 120.dp),
-        text = it,
+      AuthIdentifierView(
+        identifier = it,
+        editable = config.identifierEditable,
         onClick = config.onClickIdentifier,
-        isEnabled = true,
-        configuration =
-          ClerkButtonDefaults.configuration(
-            style = ClerkButtonConfiguration.ButtonStyle.Secondary,
-            emphasis = ClerkButtonConfiguration.Emphasis.High,
-          ),
-        icons =
-          ClerkButtonDefaults.icons(
-            trailingIcon = R.drawable.ic_edit,
-            trailingIconColor = ClerkMaterialTheme.colors.mutedForeground,
-          ),
       )
     }
     Spacer(modifier = Modifier.height(config.spacingAfterIdentifier))
@@ -182,9 +178,57 @@ private data class AuthScaffoldConfig(
   val title: String,
   val subtitle: String?,
   val identifier: String?,
+  val identifierEditable: Boolean,
   val onClickIdentifier: () -> Unit,
   val spacingAfterIdentifier: Dp,
 )
+
+@Composable
+private fun AuthIdentifierView(identifier: String, editable: Boolean, onClick: () -> Unit) {
+  val configuration =
+    ClerkButtonDefaults.configuration(
+      style = ClerkButtonConfiguration.ButtonStyle.Secondary,
+      emphasis = ClerkButtonConfiguration.Emphasis.High,
+    )
+
+  if (editable) {
+    ClerkButton(
+      paddingValues = PaddingValues(horizontal = dp8),
+      modifier = Modifier.defaultMinSize(minWidth = 120.dp),
+      text = identifier,
+      onClick = onClick,
+      isEnabled = true,
+      configuration = configuration,
+      icons =
+        ClerkButtonDefaults.icons(
+          trailingIcon = R.drawable.ic_edit,
+          trailingIconColor = ClerkMaterialTheme.colors.mutedForeground,
+        ),
+    )
+  } else {
+    val tokens = buildButtonTokens(config = configuration, isPressed = false)
+    Surface(
+      modifier = Modifier.defaultMinSize(minWidth = 120.dp).height(tokens.height),
+      shape = ClerkMaterialTheme.shape,
+      color = tokens.backgroundColor,
+      border = BorderStroke(dp1, ClerkMaterialTheme.colors.shadow.copy(alpha = 0.08f)),
+    ) {
+      Row(
+        modifier = Modifier.padding(horizontal = dp8),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+      ) {
+        Text(
+          text = identifier,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          style = tokens.textStyle,
+          color = tokens.foreground,
+        )
+      }
+    }
+  }
+}
 
 private fun signedInTrailingContent(
   showSignedInUserButton: Boolean,

--- a/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/code/SignInFactorCodeView.kt
@@ -111,12 +111,20 @@ private fun SignInFactorCodeViewImpl(
       viewModel.resetVerificationState()
     },
   )
+  val identifierEditable =
+    isSecondFactor ||
+      when (factor.strategy) {
+        StrategyKeys.PHONE_CODE -> !authState.authStartPhoneNumberLocked
+        StrategyKeys.EMAIL_CODE -> !authState.authStartIdentifierLocked
+        else -> true
+      }
   ClerkThemedAuthScaffold(
     modifier = modifier,
     onBackPressed = { authState.navigateBack() },
     title = SignInFactorCodeUiHelper.titleForStrategy(factor),
     subtitle = SignInFactorCodeUiHelper.subtitleForStrategy(factor),
     identifier = factor.safeIdentifier,
+    identifierEditable = identifierEditable,
     snackbarHostState = snackbarHostState,
     onClickIdentifier = authState::navigateToAuthStartForIdentifierEdit,
   ) {

--- a/source/ui/src/main/java/com/clerk/ui/signin/emaillink/SignInFactorOneEmailLinkView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/emaillink/SignInFactorOneEmailLinkView.kt
@@ -87,6 +87,7 @@ private fun SignInFactorOneEmailLinkViewImpl(
       Clerk.applicationName?.let { stringResource(R.string.to_continue_to, it) }
         ?: stringResource(R.string.to_continue),
     identifier = factor.safeIdentifier,
+    identifierEditable = !authState.authStartIdentifierLocked,
     onClickIdentifier = authState::navigateToAuthStartForIdentifierEdit,
     snackbarHostState = snackbarHostState,
   ) {

--- a/source/ui/src/main/java/com/clerk/ui/signup/code/SignUpCodeView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/code/SignUpCodeView.kt
@@ -77,12 +77,18 @@ private fun SignUpCodeViewImpl(
       is SignUpCodeField.Phone -> stringResource(R.string.check_your_phone)
       is SignUpCodeField.Email -> stringResource(R.string.check_your_email)
     }
+  val identifierEditable =
+    when (field) {
+      is SignUpCodeField.Phone -> !authState.authStartPhoneNumberLocked
+      is SignUpCodeField.Email -> !authState.authStartIdentifierLocked
+    }
 
   ClerkThemedAuthScaffold(
     modifier = modifier,
     title = title,
     hasLogo = false,
     identifier = field.value.formattedAsPhoneNumberIfPossible,
+    identifierEditable = identifierEditable,
     onClickIdentifier = authState::navigateToAuthStartForIdentifierEdit,
     spacingAfterIdentifier = dp28,
     snackbarHostState = snackbarHostState,

--- a/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/completeprofile/SignUpCompleteProfileView.kt
@@ -160,6 +160,8 @@ private fun SignUpCompleteProfileImpl(
         onLastChange = { authState.signUpLastName = it },
         onFocusChange = { helper.focusTo(it) },
         onSubmit = onSubmit,
+        firstLocked = authState.signUpFirstNameLocked,
+        lastLocked = authState.signUpLastNameLocked,
       )
 
       if (showLegalConsent) {
@@ -192,6 +194,8 @@ private fun InputRow(
   onLastChange: (String) -> Unit,
   onFocusChange: (CompleteProfileField) -> Unit = {},
   onSubmit: () -> Unit = {},
+  firstLocked: Boolean = false,
+  lastLocked: Boolean = false,
 ) {
   val bothEnabled = firstEnabled && lastEnabled
   val lastNameFocusRequester = remember { FocusRequester() }
@@ -228,6 +232,7 @@ private fun InputRow(
             onFocusChange = { onFocusChange(CompleteProfileField.FirstName) },
             keyboardOptions = KeyboardOptions(imeAction = firstNameImeAction),
             keyboardActions = firstNameKeyboardActions,
+            enabled = !firstLocked,
           )
         }
         if (lastEnabled) {
@@ -240,6 +245,7 @@ private fun InputRow(
             onFocusChange = { onFocusChange(CompleteProfileField.LastName) },
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(onDone = { onSubmit() }),
+            enabled = !lastLocked,
           )
         }
       }
@@ -259,6 +265,7 @@ private fun InputRow(
             onFocusChange = { onFocusChange(CompleteProfileField.FirstName) },
             keyboardOptions = KeyboardOptions(imeAction = firstNameImeAction),
             keyboardActions = firstNameKeyboardActions,
+            enabled = !firstLocked,
           )
         }
         if (lastEnabled) {
@@ -271,6 +278,7 @@ private fun InputRow(
             onFocusChange = { onFocusChange(CompleteProfileField.LastName) },
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(onDone = { onSubmit() }),
+            enabled = !lastLocked,
           )
         }
       }

--- a/source/ui/src/main/java/com/clerk/ui/signup/emaillink/SignUpEmailLinkView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/emaillink/SignUpEmailLinkView.kt
@@ -84,6 +84,7 @@ private fun SignUpEmailLinkViewImpl(
       Clerk.applicationName?.let { stringResource(R.string.to_continue_to, it) }
         ?: stringResource(R.string.to_continue),
     identifier = emailAddress,
+    identifierEditable = !authState.authStartIdentifierLocked,
     onClickIdentifier = authState::navigateToAuthStartForIdentifierEdit,
     hasLogo = false,
     snackbarHostState = snackbarHostState,

--- a/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
+++ b/workbench/src/main/java/com/clerk/workbench/MainActivity.kt
@@ -61,7 +61,7 @@ class MainActivity : ComponentActivity() {
             if (normalizedKey.isBlank()) {
               StorageHelper.deleteValue(StorageKey.PUBLIC_KEY)
             } else {
-              StorageHelper.saveValue(StorageKey.PUBLIC_KEY, normalizedKey)
+              StorageHelper.saveValue(StorageKey.PUBLIC_KEY,  normalizedKey)
             }
 
             if (normalizedProxy.isBlank()) {

--- a/workbench/src/main/java/com/clerk/workbench/WorkbenchAuthGate.kt
+++ b/workbench/src/main/java/com/clerk/workbench/WorkbenchAuthGate.kt
@@ -10,21 +10,15 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.clerk.api.Clerk
 import com.clerk.api.session.pendingTaskKey
-import com.clerk.ui.auth.AuthMode
 import com.clerk.ui.auth.AuthView
 
 @Composable
-internal fun WorkbenchAuthGate(
-  persistIdentifiers: Boolean = true,
-  signedInContent: @Composable () -> Unit,
-) {
+internal fun WorkbenchAuthGate(signedInContent: @Composable () -> Unit) {
   val isInitialized by Clerk.isInitialized.collectAsStateWithLifecycle()
   val session by Clerk.sessionFlow.collectAsStateWithLifecycle()
   val user by Clerk.userFlow.collectAsStateWithLifecycle()
   val pendingTaskKey = session?.pendingTaskKey
   var isAuthFlowActive by rememberSaveable { mutableStateOf(false) }
-  val manualTestIdentifier =
-    rememberSaveable { "sam+clerk_test@example.com" }
 
   LaunchedEffect(isInitialized, user?.id, session?.id, pendingTaskKey) {
     if (!isInitialized) return@LaunchedEffect
@@ -33,19 +27,8 @@ internal fun WorkbenchAuthGate(
 
   when {
     !isInitialized -> CircularProgressIndicator()
-    isAuthFlowActive || user == null || pendingTaskKey != null ->
-      AuthView(
-        isDismissible = true,
-        initialIdentifier = manualTestIdentifier,
-        initialFirstName = "Sam",
-        initialLastName = "Wolfand",
-        lockPrefilledFields = true,
-        persistIdentifiers = persistIdentifiers,
-        preferGoogleOneTap = false,
-        mode = AuthMode.SignUp,
-        onAuthComplete = { isAuthFlowActive = false },
-        onDismiss = {},
-      )
+    isAuthFlowActive || user == null || pendingTaskKey != null -> AuthView()
+
     else -> signedInContent()
   }
 }

--- a/workbench/src/main/java/com/clerk/workbench/WorkbenchAuthGate.kt
+++ b/workbench/src/main/java/com/clerk/workbench/WorkbenchAuthGate.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.clerk.api.Clerk
 import com.clerk.api.session.pendingTaskKey
+import com.clerk.ui.auth.AuthMode
 import com.clerk.ui.auth.AuthView
 
 @Composable
@@ -22,6 +23,8 @@ internal fun WorkbenchAuthGate(
   val user by Clerk.userFlow.collectAsStateWithLifecycle()
   val pendingTaskKey = session?.pendingTaskKey
   var isAuthFlowActive by rememberSaveable { mutableStateOf(false) }
+  val manualTestIdentifier =
+    rememberSaveable { "sam+clerk_test@example.com" }
 
   LaunchedEffect(isInitialized, user?.id, session?.id, pendingTaskKey) {
     if (!isInitialized) return@LaunchedEffect
@@ -33,7 +36,13 @@ internal fun WorkbenchAuthGate(
     isAuthFlowActive || user == null || pendingTaskKey != null ->
       AuthView(
         isDismissible = true,
+        initialIdentifier = manualTestIdentifier,
+        initialFirstName = "Sam",
+        initialLastName = "Wolfand",
+        lockPrefilledFields = true,
         persistIdentifiers = persistIdentifiers,
+        preferGoogleOneTap = false,
+        mode = AuthMode.SignUp,
         onAuthComplete = { isAuthFlowActive = false },
         onDismiss = {},
       )


### PR DESCRIPTION
### Motivation

- Add support to prefill first/last name for sign-up flows and optionally lock prefilled fields so invitation-style flows can present read-only name/identifier values.
- Ensure locking only applies to fields that were actually provided as prefilled values, keeping empty fields editable.

### Description

- Added new `AuthView` parameters: `initialFirstName`, `initialLastName`, and `lockPrefilledFields`, and plumbed them into `AuthIdentifierConfig`.
- Extended `AuthState` to track whether initial identifier/phone/first/last name were prefilled (`initial*WasPrefilled`) and a `lockPrefilledFields` flag, and to apply prefilled name values into `signUpFirstName`/`signUpLastName` when present.
- Wired read-only behavior into UI: `AuthStartView` now passes `identifierLocked`/`phoneNumberLocked` into the input helper, `SignUpCompleteProfileView` passes `firstLocked`/`lastLocked` into the `InputRow`, and text inputs use the `enabled` parameter for locking.
- Extended `ClerkPhoneNumberField`/`PhoneNumberInput`/`CountrySelector` with an `enabled` parameter so phone input and country selector respect the locked state.
- Changes touch these files: `AuthView.kt`, `AuthState.kt`, `AuthStartView.kt`, `ClerkPhoneNumberField.kt`, and `SignUpCompleteProfileView.kt` implementing prefill + locking logic.



https://github.com/user-attachments/assets/d4acdb4b-cfd4-49f7-82bb-a92749809849

