### PR TITLE
fix(ui): make auth dev mode footer background transparent

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -55,6 +56,7 @@ import com.clerk.ui.signup.collectfield.CollectField
 import com.clerk.ui.signup.collectfield.SignUpCollectFieldView
 import com.clerk.ui.signup.completeprofile.SignUpCompleteProfileView
 import com.clerk.ui.signup.emaillink.SignUpEmailLinkView
+import com.clerk.ui.theme.ClerkMaterialTheme
 import com.clerk.ui.theme.ClerkThemeOverrideProvider
 import kotlinx.serialization.Serializable
 
@@ -99,7 +101,6 @@ fun AuthView(
   mode: AuthMode = AuthMode.SignInOrUp,
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
-    val fullScreenModifier = Modifier.fillMaxSize().then(modifier)
     val backStack = rememberNavBackStack(AuthDestination.AuthStart)
     val identifierConfig =
       remember(
@@ -120,25 +121,29 @@ fun AuthView(
         )
       }
     AuthStateProvider(backStack = backStack, mode = mode, identifierConfig = identifierConfig) {
-      ObservePendingSessionTaskRouting(backStack = backStack)
-      ObserveInProgressAuthRouting(backStack = backStack, onAuthComplete = onAuthComplete)
-      TrackScreenLoaded(LocalAuthState.current.mode.name)
-      DevelopmentModeWarningBox(
-        modifier = fullScreenModifier,
-        background = DevelopmentModeWarningBackground.White,
-      ) {
-        AuthNavDisplay(
-          modifier = Modifier.fillMaxSize(),
-          backStack = backStack,
-          options =
-            AuthNavOptions(
-              preferGoogleOneTap = preferGoogleOneTap,
-              startSocialOAuthAsSignUp = startSocialOAuthAsSignUp,
-              isDismissible = isDismissible,
-              onDismiss = onDismiss,
-              onAuthComplete = onAuthComplete,
-            ),
-        )
+      ClerkMaterialTheme {
+        val fullScreenModifier =
+          Modifier.fillMaxSize().background(ClerkMaterialTheme.colors.background).then(modifier)
+        ObservePendingSessionTaskRouting(backStack = backStack)
+        ObserveInProgressAuthRouting(backStack = backStack, onAuthComplete = onAuthComplete)
+        TrackScreenLoaded(LocalAuthState.current.mode.name)
+        DevelopmentModeWarningBox(
+          modifier = fullScreenModifier,
+          background = DevelopmentModeWarningBackground.White,
+        ) {
+          AuthNavDisplay(
+            modifier = Modifier.fillMaxSize(),
+            backStack = backStack,
+            options =
+              AuthNavOptions(
+                preferGoogleOneTap = preferGoogleOneTap,
+                startSocialOAuthAsSignUp = startSocialOAuthAsSignUp,
+                isDismissible = isDismissible,
+                onDismiss = onDismiss,
+                onAuthComplete = onAuthComplete,
+              ),
+          )
+        }
       }
     }
   }

--- a/source/ui/src/main/java/com/clerk/ui/core/footer/DevelopmentModeWarning.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/footer/DevelopmentModeWarning.kt
@@ -93,7 +93,8 @@ private fun DevelopmentModeWarningContent(
           .height(metrics.height)
           .paint(
             painter = painterResource(background.drawableResId),
-            contentScale = ContentScale.FillBounds,
+            alignment = Alignment.TopCenter,
+            contentScale = ContentScale.Crop,
           )
           .padding(bottom = metrics.labelBottomPadding),
       contentAlignment = Alignment.BottomCenter,

--- a/source/ui/src/main/res/drawable/dev_mode_background_white.xml
+++ b/source/ui/src/main/res/drawable/dev_mode_background_white.xml
@@ -1,131 +1,128 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aapt="http://schemas.android.com/aapt"
-    android:width="402dp"
-    android:height="125dp"
-    android:viewportWidth="402"
-    android:viewportHeight="125">
+    android:width="400dp"
+    android:height="100dp"
+    android:viewportWidth="400"
+    android:viewportHeight="100">
   <group>
     <clip-path
-        android:pathData="M0,0h402v125h-402z"/>
-    <path
-        android:pathData="M0,0h402v125h-402z"
-        android:fillColor="@color/dev_mode_warning_background"/>
+        android:pathData="M0,0h400v100h-400z"/>
     <path
         android:pathData="M210.44,-207.56l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M219.37,-198.63l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M228.3,-189.7l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M237.23,-180.77l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M246.16,-171.84l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M255.09,-162.91l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M264.02,-153.98l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M272.95,-145.04l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M281.89,-136.12l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M290.82,-127.18l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M299.75,-118.25l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M308.68,-109.32l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M317.61,-100.39l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M326.54,-91.46l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M335.47,-82.53l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M344.4,-73.6l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M353.33,-64.67l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M362.26,-55.74l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M371.19,-46.81l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M380.12,-37.88l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M389.05,-28.95l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M397.98,-20.02l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M406.91,-11.09l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M415.84,-2.16l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M424.77,6.77l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M433.7,15.7l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M442.63,24.63l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M451.56,33.56l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M460.49,42.49l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M469.42,51.42l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M478.35,60.35l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M487.28,69.28l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M496.21,78.21l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M505.14,87.14l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
         android:pathData="M514.07,96.07l4.69,4.69l-312.51,312.51l-4.69,-4.69z"
-        android:fillColor="@color/dev_mode_warning_stripe"/>
+        android:fillColor="@color/dev_mode_background_white_stripe"/>
     <path
-        android:pathData="M0,0h402v125h-402z">
+        android:pathData="M0,0h400v100h-400z">
       <aapt:attr name="android:fillColor">
         <gradient
-            android:startX="201"
+            android:startX="200"
             android:startY="0"
-            android:endX="201"
-            android:endY="125"
+            android:endX="200"
+            android:endY="100"
             android:type="linear">
           <item android:offset="0" android:color="@color/dev_mode_background_white_start"/>
-          <item android:offset="1" android:color="@color/dev_mode_warning_gradient_end"/>
+          <item android:offset="1" android:color="@color/dev_mode_background_white_end"/>
         </gradient>
       </aapt:attr>
     </path>

--- a/source/ui/src/main/res/values-night/colors.xml
+++ b/source/ui/src/main/res/values-night/colors.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="dev_mode_background_grey_start">#FF1A1A1D</color>
-    <color name="dev_mode_background_white_start">#FF131316</color>
+    <color name="dev_mode_background_white_start">#00131316</color>
+    <color name="dev_mode_background_white_end">#001F1712</color>
+    <color name="dev_mode_background_white_stripe">#18332219</color>
     <color name="dev_mode_warning_background">#FF241A14</color>
     <color name="dev_mode_warning_gradient_end">#991F1712</color>
     <color name="dev_mode_warning_stripe">#FF332219</color>

--- a/source/ui/src/main/res/values/colors.xml
+++ b/source/ui/src/main/res/values/colors.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="dev_mode_background_grey_start">#FFF9F9F9</color>
-    <color name="dev_mode_background_white_start">#FFFFFFFF</color>
+    <color name="dev_mode_background_white_start">#00FFFFFF</color>
+    <color name="dev_mode_background_white_end">#00FFF6ED</color>
+    <color name="dev_mode_background_white_stripe">#18FFEBD5</color>
     <color name="dev_mode_warning_background">#FFFFF6ED</color>
     <color name="dev_mode_warning_gradient_end">#99FFF6ED</color>
     <color name="dev_mode_warning_stripe">#FFFFEBD5</color>

--- a/workbench/src/main/java/com/clerk/workbench/UiActivity2.kt
+++ b/workbench/src/main/java/com/clerk/workbench/UiActivity2.kt
@@ -33,7 +33,7 @@ class UiActivity2 : ComponentActivity() {
       val backgroundColor = if (isSystemInDarkTheme()) BackgroundDark else Background
       WorkbenchTheme {
         Column(modifier = Modifier.fillMaxSize().background(color = Color(0xFFF9F9F9))) {
-          WorkbenchAuthGate(persistIdentifiers = false) {
+          WorkbenchAuthGate() {
             Column(
               modifier =
                 Modifier.background(color = backgroundColor).fillMaxSize().statusBarsPadding()

--- a/workbench/src/main/java/com/clerk/workbench/WorkbenchApplication.kt
+++ b/workbench/src/main/java/com/clerk/workbench/WorkbenchApplication.kt
@@ -1,8 +1,11 @@
 package com.clerk.workbench
 
 import android.app.Application
+import androidx.compose.ui.graphics.Color
 import com.clerk.api.Clerk
 import com.clerk.api.ClerkConfigurationOptions
+import com.clerk.api.ui.ClerkColors
+import com.clerk.api.ui.ClerkTheme
 
 class WorkbenchApplication : Application() {
 


### PR DESCRIPTION
## Summary

- Match the iOS dev-mode footer behavior by using a shorter white background asset with transparent alpha instead of an opaque white slab.
- Make the white asset transparent at both the top and bottom so the home-indicator area does not fade back to white.
- Top-align and crop the background painter so the Android footer renders like the iOS implementation.
- Paint the auth root with the Clerk background behind the reserved footer space, preserving the branded line and orange `Development mode` text while letting the screen background show through.

## Linear

MOBILE-528

<img width="1198" height="2539" alt="image" src="https://github.com/user-attachments/assets/1bb08da1-01f8-4e9f-a594-f45122661a7b" />
<img width="1198" height="2539" alt="image" src="https://github.com/user-attachments/assets/f1dc4f5d-73a9-4941-9216-4d516607fb50" />
