### PR TITLE
feat(api): decode environment feature flags

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/Environment.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/Environment.kt
@@ -13,6 +13,7 @@ internal data class Environment(
   @SerialName("user_settings") val userSettings: UserSettings,
   @SerialName("organization_settings")
   val organizationSettings: OrganizationSettings = OrganizationSettings(),
+  @SerialName("feature_flags") val featureFlags: FeatureFlags = FeatureFlags(),
 ) {
   val passkeyIsEnabled: Boolean
     get() = userSettings.attributes.any { (key, value) -> key == "passkey" && value.enabled }

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/FeatureFlags.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/FeatureFlags.kt
@@ -1,0 +1,9 @@
+package com.clerk.api.network.model.environment
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class FeatureFlags(
+  @SerialName("android_test_flag") val androidTestFlag: Boolean = false
+)

--- a/source/api/src/test/java/com/clerk/api/network/model/environment/EnvironmentSerializationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/model/environment/EnvironmentSerializationTest.kt
@@ -1,0 +1,86 @@
+package com.clerk.api.network.model.environment
+
+import com.clerk.api.network.ClerkApi
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EnvironmentSerializationTest {
+
+  @Test
+  fun `feature flags default to disabled when omitted`() {
+    val environment = ClerkApi.json.decodeFromString<Environment>(environmentJson())
+
+    assertFalse(environment.featureFlags.androidTestFlag)
+  }
+
+  @Test
+  fun `feature flags decode android test flag`() {
+    val environment =
+      ClerkApi.json.decodeFromString<Environment>(
+        environmentJson(
+          featureFlagsJson =
+            """
+            "feature_flags": {
+              "android_test_flag": true
+            },
+            """
+              .trimIndent()
+        )
+      )
+
+    assertTrue(environment.featureFlags.androidTestFlag)
+  }
+
+  @Test
+  fun `feature flags default missing fields to disabled`() {
+    val environment =
+      ClerkApi.json.decodeFromString<Environment>(
+        environmentJson(
+          featureFlagsJson =
+            """
+            "feature_flags": {},
+            """
+              .trimIndent()
+        )
+      )
+
+    assertFalse(environment.featureFlags.androidTestFlag)
+  }
+
+  private fun environmentJson(featureFlagsJson: String = ""): String {
+    return """
+      {
+        "auth_config": {
+          "single_session_mode": false
+        },
+        "display_config": {
+          "instance_environment_type": "development",
+          "application_name": "Test App",
+          "preferred_sign_in_strategy": "password",
+          "branded": true,
+          "logo_image_url": "https://example.com/logo.png",
+          "home_url": "/",
+          "privacy_policy_url": null,
+          "terms_url": null,
+          "google_one_tap_client_id": null
+        },
+        "user_settings": {
+          "attributes": {},
+          "sign_up": {
+            "custom_action_required": false,
+            "progressive": false,
+            "mode": "public",
+            "legal_consent_enabled": false
+          },
+          "social": {},
+          "actions": {},
+          "passkey_settings": null
+        },
+        $featureFlagsJson
+        "organization_settings": {}
+      }
+    """
+      .trimIndent()
+  }
+}


### PR DESCRIPTION
## Summary

Adds internal decoding for SDK feature flags returned by FAPI `/v1/environment`.

This includes:
- internal `FeatureFlags` environment model
- `Environment.featureFlags` with default-disabled fallback
- serialization tests for absent, present, and empty `feature_flags`

This does not add public developer-facing APIs or gate production SDK behavior yet.

## Dependency

Depends on the backend SDK feature flag foundation PR: https://github.com/clerk/clerk_go/pull/20086

## Verification

- `./gradlew :source:api:testDebugUnitTest --tests "com.clerk.api.network.model.environment.EnvironmentSerializationTest"`
- `./gradlew :source:api:spotlessCheck`
