### PR TITLE
Enable automatic passkey sign-in on supported auth screens

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -299,6 +299,9 @@ object Clerk {
   val passkeyIsEnabled: Boolean
     get() = environment?.passkeyIsEnabled ?: false
 
+  val passkeyAutofillIsEnabled: Boolean
+    get() = environment?.userSettings?.passkeySettings?.allowAutofill ?: false
+
   val isEmailEnabled: Boolean
     get() = environment?.emailIsEnabled ?: false
 

--- a/source/api/src/main/kotlin/com/clerk/api/credentials/CredentialFlowException.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/credentials/CredentialFlowException.kt
@@ -28,7 +28,8 @@ internal sealed class CredentialFlowException(
   internal class NoSavedCredential :
     CredentialFlowException(
       message = "No saved credentials are available on this device.",
-      userMessage = "No saved credentials are available on this device. Try another sign-in method.",
+      userMessage =
+        "No saved credentials are available on this device. Try another sign-in method.",
     )
 
   internal class UserCancelled :
@@ -94,6 +95,11 @@ private val ClerkResult.Failure<ClerkErrorResponse>.credentialFlowUiMessage: Str
 
 val ClerkResult.Failure<ClerkErrorResponse>.shouldSuppressCredentialFlowError: Boolean
   get() = (throwable as? CredentialFlowException)?.suppressUserFacingError == true
+
+val ClerkResult.Failure<ClerkErrorResponse>.shouldSuppressAutomaticCredentialFlowError: Boolean
+  get() =
+    throwable is CredentialFlowException.UserCancelled ||
+      throwable is CredentialFlowException.NoSavedCredential
 
 val ClerkResult.Failure<ClerkErrorResponse>.shouldFallbackToOAuthFromGoogleOneTap: Boolean
   get() = throwable is CredentialFlowException.NoGoogleAccount

--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
@@ -121,8 +121,12 @@ internal object GoogleCredentialAuthenticationService {
   suspend fun signInWithGoogleCredential(
     credentialTypes: List<SignIn.CredentialType>,
     allowedCredentialIds: List<String> = emptyList(),
+    preferImmediatelyAvailableCredentials: Boolean = false,
   ): ClerkResult<SignIn, ClerkErrorResponse> {
-    ClerkLog.d("Starting passkey sign-in")
+    ClerkLog.d(
+      "Starting passkey sign-in; preferImmediatelyAvailableCredentials=" +
+        preferImmediatelyAvailableCredentials
+    )
     return when {
       credentialTypes.isEmpty() -> {
         ClerkResult.unknownFailure(IllegalStateException("No credential types specified"))
@@ -145,6 +149,7 @@ internal object GoogleCredentialAuthenticationService {
                   nonce = signIn.firstFactorVerification?.nonce,
                   allowedCredentialIds = allowedCredentialIds,
                   credentialRequestTypes = credentialTypes,
+                  preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials,
                 )
               handleCredential(credential, signIn)
             } catch (e: GetCredentialException) {
@@ -308,9 +313,15 @@ internal object GoogleCredentialAuthenticationService {
     nonce: String?,
     allowedCredentialIds: List<String> = emptyList(),
     credentialRequestTypes: List<SignIn.CredentialType>,
+    preferImmediatelyAvailableCredentials: Boolean = false,
   ): Credential {
     val credentialRequest =
-      buildCredentialRequest(nonce, allowedCredentialIds, credentialRequestTypes)
+      buildCredentialRequest(
+        nonce = nonce,
+        allowedCredentialIds = allowedCredentialIds,
+        credentialRequestTypes = credentialRequestTypes,
+        preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials,
+      )
 
     val result =
       try {
@@ -350,6 +361,7 @@ internal object GoogleCredentialAuthenticationService {
     nonce: String?,
     allowedCredentialIds: List<String> = emptyList(),
     credentialRequestTypes: List<SignIn.CredentialType>,
+    preferImmediatelyAvailableCredentials: Boolean = false,
   ): GetCredentialRequest {
     val requestOptions = mutableListOf<CredentialOption>()
 
@@ -368,7 +380,16 @@ internal object GoogleCredentialAuthenticationService {
       }
     }
 
-    return GetCredentialRequest(requestOptions)
+    return GetCredentialRequest(
+        credentialOptions = requestOptions,
+        preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials,
+      )
+      .also {
+        ClerkLog.d(
+          "Built credential request; preferImmediatelyAvailableCredentials=" +
+            it.preferImmediatelyAvailableCredentials
+        )
+      }
   }
 
   /**
@@ -403,6 +424,9 @@ internal object GoogleCredentialAuthenticationService {
     val rpId = requestJson.passkeyRpId() ?: PasskeyHelper.getDomain()
     val allowCredentials =
       allowedCredentialIds.toAllowCredentials().ifEmpty { requestJson.passkeyAllowCredentials() }
+    ClerkLog.d(
+      "Created passkey request; rpId=$rpId, allowCredentialsCount=${allowCredentials.size}"
+    )
 
     return GetPasskeyRequest(
       challenge = challenge,

--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
@@ -15,6 +15,7 @@ import com.clerk.api.Clerk
 import com.clerk.api.Constants.Fields.STRATEGY
 import com.clerk.api.credentials.CredentialFlowException
 import com.clerk.api.credentials.classifyGetCredentialFailure
+import com.clerk.api.credentials.shouldSuppressAutomaticCredentialFlowError
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
@@ -154,10 +155,22 @@ internal object GoogleCredentialAuthenticationService {
               handleCredential(credential, signIn)
             } catch (e: GetCredentialException) {
               ClerkLog.e("Passkey sign-in failed: ${e.message}")
-              classifyGetCredentialFailure(e, credentialTypes)
+              classifyGetCredentialFailure(e, credentialTypes).also { failure ->
+                clearSuppressedAutomaticSignInAttempt(
+                  preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials,
+                  signIn = signIn,
+                  failure = failure,
+                )
+              }
             } catch (e: CredentialFlowException) {
               ClerkLog.e("Passkey sign-in cannot start: ${e.message}")
-              ClerkResult.unknownFailure(e)
+              ClerkResult.unknownFailure(e).also { failure ->
+                clearSuppressedAutomaticSignInAttempt(
+                  preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials,
+                  signIn = signIn,
+                  failure = failure,
+                )
+              }
             } catch (e: Exception) {
               ClerkLog.e("Passkey sign-in failed: ${e.message}")
               ClerkResult.unknownFailure(e)
@@ -170,6 +183,22 @@ internal object GoogleCredentialAuthenticationService {
         }
       }
     }
+  }
+
+  private fun clearSuppressedAutomaticSignInAttempt(
+    preferImmediatelyAvailableCredentials: Boolean,
+    signIn: SignIn,
+    failure: ClerkResult.Failure<ClerkErrorResponse>,
+  ) {
+    if (
+      !preferImmediatelyAvailableCredentials || !failure.shouldSuppressAutomaticCredentialFlowError
+    ) {
+      return
+    }
+    if (!Clerk.clientInitialized || Clerk.client.signIn?.id != signIn.id) return
+
+    ClerkLog.d("Clearing suppressed automatic passkey sign-in attempt ${signIn.id}")
+    Clerk.updateClient(Clerk.client.copy(signIn = null))
   }
 
   /**

--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/PasskeyService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/PasskeyService.kt
@@ -22,11 +22,13 @@ internal object PasskeyService {
    * @return A [ClerkResult] containing either a successful [SignIn] or an error response.
    */
   suspend fun signInWithPasskey(
-    allowedCredentialIds: List<String> = emptyList()
+    allowedCredentialIds: List<String> = emptyList(),
+    preferImmediatelyAvailableCredentials: Boolean = false,
   ): ClerkResult<SignIn, ClerkErrorResponse> {
     return GoogleCredentialAuthenticationService.signInWithGoogleCredential(
       credentialTypes = listOf(SignIn.CredentialType.PASSKEY),
       allowedCredentialIds = allowedCredentialIds,
+      preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials,
     )
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
@@ -600,7 +600,10 @@ data class SignIn(
       data class Ticket(val ticket: String, override val strategy: String = TICKET) : Strategy
 
       /** Passkey strategy for authentication using a passkey. */
-      data class Passkey(override val strategy: String = PASSKEY) : Strategy
+      data class Passkey(
+        override val strategy: String = PASSKEY,
+        val preferImmediatelyAvailableCredentials: Boolean = false,
+      ) : Strategy
 
       @AutoMap
       @Serializable
@@ -640,7 +643,10 @@ data class SignIn(
      */
     suspend fun create(params: CreateParams.Strategy): ClerkResult<SignIn, ClerkErrorResponse> {
       return when (params) {
-        is CreateParams.Strategy.Passkey -> PasskeyService.signInWithPasskey()
+        is CreateParams.Strategy.Passkey ->
+          PasskeyService.signInWithPasskey(
+            preferImmediatelyAvailableCredentials = params.preferImmediatelyAvailableCredentials
+          )
         else -> {
           val baseMap =
             if (params is CreateParams.Strategy.Transfer) {

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
@@ -600,10 +600,7 @@ data class SignIn(
       data class Ticket(val ticket: String, override val strategy: String = TICKET) : Strategy
 
       /** Passkey strategy for authentication using a passkey. */
-      data class Passkey(
-        override val strategy: String = PASSKEY,
-        val preferImmediatelyAvailableCredentials: Boolean = false,
-      ) : Strategy
+      data class Passkey(override val strategy: String = PASSKEY) : Strategy
 
       @AutoMap
       @Serializable
@@ -643,10 +640,7 @@ data class SignIn(
      */
     suspend fun create(params: CreateParams.Strategy): ClerkResult<SignIn, ClerkErrorResponse> {
       return when (params) {
-        is CreateParams.Strategy.Passkey ->
-          PasskeyService.signInWithPasskey(
-            preferImmediatelyAvailableCredentials = params.preferImmediatelyAvailableCredentials
-          )
+        is CreateParams.Strategy.Passkey -> create(params)
         else -> {
           val baseMap =
             if (params is CreateParams.Strategy.Transfer) {
@@ -658,6 +652,25 @@ data class SignIn(
           ClerkApi.signIn.createSignIn(paramMap)
         }
       }
+    }
+
+    /**
+     * Starts the sign in process with a passkey.
+     *
+     * @param params The passkey strategy to authenticate with.
+     * @param preferImmediatelyAvailableCredentials Whether the credential provider should only
+     *   return credentials available without extra provider UI.
+     * @return A [ClerkResult] containing the created [SignIn] object on success, or a
+     *   [ClerkErrorResponse] on failure.
+     */
+    @Suppress("UnusedParameter")
+    suspend fun create(
+      params: CreateParams.Strategy.Passkey,
+      preferImmediatelyAvailableCredentials: Boolean = false,
+    ): ClerkResult<SignIn, ClerkErrorResponse> {
+      return PasskeyService.signInWithPasskey(
+        preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials
+      )
     }
 
     /**

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
@@ -3,6 +3,7 @@ package com.clerk.api.passkeys
 import android.app.Activity
 import androidx.credentials.Credential
 import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetCredentialResponse
 import androidx.credentials.PasswordCredential
 import androidx.credentials.PublicKeyCredential
@@ -26,6 +27,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.slot
 import io.mockk.unmockkAll
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -132,6 +134,29 @@ class PasskeyAuthenticationServiceTest {
     // Then
     assertTrue(result is ClerkResult.Success)
     assertEquals(mockSignIn, (result as ClerkResult.Success).value)
+  }
+
+  @Test
+  fun `signInWithPasskey can prefer immediately available credentials`() = runTest {
+    val nonce = """{"challenge":"test-challenge"}"""
+    val requestSlot = slot<GetCredentialRequest>()
+
+    every { mockSignIn.firstFactorVerification } returns mockVerification
+    every { mockVerification.nonce } returns nonce
+    every { mockGetCredentialResponse.credential } returns mockPasswordCredential
+
+    coEvery { ClerkApi.signIn.createSignIn(any()) } returns ClerkResult.success(mockSignIn)
+    coEvery { mockCredentialManager.getCredential(any(), capture(requestSlot)) } returns
+      mockGetCredentialResponse
+
+    val result =
+      GoogleCredentialAuthenticationService.signInWithGoogleCredential(
+        credentialTypes = listOf(SignIn.CredentialType.PASSKEY),
+        preferImmediatelyAvailableCredentials = true,
+      )
+
+    assertTrue(result is ClerkResult.Success)
+    assertTrue(requestSlot.captured.preferImmediatelyAvailableCredentials)
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
@@ -11,6 +11,7 @@ import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.credentials.exceptions.NoCredentialException
 import com.clerk.api.Clerk
 import com.clerk.api.credentials.CredentialFlowException
+import com.clerk.api.credentials.shouldSuppressAutomaticCredentialFlowError
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.api.SessionApi
 import com.clerk.api.network.api.SignInApi
@@ -32,6 +33,7 @@ import io.mockk.unmockkAll
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Ignore
@@ -227,6 +229,27 @@ class PasskeyAuthenticationServiceTest {
 
     assertTrue(result is ClerkResult.Failure)
     assertTrue((result as ClerkResult.Failure).throwable is CredentialFlowException.UserCancelled)
+  }
+
+  @Test
+  fun `automatic credential flow suppresses user cancellation`() {
+    val result = ClerkResult.unknownFailure(CredentialFlowException.UserCancelled())
+
+    assertTrue(result.shouldSuppressAutomaticCredentialFlowError)
+  }
+
+  @Test
+  fun `automatic credential flow suppresses no saved credential`() {
+    val result = ClerkResult.unknownFailure(CredentialFlowException.NoSavedCredential())
+
+    assertTrue(result.shouldSuppressAutomaticCredentialFlowError)
+  }
+
+  @Test
+  fun `automatic credential flow does not suppress provider unavailable`() {
+    val result = ClerkResult.unknownFailure(CredentialFlowException.ProviderUnavailable())
+
+    assertFalse(result.shouldSuppressAutomaticCredentialFlowError)
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
@@ -15,6 +15,7 @@ import com.clerk.api.credentials.shouldSuppressAutomaticCredentialFlowError
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.api.SessionApi
 import com.clerk.api.network.api.SignInApi
+import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.model.verification.Verification
@@ -26,10 +27,13 @@ import com.clerk.api.signin.attemptFirstFactor
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -209,6 +213,35 @@ class PasskeyAuthenticationServiceTest {
     val failure = result as ClerkResult.Failure
     assertEquals(ClerkResult.Failure.ErrorType.UNKNOWN, failure.errorType)
     assertTrue(failure.throwable is CredentialFlowException.NoSavedCredential)
+  }
+
+  @Test
+  fun `automatic signInWithPasskey clears suppressed current sign in`() = runTest {
+    val nonce = """{"challenge":"test-challenge"}"""
+    val client = Client(id = "client_123", signIn = mockSignIn)
+
+    every { mockSignIn.id } returns "sign_in_123"
+    every { mockSignIn.firstFactorVerification } returns mockVerification
+    every { mockVerification.nonce } returns nonce
+    every { Clerk.clientInitialized } returns true
+    every { Clerk.client } returns client
+    every { Clerk.updateClient(any()) } just runs
+
+    coEvery { ClerkApi.signIn.createSignIn(any()) } returns ClerkResult.success(mockSignIn)
+    coEvery { mockCredentialManager.getCredential(any(), any()) } throws
+      NoCredentialException("No credentials available")
+
+    val result =
+      GoogleCredentialAuthenticationService.signInWithGoogleCredential(
+        credentialTypes = listOf(SignIn.CredentialType.PASSKEY),
+        preferImmediatelyAvailableCredentials = true,
+      )
+
+    assertTrue(result is ClerkResult.Failure)
+    assertTrue(
+      (result as ClerkResult.Failure).throwable is CredentialFlowException.NoSavedCredential
+    )
+    verify(exactly = 1) { Clerk.updateClient(client.copy(signIn = null)) }
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyServiceTest.kt
@@ -90,6 +90,29 @@ class PasskeyServiceTest {
     }
 
   @Test
+  fun `signInWithPasskey can prefer immediately available credentials`() = runTest {
+    coEvery {
+      GoogleCredentialAuthenticationService.signInWithGoogleCredential(
+        allowedCredentialIds = emptyList(),
+        credentialTypes = listOf(SignIn.CredentialType.PASSKEY),
+        preferImmediatelyAvailableCredentials = true,
+      )
+    } returns ClerkResult.success(mockSignIn)
+
+    val result = PasskeyService.signInWithPasskey(preferImmediatelyAvailableCredentials = true)
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(mockSignIn, (result as ClerkResult.Success).value)
+    coVerify {
+      GoogleCredentialAuthenticationService.signInWithGoogleCredential(
+        allowedCredentialIds = emptyList(),
+        credentialTypes = listOf(SignIn.CredentialType.PASSKEY),
+        preferImmediatelyAvailableCredentials = true,
+      )
+    }
+  }
+
+  @Test
   fun `signInWithPasskey returns error when PasskeyAuthenticationService fails`() = runTest {
     // Given
     val error =

--- a/source/api/src/test/java/com/clerk/api/signin/SignInCreateTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signin/SignInCreateTest.kt
@@ -1,0 +1,47 @@
+package com.clerk.api.signin
+
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.passkeys.PasskeyService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SignInCreateTest {
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `create with passkey strategy delegates to PasskeyService`() = runTest {
+    val signIn = SignIn(id = "sign_in_123")
+    mockkObject(PasskeyService)
+    coEvery {
+      PasskeyService.signInWithPasskey(
+        allowedCredentialIds = emptyList(),
+        preferImmediatelyAvailableCredentials = true,
+      )
+    } returns ClerkResult.success(signIn)
+
+    val result =
+      SignIn.create(
+        SignIn.CreateParams.Strategy.Passkey(preferImmediatelyAvailableCredentials = true)
+      )
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(signIn, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) {
+      PasskeyService.signInWithPasskey(
+        allowedCredentialIds = emptyList(),
+        preferImmediatelyAvailableCredentials = true,
+      )
+    }
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/signin/SignInCreateTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signin/SignInCreateTest.kt
@@ -32,7 +32,8 @@ class SignInCreateTest {
 
     val result =
       SignIn.create(
-        SignIn.CreateParams.Strategy.Passkey(preferImmediatelyAvailableCredentials = true)
+        SignIn.CreateParams.Strategy.Passkey(),
+        preferImmediatelyAvailableCredentials = true,
       )
 
     assertTrue(result is ClerkResult.Success)
@@ -43,5 +44,13 @@ class SignInCreateTest {
         preferImmediatelyAvailableCredentials = true,
       )
     }
+  }
+
+  @Test
+  fun `passkey strategy preserves legacy jvm constructor and copy signatures`() {
+    val passkeyClass = SignIn.CreateParams.Strategy.Passkey::class.java
+
+    passkeyClass.getDeclaredConstructor(String::class.java)
+    passkeyClass.getDeclaredMethod("copy", String::class.java)
   }
 }

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -135,17 +135,30 @@ internal fun AuthStartViewImpl(
       lockedInitialIdentifierIsActive = lockedInitialIdentifierIsActive,
       passkeySignInConfigIsEnabled = passkeySignInConfigIsEnabled,
     )
-  var automaticPasskeySignInHasStarted by
-    rememberSaveable(authState.identifierConfigVersion, authState.mode) { mutableStateOf(false) }
+  var automaticPasskeySignInHasStarted by rememberSaveable { mutableStateOf(false) }
 
-  LaunchedEffect(automaticPasskeySignInIsEnabled, automaticPasskeySignInHasStarted) {
+  LaunchedEffect(
+    automaticPasskeySignInIsEnabled,
+    automaticPasskeySignInHasStarted,
+    authState.mode,
+    lockedInitialIdentifierIsActive,
+    passkeySignInConfigIsEnabled,
+  ) {
     ClerkLog.d(
       "AuthStart automatic passkey gate: enabled=$automaticPasskeySignInIsEnabled, " +
         "hasStarted=$automaticPasskeySignInHasStarted, mode=${authState.mode}, " +
         "lockedInitialIdentifierIsActive=$lockedInitialIdentifierIsActive, " +
         "passkeySignInConfigIsEnabled=$passkeySignInConfigIsEnabled"
     )
-    if (automaticPasskeySignInIsEnabled && !automaticPasskeySignInHasStarted) {
+    if (!automaticPasskeySignInIsEnabled) {
+      if (automaticPasskeySignInHasStarted) {
+        authStartViewModel.cancelAutomaticPasskeySignIn()
+        automaticPasskeySignInHasStarted = false
+      }
+      return@LaunchedEffect
+    }
+
+    if (!automaticPasskeySignInHasStarted) {
       automaticPasskeySignInHasStarted = true
       authStartViewModel.startAutomaticPasskeySignIn()
     }

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -27,6 +28,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.clerk.api.Clerk
+import com.clerk.api.log.ClerkLog
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.R
@@ -124,6 +126,34 @@ internal fun AuthStartViewImpl(
     }
   val showDismissButton = shouldShowAuthDismissButton(isDismissible)
   val dismissHandler = rememberDismissHandler(onDismiss)
+  val lockedInitialIdentifierIsActive =
+    authState.authStartIdentifierLocked || authState.authStartPhoneNumberLocked
+  val passkeySignInConfigIsEnabled = authViewHelper.passkeySignInConfigIsEnabled
+  val automaticPasskeySignInIsEnabled =
+    shouldStartAutomaticPasskeySignIn(
+      authMode = authState.mode,
+      lockedInitialIdentifierIsActive = lockedInitialIdentifierIsActive,
+      passkeySignInConfigIsEnabled = passkeySignInConfigIsEnabled,
+    )
+  var automaticPasskeySignInHasStarted by
+    rememberSaveable(authState.identifierConfigVersion, authState.mode) { mutableStateOf(false) }
+
+  LaunchedEffect(automaticPasskeySignInIsEnabled, automaticPasskeySignInHasStarted) {
+    ClerkLog.d(
+      "AuthStart automatic passkey gate: enabled=$automaticPasskeySignInIsEnabled, " +
+        "hasStarted=$automaticPasskeySignInHasStarted, mode=${authState.mode}, " +
+        "lockedInitialIdentifierIsActive=$lockedInitialIdentifierIsActive, " +
+        "passkeySignInConfigIsEnabled=$passkeySignInConfigIsEnabled"
+    )
+    if (automaticPasskeySignInIsEnabled && !automaticPasskeySignInHasStarted) {
+      automaticPasskeySignInHasStarted = true
+      authStartViewModel.startAutomaticPasskeySignIn()
+    }
+  }
+
+  DisposableEffect(authStartViewModel) {
+    onDispose { authStartViewModel.cancelAutomaticPasskeySignIn() }
+  }
 
   LaunchedEffect(state) {
     when (val s = state) {

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewHelper.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewHelper.kt
@@ -24,6 +24,8 @@ internal class AuthStartViewHelper {
   internal var testEnabledFirstFactorAttributes: List<String>? = null
   internal var testSocialProviders: List<OAuthProvider>? = null
   internal var testApplicationName: String? = null
+  internal var testPasskeyIsEnabled: Boolean? = null
+  internal var testPasskeyAutofillIsEnabled: Boolean? = null
 
   val authenticatableSocialProviders: List<OAuthProvider>
     get() {
@@ -70,6 +72,11 @@ internal class AuthStartViewHelper {
           } == true
       } && showIdentifierField
     }
+
+  val passkeySignInConfigIsEnabled: Boolean
+    get() =
+      (testPasskeyIsEnabled ?: Clerk.passkeyIsEnabled) &&
+        (testPasskeyAutofillIsEnabled ?: Clerk.passkeyAutofillIsEnabled)
 
   fun getKeyboardType(isPhoneNumberFieldActive: Boolean): KeyboardType {
     return if (isPhoneNumberFieldActive) {
@@ -171,10 +178,14 @@ internal class AuthStartViewHelper {
     enabledFirstFactorAttributes: List<String>? = null,
     socialProviders: List<OAuthProvider>? = null,
     applicationName: String? = null,
+    passkeyIsEnabled: Boolean? = null,
+    passkeyAutofillIsEnabled: Boolean? = null,
   ) {
     testEnabledFirstFactorAttributes = enabledFirstFactorAttributes
     testSocialProviders = socialProviders
     testApplicationName = applicationName
+    testPasskeyIsEnabled = passkeyIsEnabled
+    testPasskeyAutofillIsEnabled = passkeyAutofillIsEnabled
   }
 
   @VisibleForTesting
@@ -182,5 +193,17 @@ internal class AuthStartViewHelper {
     testEnabledFirstFactorAttributes = null
     testSocialProviders = null
     testApplicationName = null
+    testPasskeyIsEnabled = null
+    testPasskeyAutofillIsEnabled = null
   }
+}
+
+internal fun shouldStartAutomaticPasskeySignIn(
+  authMode: AuthMode,
+  lockedInitialIdentifierIsActive: Boolean,
+  passkeySignInConfigIsEnabled: Boolean,
+): Boolean {
+  return authMode != AuthMode.SignUp &&
+    !lockedInitialIdentifierIsActive &&
+    passkeySignInConfigIsEnabled
 }

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.viewModelScope
 import com.clerk.api.Clerk
 import com.clerk.api.credentials.resolvedCredentialFlowMessage
 import com.clerk.api.credentials.shouldFallbackToOAuthFromGoogleOneTap
+import com.clerk.api.credentials.shouldSuppressAutomaticCredentialFlowError
 import com.clerk.api.credentials.shouldSuppressCredentialFlowError
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
@@ -19,9 +21,11 @@ import com.clerk.api.signup.SignUp
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.ResultType
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -45,6 +49,8 @@ internal class AuthStartViewModel : ViewModel() {
    */
   val state: StateFlow<AuthState> = _state.asStateFlow()
 
+  private var automaticPasskeySignInJob: Job? = null
+
   /**
    * Resets the current state back to [AuthState.Idle].
    *
@@ -53,6 +59,54 @@ internal class AuthStartViewModel : ViewModel() {
    */
   internal fun resetState() {
     _state.value = AuthState.Idle
+  }
+
+  internal fun startAutomaticPasskeySignIn() {
+    if (automaticPasskeySignInJob?.isActive == true) {
+      ClerkLog.d("Automatic passkey sign-in already running; skipping duplicate start")
+      return
+    }
+
+    ClerkLog.d("Starting automatic passkey sign-in")
+    automaticPasskeySignInJob =
+      viewModelScope.launch(Dispatchers.IO) {
+        try {
+          when (
+            val result =
+              SignIn.create(
+                SignIn.CreateParams.Strategy.Passkey(preferImmediatelyAvailableCredentials = true)
+              )
+          ) {
+            is ClerkResult.Success -> {
+              ClerkLog.d("Automatic passkey sign-in succeeded with status ${result.value.status}")
+              if (isActive) handleSignInSuccess(result.value)
+            }
+            is ClerkResult.Failure -> {
+              if (!isActive) return@launch
+              if (result.shouldSuppressAutomaticCredentialFlowError) {
+                ClerkLog.d(
+                  "Automatic passkey sign-in finished without UI: " +
+                    "${result.throwable?.javaClass?.simpleName}"
+                )
+                return@launch
+              }
+              ClerkLog.e(
+                "Automatic passkey sign-in failed: ${result.resolvedCredentialFlowMessage}"
+              )
+              withContext(Dispatchers.Main) {
+                _state.value = AuthState.Error(result.resolvedCredentialFlowMessage)
+              }
+            }
+          }
+        } finally {
+          automaticPasskeySignInJob = null
+        }
+      }
+  }
+
+  internal fun cancelAutomaticPasskeySignIn() {
+    automaticPasskeySignInJob?.cancel()
+    automaticPasskeySignInJob = null
   }
 
   /**
@@ -71,6 +125,7 @@ internal class AuthStartViewModel : ViewModel() {
     identifier: String,
     unsafeMetadata: Map<String, Any>? = null,
   ) {
+    cancelAutomaticPasskeySignIn()
     when (authMode) {
       AuthMode.SignIn ->
         signIn(
@@ -175,6 +230,7 @@ internal class AuthStartViewModel : ViewModel() {
     startOAuthWithSignUp: Boolean = false,
     unsafeMetadata: Map<String, Any>? = null,
   ) {
+    cancelAutomaticPasskeySignIn()
     _state.value = AuthState.OAuthState.Loading
     if (preferGoogleOneTap && provider == OAuthProvider.GOOGLE && Clerk.isGoogleOneTapEnabled) {
       handleGoogleOneTap(provider, transferable, startOAuthWithSignUp, unsafeMetadata)

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -20,6 +20,8 @@ import com.clerk.api.signin.startingFirstFactor
 import com.clerk.api.signup.SignUp
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.ResultType
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -68,8 +70,8 @@ internal class AuthStartViewModel : ViewModel() {
     }
 
     ClerkLog.d("Starting automatic passkey sign-in")
-    automaticPasskeySignInJob =
-      viewModelScope.launch(Dispatchers.IO) {
+    val job =
+      viewModelScope.launch(Dispatchers.IO, start = CoroutineStart.LAZY) {
         try {
           when (
             val result =
@@ -99,14 +101,19 @@ internal class AuthStartViewModel : ViewModel() {
             }
           }
         } finally {
-          automaticPasskeySignInJob = null
+          if (automaticPasskeySignInJob === coroutineContext[Job]) {
+            automaticPasskeySignInJob = null
+          }
         }
       }
+    automaticPasskeySignInJob = job
+    job.start()
   }
 
   internal fun cancelAutomaticPasskeySignIn() {
-    automaticPasskeySignInJob?.cancel()
+    val job = automaticPasskeySignInJob ?: return
     automaticPasskeySignInJob = null
+    job.cancel()
   }
 
   /**

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -76,7 +76,8 @@ internal class AuthStartViewModel : ViewModel() {
           when (
             val result =
               SignIn.create(
-                SignIn.CreateParams.Strategy.Passkey(preferImmediatelyAvailableCredentials = true)
+                SignIn.CreateParams.Strategy.Passkey(),
+                preferImmediatelyAvailableCredentials = true,
               )
           ) {
             is ClerkResult.Success -> {

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthStartViewHelperTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthStartViewHelperTest.kt
@@ -84,4 +84,64 @@ class AuthStartViewHelperTest {
     assertFalse(contentType == ContentType.EmailAddress)
     assertFalse(contentType == ContentType.Username)
   }
+
+  @Test
+  fun automaticPasskeySignInIsEnabledForUnlockedSignInWhenPasskeyAutofillIsEnabled() {
+    val helper = AuthStartViewHelper()
+    helper.setTestValues(passkeyIsEnabled = true, passkeyAutofillIsEnabled = true)
+
+    val result =
+      shouldStartAutomaticPasskeySignIn(
+        authMode = AuthMode.SignIn,
+        lockedInitialIdentifierIsActive = false,
+        passkeySignInConfigIsEnabled = helper.passkeySignInConfigIsEnabled,
+      )
+
+    assertTrue(result)
+  }
+
+  @Test
+  fun automaticPasskeySignInIsDisabledForSignUp() {
+    val helper = AuthStartViewHelper()
+    helper.setTestValues(passkeyIsEnabled = true, passkeyAutofillIsEnabled = true)
+
+    val result =
+      shouldStartAutomaticPasskeySignIn(
+        authMode = AuthMode.SignUp,
+        lockedInitialIdentifierIsActive = false,
+        passkeySignInConfigIsEnabled = helper.passkeySignInConfigIsEnabled,
+      )
+
+    assertFalse(result)
+  }
+
+  @Test
+  fun automaticPasskeySignInIsDisabledWhenInitialIdentifierIsLocked() {
+    val helper = AuthStartViewHelper()
+    helper.setTestValues(passkeyIsEnabled = true, passkeyAutofillIsEnabled = true)
+
+    val result =
+      shouldStartAutomaticPasskeySignIn(
+        authMode = AuthMode.SignInOrUp,
+        lockedInitialIdentifierIsActive = true,
+        passkeySignInConfigIsEnabled = helper.passkeySignInConfigIsEnabled,
+      )
+
+    assertFalse(result)
+  }
+
+  @Test
+  fun automaticPasskeySignInIsDisabledWhenPasskeyAutofillIsDisabled() {
+    val helper = AuthStartViewHelper()
+    helper.setTestValues(passkeyIsEnabled = true, passkeyAutofillIsEnabled = false)
+
+    val result =
+      shouldStartAutomaticPasskeySignIn(
+        authMode = AuthMode.SignIn,
+        lockedInitialIdentifierIsActive = false,
+        passkeySignInConfigIsEnabled = helper.passkeySignInConfigIsEnabled,
+      )
+
+    assertFalse(result)
+  }
 }

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -87,8 +87,12 @@ class AuthViewModelTest {
   fun automaticPasskeySignInUsesPasskeyStrategy() = runTest {
     val signIn = SignIn(id = "sign_in_123")
     mockkObject(SignIn.Companion)
-    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
-      ClerkResult.success(signIn)
+    coEvery {
+      SignIn.create(
+        any<SignIn.CreateParams.Strategy.Passkey>(),
+        preferImmediatelyAvailableCredentials = true,
+      )
+    } returns ClerkResult.success(signIn)
 
     viewModel.state.test {
       assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
@@ -98,9 +102,8 @@ class AuthViewModelTest {
       assertEquals(AuthStartViewModel.AuthState.Success.SignInSuccess(signIn), awaitItem())
       coVerify(exactly = 1) {
         SignIn.create(
-          match<SignIn.CreateParams.Strategy> {
-            it is SignIn.CreateParams.Strategy.Passkey && it.preferImmediatelyAvailableCredentials
-          }
+          any<SignIn.CreateParams.Strategy.Passkey>(),
+          preferImmediatelyAvailableCredentials = true,
         )
       }
     }
@@ -113,15 +116,25 @@ class AuthViewModelTest {
         .getDeclaredConstructor()
         .newInstance() as Throwable
     mockkObject(SignIn.Companion)
-    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
-      ClerkResult.unknownFailure(noSavedCredentialException)
+    coEvery {
+      SignIn.create(
+        any<SignIn.CreateParams.Strategy.Passkey>(),
+        preferImmediatelyAvailableCredentials = true,
+      )
+    } returns ClerkResult.unknownFailure(noSavedCredentialException)
 
     viewModel.state.test {
       assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
 
       viewModel.startAutomaticPasskeySignIn()
 
-      coVerify(timeout = 1_000, exactly = 1) { SignIn.create(any<SignIn.CreateParams.Strategy>()) }
+      coVerify(timeout = 1_000, exactly = 1) {
+        SignIn.create(
+          any<SignIn.CreateParams.Strategy.Passkey>(),
+          preferImmediatelyAvailableCredentials = true,
+        )
+      }
+      testDispatcher.scheduler.advanceUntilIdle()
       expectNoEvents()
     }
   }
@@ -133,15 +146,25 @@ class AuthViewModelTest {
         .getDeclaredConstructor()
         .newInstance() as Throwable
     mockkObject(SignIn.Companion)
-    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
-      ClerkResult.unknownFailure(userCancelledException)
+    coEvery {
+      SignIn.create(
+        any<SignIn.CreateParams.Strategy.Passkey>(),
+        preferImmediatelyAvailableCredentials = true,
+      )
+    } returns ClerkResult.unknownFailure(userCancelledException)
 
     viewModel.state.test {
       assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
 
       viewModel.startAutomaticPasskeySignIn()
 
-      coVerify(timeout = 1_000, exactly = 1) { SignIn.create(any<SignIn.CreateParams.Strategy>()) }
+      coVerify(timeout = 1_000, exactly = 1) {
+        SignIn.create(
+          any<SignIn.CreateParams.Strategy.Passkey>(),
+          preferImmediatelyAvailableCredentials = true,
+        )
+      }
+      testDispatcher.scheduler.advanceUntilIdle()
       expectNoEvents()
     }
   }
@@ -149,7 +172,12 @@ class AuthViewModelTest {
   @Test
   fun automaticPasskeySignInSurfacesApiErrors() = runTest {
     mockkObject(SignIn.Companion)
-    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
+    coEvery {
+      SignIn.create(
+        any<SignIn.CreateParams.Strategy.Passkey>(),
+        preferImmediatelyAvailableCredentials = true,
+      )
+    } returns
       ClerkResult.apiFailure(
         ClerkErrorResponse(errors = listOf(ClerkError(longMessage = "Passkey failed")))
       )

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -82,6 +82,66 @@ class AuthViewModelTest {
   }
 
   @Test
+  fun automaticPasskeySignInUsesPasskeyStrategy() = runTest {
+    val signIn = SignIn(id = "sign_in_123")
+    mockkObject(SignIn.Companion)
+    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
+      ClerkResult.success(signIn)
+
+    viewModel.state.test {
+      assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
+
+      viewModel.startAutomaticPasskeySignIn()
+
+      assertEquals(AuthStartViewModel.AuthState.Success.SignInSuccess(signIn), awaitItem())
+      coVerify(exactly = 1) {
+        SignIn.create(
+          match<SignIn.CreateParams.Strategy> {
+            it is SignIn.CreateParams.Strategy.Passkey && it.preferImmediatelyAvailableCredentials
+          }
+        )
+      }
+    }
+  }
+
+  @Test
+  fun automaticPasskeySignInSuppressesNoSavedCredentialError() = runTest {
+    val noSavedCredentialException =
+      Class.forName("com.clerk.api.credentials.CredentialFlowException\$NoSavedCredential")
+        .getDeclaredConstructor()
+        .newInstance() as Throwable
+    mockkObject(SignIn.Companion)
+    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
+      ClerkResult.unknownFailure(noSavedCredentialException)
+
+    viewModel.state.test {
+      assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
+
+      viewModel.startAutomaticPasskeySignIn()
+
+      coVerify(timeout = 1_000, exactly = 1) { SignIn.create(any<SignIn.CreateParams.Strategy>()) }
+      expectNoEvents()
+    }
+  }
+
+  @Test
+  fun automaticPasskeySignInSurfacesApiErrors() = runTest {
+    mockkObject(SignIn.Companion)
+    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
+      ClerkResult.apiFailure(
+        ClerkErrorResponse(errors = listOf(ClerkError(longMessage = "Passkey failed")))
+      )
+
+    viewModel.state.test {
+      assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
+
+      viewModel.startAutomaticPasskeySignIn()
+
+      assertEquals(AuthStartViewModel.AuthState.Error("Passkey failed"), awaitItem())
+    }
+  }
+
+  @Test
   fun oauthResultWithSignInResultTypeShouldSetCorrectSuccessState() {
     // Test the OAuth result processing logic
     val mockSignIn = mockk<SignIn>(relaxed = true)

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -78,6 +78,8 @@ class AuthViewModelTest {
       )
 
       assertEquals(AuthStartViewModel.AuthState.Loading, awaitItem())
+      coVerify(timeout = 1_000, exactly = 1) { SignIn.create(any<SignIn.CreateParams.Strategy>()) }
+      cancelAndIgnoreRemainingEvents()
     }
   }
 

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -125,6 +125,26 @@ class AuthViewModelTest {
   }
 
   @Test
+  fun automaticPasskeySignInSuppressesUserCancelledError() = runTest {
+    val userCancelledException =
+      Class.forName("com.clerk.api.credentials.CredentialFlowException\$UserCancelled")
+        .getDeclaredConstructor()
+        .newInstance() as Throwable
+    mockkObject(SignIn.Companion)
+    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
+      ClerkResult.unknownFailure(userCancelledException)
+
+    viewModel.state.test {
+      assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
+
+      viewModel.startAutomaticPasskeySignIn()
+
+      coVerify(timeout = 1_000, exactly = 1) { SignIn.create(any<SignIn.CreateParams.Strategy>()) }
+      expectNoEvents()
+    }
+  }
+
+  @Test
   fun automaticPasskeySignInSurfacesApiErrors() = runTest {
     mockkObject(SignIn.Companion)
     coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -325,16 +325,22 @@ class AuthViewModelTest {
     mockkObject(SignUp.Companion)
     coEvery { SignUp.create(any<SignUp.CreateParams>()) } returns ClerkResult.success(mockSignUp)
 
-    viewModel.startAuth(
-      authMode = AuthMode.SignUp,
-      isPhoneNumberFieldActive = false,
-      phoneNumber = "",
-      identifier = "test@example.com",
-      unsafeMetadata = mapOf("test" to "test", "nested" to mapOf("active" to true)),
-    )
+    viewModel.state.test {
+      assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
+
+      viewModel.startAuth(
+        authMode = AuthMode.SignUp,
+        isPhoneNumberFieldActive = false,
+        phoneNumber = "",
+        identifier = "test@example.com",
+        unsafeMetadata = mapOf("test" to "test", "nested" to mapOf("active" to true)),
+      )
+
+      assertEquals(AuthStartViewModel.AuthState.Loading, awaitItem())
+      assertEquals(AuthStartViewModel.AuthState.Success.SignUpSuccess(mockSignUp), awaitItem())
+    }
 
     coVerify(timeout = 1_000, exactly = 1) { SignUp.create(capture(paramsSlot)) }
-    testDispatcher.scheduler.advanceUntilIdle()
     val params = paramsSlot.captured as SignUp.CreateParams.Standard
     val unsafeMetadata = requireNotNull(params.unsafeMetadata)
     assertEquals("test@example.com", params.emailAddress)
@@ -354,16 +360,22 @@ class AuthViewModelTest {
       )
     coEvery { SignUp.create(any<SignUp.CreateParams>()) } returns ClerkResult.success(mockSignUp)
 
-    viewModel.startAuth(
-      authMode = AuthMode.SignInOrUp,
-      isPhoneNumberFieldActive = true,
-      phoneNumber = "+1234567890",
-      identifier = "test@example.com",
-      unsafeMetadata = mapOf("source" to "prebuilt"),
-    )
+    viewModel.state.test {
+      assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
+
+      viewModel.startAuth(
+        authMode = AuthMode.SignInOrUp,
+        isPhoneNumberFieldActive = true,
+        phoneNumber = "+1234567890",
+        identifier = "test@example.com",
+        unsafeMetadata = mapOf("source" to "prebuilt"),
+      )
+
+      assertEquals(AuthStartViewModel.AuthState.Loading, awaitItem())
+      assertEquals(AuthStartViewModel.AuthState.Success.SignUpSuccess(mockSignUp), awaitItem())
+    }
 
     coVerify(timeout = 1_000, exactly = 1) { SignUp.create(capture(paramsSlot)) }
-    testDispatcher.scheduler.advanceUntilIdle()
     val params = paramsSlot.captured as SignUp.CreateParams.Standard
     val unsafeMetadata = requireNotNull(params.unsafeMetadata)
     assertEquals("+1234567890", params.phoneNumber)

--- a/workbench/src/main/java/com/clerk/workbench/WorkbenchApplication.kt
+++ b/workbench/src/main/java/com/clerk/workbench/WorkbenchApplication.kt
@@ -20,7 +20,6 @@ class WorkbenchApplication : Application() {
         this,
         key,
         options = ClerkConfigurationOptions(enableDebugMode = true, proxyUrl = proxyUrl),
-        theme = ClerkTheme(colors = ClerkColors(background = Color.Green))
       )
     }
   }

--- a/workbench/src/main/java/com/clerk/workbench/WorkbenchApplication.kt
+++ b/workbench/src/main/java/com/clerk/workbench/WorkbenchApplication.kt
@@ -1,11 +1,8 @@
 package com.clerk.workbench
 
 import android.app.Application
-import androidx.compose.ui.graphics.Color
 import com.clerk.api.Clerk
 import com.clerk.api.ClerkConfigurationOptions
-import com.clerk.api.ui.ClerkColors
-import com.clerk.api.ui.ClerkTheme
 
 class WorkbenchApplication : Application() {
 


### PR DESCRIPTION
## Summary
- Add support for automatic passkey sign-in when passkey autofill is enabled and the auth screen is eligible
- Thread `preferImmediatelyAvailableCredentials` through the passkey sign-in path
- Suppress expected automatic-flow errors like user cancellation and no saved credentials
- Add tests for the API and UI gating logic

note: when the screen goes black, the passkey modal is shown, screen recording blocks it for security reasons


https://github.com/user-attachments/assets/b2a99f12-2dbc-4075-b250-d60242bc6ae5




