### PR TITLE
ci: skip draft pull request runs for Android workflows

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -1,10 +1,13 @@
 name: Android Unit Test
 on:
+  workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "sam/clerk-ui" ]
 
 jobs:
   test-module:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       matrix:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,10 +1,13 @@
 name: Build Android App
 on:
+  workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "sam/clerk-ui" ]
 
 jobs:
   build-module:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       matrix:

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -1,8 +1,12 @@
 name: reviewdog
-on: [ pull_request ]
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   detekt:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     name: Check Code Quality
     runs-on: blacksmith-4vcpu-ubuntu-2404
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,10 +1,13 @@
 name: Integration Tests
 on:
+  workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main" ]
 
 jobs:
   integration-test:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/paparazzi-verify.yml
+++ b/.github/workflows/paparazzi-verify.yml
@@ -1,11 +1,13 @@
 name: Paparazzi Verify
 
 on:
+  workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   verify:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     permissions:


### PR DESCRIPTION
### Motivation
- Prevent expensive Android CI jobs from running on draft PRs during AI review while still allowing reviewers to run workflows manually. 
- Ensure CI executes automatically when a draft PR is marked `ready_for_review` so standard checks run once the author is ready.

### Description
- Add `workflow_dispatch` to workflow triggers and include `ready_for_review` in `pull_request` event types to allow manual runs and to run when a draft is marked ready. 
- Gate top-level jobs with `if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false` to skip CI for draft PR events. 
- Updated workflows: `.github/workflows/android.yml`, `.github/workflows/android-test.yml`, `.github/workflows/detekt.yml`, `.github/workflows/integration-test.yml`, and `.github/workflows/paparazzi-verify.yml`.

### Testing
- Loaded every workflow with Ruby YAML parsing via `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'` which succeeded. 
- Ran `git diff --check` to validate there are no whitespace or diff errors which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4420c6fca483229f9699300e6ac095)