### PR TITLE
Add Android sign-in email link helper

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/magiclink/NativeMagicLinkManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/magiclink/NativeMagicLinkManager.kt
@@ -108,38 +108,62 @@ internal object NativeMagicLinkService : NativeMagicLinkManager {
     return if (missingReason != null) {
       ClerkResult.apiFailure(NativeMagicLinkError(reasonCode = missingReason.code))
     } else {
-      val requiredEmailAddressId = checkNotNull(emailAddressId)
-      val requiredRedirectUri = checkNotNull(redirectUri)
-      val pkcePair = PkceUtil.generatePair()
-      val prepareRequest =
-        NativeMagicLinkPrepareRequest(
-          emailAddressId = requiredEmailAddressId,
-          redirectUri = requiredRedirectUri,
-          codeChallenge = pkcePair.challenge,
-        )
       when (
         val prepareResult =
-          ClerkApi.signIn.prepareSignInFirstFactor(signIn.id, prepareRequest.toFields())
+          prepareSignInEmailLink(signIn, checkNotNull(emailAddressId), checkNotNull(redirectUri))
       ) {
         is ClerkResult.Failure ->
           ClerkResult.apiFailure(
             prepareResult.toNativeMagicLinkError(NativeMagicLinkReason.PREPARE_FAILED)
           )
 
-        is ClerkResult.Success -> {
-          NativeMagicLinkLogger.prepareSuccess(
+        is ClerkResult.Success -> ClerkResult.success(prepareResult.value)
+      }
+    }
+  }
+
+  internal suspend fun prepareSignInEmailLink(
+    signIn: SignIn,
+    emailAddressId: String,
+  ): ClerkResult<SignIn, ClerkErrorResponse> {
+    val redirectUri =
+      resolveNativeEmailLinkRedirectUri()
+        ?: return ClerkResult.apiFailure(nativeRedirectUriRequiredError())
+
+    return prepareSignInEmailLink(signIn, emailAddressId, redirectUri)
+  }
+
+  private suspend fun prepareSignInEmailLink(
+    signIn: SignIn,
+    emailAddressId: String,
+    redirectUri: String,
+  ): ClerkResult<SignIn, ClerkErrorResponse> {
+    val pkcePair = PkceUtil.generatePair()
+    val prepareRequest =
+      NativeMagicLinkPrepareRequest(
+        emailAddressId = emailAddressId,
+        redirectUri = redirectUri,
+        codeChallenge = pkcePair.challenge,
+      )
+
+    return when (
+      val prepareResult =
+        ClerkApi.signIn.prepareSignInFirstFactor(signIn.id, prepareRequest.toFields())
+    ) {
+      is ClerkResult.Failure -> prepareResult
+      is ClerkResult.Success -> {
+        NativeMagicLinkLogger.prepareSuccess(
+          state = PendingNativeMagicLinkState.SIGN_IN,
+          flowId = signIn.id,
+        )
+        persistPendingFlow(
+          createPendingFlow(
+            codeVerifier = pkcePair.verifier,
             state = PendingNativeMagicLinkState.SIGN_IN,
             flowId = signIn.id,
           )
-          persistPendingFlow(
-            createPendingFlow(
-              codeVerifier = pkcePair.verifier,
-              state = PendingNativeMagicLinkState.SIGN_IN,
-              flowId = signIn.id,
-            )
-          )
-          ClerkResult.success(prepareResult.value)
-        }
+        )
+        prepareResult
       }
     }
   }
@@ -161,18 +185,7 @@ internal object NativeMagicLinkService : NativeMagicLinkManager {
         }
 
     if (redirectUri.isNullOrBlank()) {
-      return ClerkResult.apiFailure(
-        ClerkErrorResponse(
-          errors =
-            listOf(
-              Error(
-                message = "is invalid",
-                longMessage = "redirect_uri is required for native email-link verification",
-                code = "native_redirect_uri_required",
-              )
-            )
-        )
-      )
+      return ClerkResult.apiFailure(nativeRedirectUriRequiredError())
     }
 
     val pkcePair = PkceUtil.generatePair()
@@ -319,6 +332,19 @@ internal object NativeMagicLinkService : NativeMagicLinkManager {
       }
     }
   }
+}
+
+private fun nativeRedirectUriRequiredError(): ClerkErrorResponse {
+  return ClerkErrorResponse(
+    errors =
+      listOf(
+        Error(
+          message = "is invalid",
+          longMessage = "redirect_uri is required for native email-link verification",
+          code = "native_redirect_uri_required",
+        )
+      )
+  )
 }
 
 public fun interface NativeMagicLinkAttestationProvider {

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
@@ -10,9 +10,11 @@ import com.clerk.api.Constants.Strategy.RESET_PASSWORD_EMAIL_CODE
 import com.clerk.api.Constants.Strategy.RESET_PASSWORD_PHONE_CODE
 import com.clerk.api.auth.builders.SendCodeBuilder
 import com.clerk.api.auth.types.MfaType
+import com.clerk.api.magiclink.NativeMagicLinkService
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.environment.PreferredSignInStrategy
 import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.network.model.factor.FactorComparators
 import com.clerk.api.network.model.factor.isResetFactor
@@ -252,6 +254,55 @@ suspend fun SignIn.sendCode(
     }
 
   return ClerkApi.signIn.prepareSignInFirstFactor(this.id, params.toMap())
+}
+
+/**
+ * Sends a verification link to the user's email address for first factor authentication.
+ *
+ * This is a convenience method that prepares the email link verification strategy. The link will be
+ * sent to the email address associated with the sign-in. After the user opens the link, handle the
+ * deep link callback with [com.clerk.api.auth.Auth.handle].
+ *
+ * @param emailAddressId Optional ID of the email address to send the link to. If not provided, the
+ *   email address ID will be automatically retrieved from the supported first factors.
+ * @return A [ClerkResult] containing the updated [SignIn] object on success, or a
+ *   [ClerkErrorResponse] on failure.
+ */
+suspend fun SignIn.sendEmailLink(
+  emailAddressId: String? = null
+): ClerkResult<SignIn, ClerkErrorResponse> {
+  val emailId =
+    emailAddressId
+      ?: supportedFirstFactors?.find { it.strategy == EMAIL_LINK }?.emailAddressId
+      ?: error("No email address found for email_link strategy")
+  val supportedFirstFactorStrategies = supportedFirstFactors?.map { it.strategy }.orEmpty()
+  val validationError =
+    when {
+      status != SignIn.Status.NEEDS_FIRST_FACTOR ->
+        invalidEmailLinkPrepareState(
+          code = "sign_in_status_invalid",
+          longMessage = "Cannot prepare first factor while sign-in status is ${status.name}",
+        )
+      EMAIL_LINK !in supportedFirstFactorStrategies ->
+        invalidEmailLinkPrepareState(
+          code = "first_factor_strategy_not_supported",
+          longMessage = "$EMAIL_LINK is not supported for this sign-in attempt",
+        )
+      else -> null
+    }
+
+  return validationError ?: NativeMagicLinkService.prepareSignInEmailLink(this, emailId)
+}
+
+private fun invalidEmailLinkPrepareState(
+  code: String,
+  longMessage: String,
+): ClerkResult.Failure<ClerkErrorResponse> {
+  return ClerkResult.apiFailure(
+    ClerkErrorResponse(
+      errors = listOf(Error(message = "is invalid", longMessage = longMessage, code = code))
+    )
+  )
 }
 
 /**

--- a/source/api/src/test/java/com/clerk/api/magiclink/NativeMagicLinkServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/magiclink/NativeMagicLinkServiceTest.kt
@@ -17,6 +17,7 @@ import com.clerk.api.network.model.magiclink.NativeMagicLinkCompleteResponse
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
 import com.clerk.api.signin.SignIn
+import com.clerk.api.signin.sendEmailLink
 import com.clerk.api.signup.SignUp
 import com.clerk.api.storage.StorageHelper
 import io.mockk.coEvery
@@ -26,6 +27,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.runs
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -156,6 +158,33 @@ class NativeMagicLinkServiceTest {
     )
 
     verifyEndToEndRequests()
+  }
+
+  @Test
+  fun `send email link prepares existing sign-in and stores pending flow`() = runTest {
+    val prepareFields = slot<Map<String, String>>()
+    val signIn = emailLinkSignIn().copy(status = SignIn.Status.NEEDS_FIRST_FACTOR)
+    val preparedSignIn = signIn.copy(firstFactorVerification = mockk(relaxed = true))
+
+    coEvery { signInApi.prepareSignInFirstFactor(signIn.id, capture(prepareFields)) } returns
+      ClerkResult.success(preparedSignIn)
+
+    val result = signIn.sendEmailLink()
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(preparedSignIn, (result as ClerkResult.Success).value)
+    assertEquals("email_link", prepareFields.captured["strategy"])
+    assertEquals("email_123", prepareFields.captured["email_address_id"])
+    assertEquals("clerk://com.clerk.test.callback", prepareFields.captured["redirect_uri"])
+    assertEquals("S256", prepareFields.captured["code_challenge_method"])
+    assertTrue(prepareFields.captured["code_challenge"]?.isNotBlank() == true)
+    assertTrue(!prepareFields.captured.containsKey("code_verifier"))
+
+    val pendingFlow = PersistentPendingNativeMagicLinkStore().load()
+    assertEquals("sign_in_123", pendingFlow?.flowId)
+    assertEquals(PendingNativeMagicLinkState.SIGN_IN, pendingFlow?.state)
+    assertTrue(pendingFlow?.codeVerifier?.isNotBlank() == true)
+    coVerify(exactly = 0) { signInApi.createSignIn(any()) }
   }
 
   private fun verifyEndToEndRequests() {


### PR DESCRIPTION
## Summary

Adds a `SignIn.sendEmailLink()` convenience helper for Android sign-in continuation flows. The helper prepares the existing sign-in's `email_link` first factor through the native PKCE magic-link path, reusing the same pending-flow persistence used by `startEmailLinkSignIn()`.

## Why

The native docs need to show Android parity with iOS for continuing an existing sign-in by sending an email link. Android already supported top-level email-link sign-in, but did not expose a continuation helper on `SignIn`.

## Validation

- `./gradlew :source:api:testDebugUnitTest --tests com.clerk.api.magiclink.NativeMagicLinkServiceTest`
- `./gradlew :source:api:spotlessCheck`