### PR TITLE
fix(ui): align social button layout with web

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -33,14 +33,12 @@ import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.R
 import com.clerk.ui.core.badge.LastUsedAuthBadgeOverlay
-import com.clerk.ui.core.button.social.ClerkSocialButton
 import com.clerk.ui.core.button.social.ClerkSocialRow
 import com.clerk.ui.core.button.standard.ClerkButton
 import com.clerk.ui.core.button.standard.ClerkButtonDefaults
 import com.clerk.ui.core.button.standard.ClerkTextButton
 import com.clerk.ui.core.composition.LocalAuthState
 import com.clerk.ui.core.dimens.dp24
-import com.clerk.ui.core.dimens.dp8
 import com.clerk.ui.core.divider.TextDivider
 import com.clerk.ui.core.input.ClerkPhoneNumberField
 import com.clerk.ui.core.input.ClerkTextField
@@ -118,12 +116,6 @@ internal fun AuthStartViewImpl(
       storedIdentifierType = authState.storedIdentifierType,
     )
   val lastUsedSocialProvider = lastUsedAuth?.socialProvider
-  val socialProvidersMinusLastUsed =
-    if (lastUsedSocialProvider == null) {
-      socialProviders
-    } else {
-      socialProviders.filter { it != lastUsedSocialProvider }
-    }
   val showDismissButton = shouldShowAuthDismissButton(isDismissible)
   val dismissHandler = rememberDismissHandler(onDismiss)
   val lockedInitialIdentifierIsActive =
@@ -277,30 +269,14 @@ internal fun AuthStartViewImpl(
         if (authViewHelper.showOrDivider) {
           TextDivider(stringResource(R.string.or))
         }
-        Column(verticalArrangement = Arrangement.spacedBy(dp8)) {
-          if (lastUsedSocialProvider != null) {
-            LastUsedAuthBadgeOverlay(isVisible = true, modifier = Modifier.fillMaxWidth()) {
-              ClerkSocialButton(
-                provider = lastUsedSocialProvider,
-                modifier = Modifier.fillMaxWidth(),
-                onClick = {
-                  authState.enableInProgressAuthAttemptResume()
-                  authStartViewModel.authenticateWithSocialProvider(
-                    provider = it,
-                    transferable = authState.mode.transferable,
-                    preferGoogleOneTap = preferGoogleOneTap,
-                    startOAuthWithSignUp = startSocialOAuthAsSignUp,
-                    unsafeMetadata = authState.unsafeMetadata,
-                  )
-                },
-                forceIconOnly = false,
-              )
-            }
-          }
-
-          if (socialProvidersMinusLastUsed.isNotEmpty()) {
+        if (socialProviders.isNotEmpty()) {
+          LastUsedAuthBadgeOverlay(
+            isVisible = lastUsedSocialProvider != null,
+            modifier = Modifier.fillMaxWidth(),
+          ) {
             ClerkSocialRow(
-              providers = socialProvidersMinusLastUsed.toImmutableList(),
+              providers = socialProviders.toImmutableList(),
+              lastUsedProvider = lastUsedSocialProvider,
               onClick = {
                 authState.enableInProgressAuthAttemptResume()
                 authStartViewModel.authenticateWithSocialProvider(

--- a/source/ui/src/main/java/com/clerk/ui/core/button/social/ClerkSocialRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/button/social/ClerkSocialRow.kt
@@ -1,7 +1,6 @@
 package com.clerk.ui.core.button.social
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,17 +14,12 @@ import com.clerk.ui.core.dimens.dp8
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
-private const val MAX_BUTTONS_PER_ROW = 3
-
 /**
  * A composable row layout for displaying multiple social authentication buttons.
  *
- * This component arranges social login buttons in rows of exactly 3 buttons each. When there are
- * more than 3 buttons, they wrap to additional rows. Each button takes equal width within its row
- * and is displayed in icon-only mode for consistent, compact sizing.
- *
- * For the last row, if there's an odd number of buttons remaining, they are offset in a brick
- * pattern with the first button centered and any additional buttons spread evenly.
+ * This component uses the same layout rules as Clerk's web components: social providers are evenly
+ * distributed into rows of up to five buttons, a last-used provider can be separated into its own
+ * first row, and one/two-provider rows render as full-width block buttons on mobile.
  *
  * @param providers List of [OAuthProvider]s to display as social login buttons.
  * @param modifier Optional [Modifier] for theming and styling.
@@ -34,6 +28,7 @@ private const val MAX_BUTTONS_PER_ROW = 3
  *   [OAuthProvider].
  * @param allowSingleProviderFullWidth Whether a single provider should render as a full-width
  *   button with text. Defaults to `true`.
+ * @param lastUsedProvider Optional provider to separate into its own first row.
  */
 @Composable
 fun ClerkSocialRow(
@@ -42,65 +37,43 @@ fun ClerkSocialRow(
   clerkTheme: ClerkTheme? = null,
   onClick: (OAuthProvider) -> Unit = {},
   allowSingleProviderFullWidth: Boolean = true,
+  lastUsedProvider: OAuthProvider? = null,
 ) {
-  val isSingleProvider = providers.size == 1 && allowSingleProviderFullWidth
+  val socialButtonRows =
+    distributeSocialButtonsIntoRows(providers = providers, lastUsedProvider = lastUsedProvider)
 
   Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(dp8)) {
-    val chunks = providers.chunked(MAX_BUTTONS_PER_ROW)
+    socialButtonRows.rows.forEach { rowProviders ->
+      val shouldUseBlockButtons =
+        allowSingleProviderFullWidth &&
+          (rowProviders.size == 1 ||
+            (!socialButtonRows.lastUsedProviderPresent && providers.size == 2))
 
-    // Special-case: single provider gets a full-width button with text
-    if (isSingleProvider) {
-      Row(modifier = Modifier.fillMaxWidth()) {
-        ClerkSocialButton(
-          provider = providers.first(),
-          isEnabled = true,
-          onClick = onClick,
-          forceIconOnly = false,
-          modifier = Modifier.fillMaxWidth(),
-          clerkTheme = clerkTheme,
-        )
-      }
-      return@Column
-    }
-
-    chunks.forEachIndexed { rowIndex, rowProviders ->
-      val isLastRow = rowIndex == chunks.size - 1
-
-      // Build exactly 3 equal-width slots for every row. For the last row, use a brick pattern
-      // so that 1 item is centered and 2 items sit at the edges.
-      val rowSlots: List<OAuthProvider?> =
-        when {
-          // Full rows: fill left-to-right, pad trailing with nulls (placeholders)
-          !isLastRow || rowProviders.size == MAX_BUTTONS_PER_ROW ->
-            rowProviders + List(MAX_BUTTONS_PER_ROW - rowProviders.size) { null }
-          // Last row with 1 item: center
-          rowProviders.size == 1 -> listOf(null, rowProviders[0], null)
-          // Last row with 2 items: no middle spacer, buttons take full width
-          rowProviders.size == 2 -> rowProviders
-          else -> rowProviders
+      if (shouldUseBlockButtons) {
+        rowProviders.forEach { provider ->
+          ClerkSocialButton(
+            provider = provider,
+            isEnabled = true,
+            onClick = onClick,
+            forceIconOnly = false,
+            modifier = Modifier.fillMaxWidth(),
+            clerkTheme = clerkTheme,
+          )
         }
-
-      Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement =
-          when {
-            isLastRow && rowProviders.size == 2 -> Arrangement.spacedBy(dp8)
-            else -> Arrangement.spacedBy(dp8, Alignment.CenterHorizontally)
-          },
-      ) {
-        rowSlots.forEach { slotProvider ->
-          Box(modifier = Modifier.weight(1f)) {
-            if (slotProvider != null) {
-              ClerkSocialButton(
-                provider = slotProvider,
-                isEnabled = true,
-                onClick = onClick,
-                forceIconOnly = true,
-                modifier = Modifier.fillMaxWidth(),
-                clerkTheme = clerkTheme,
-                expandIconWidth = isLastRow && rowProviders.size == 2,
-              )
-            }
+      } else {
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.spacedBy(dp8, Alignment.CenterHorizontally),
+        ) {
+          rowProviders.forEach { provider ->
+            ClerkSocialButton(
+              provider = provider,
+              isEnabled = true,
+              onClick = onClick,
+              forceIconOnly = true,
+              modifier = Modifier.weight(1f),
+              clerkTheme = clerkTheme,
+            )
           }
         }
       }

--- a/source/ui/src/main/java/com/clerk/ui/core/button/social/SocialButtonLayout.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/button/social/SocialButtonLayout.kt
@@ -1,0 +1,60 @@
+package com.clerk.ui.core.button.social
+
+import androidx.annotation.VisibleForTesting
+
+internal const val MAX_SOCIAL_BUTTONS_PER_ROW = 5
+
+/**
+ * Evenly distributes social providers into rows using the same rules as Clerk's web components.
+ *
+ * If [lastUsedProvider] is present in [providers], it is separated into its own first row and the
+ * remaining providers are distributed independently.
+ */
+@VisibleForTesting
+internal fun <T> distributeSocialButtonsIntoRows(
+  providers: List<T>,
+  maxProvidersPerRow: Int = MAX_SOCIAL_BUTTONS_PER_ROW,
+  lastUsedProvider: T? = null,
+): SocialButtonRows<T> {
+  if (providers.isEmpty()) {
+    return SocialButtonRows(rows = emptyList(), lastUsedProviderPresent = false)
+  }
+
+  if (lastUsedProvider != null && providers.contains(lastUsedProvider)) {
+    val remainingProviders = providers.filter { it != lastUsedProvider }
+    if (remainingProviders.isEmpty()) {
+      return SocialButtonRows(
+        rows = listOf(listOf(lastUsedProvider)),
+        lastUsedProviderPresent = true,
+      )
+    }
+
+    val remainingRows =
+      distributeSocialButtonsIntoRows(
+        providers = remainingProviders,
+        maxProvidersPerRow = maxProvidersPerRow,
+        lastUsedProvider = null,
+      )
+    return SocialButtonRows(
+      rows = listOf(listOf(lastUsedProvider)) + remainingRows.rows,
+      lastUsedProviderPresent = true,
+    )
+  }
+
+  if (providers.size <= maxProvidersPerRow) {
+    return SocialButtonRows(rows = listOf(providers), lastUsedProviderPresent = false)
+  }
+
+  val rowCount = ceilDiv(providers.size, maxProvidersPerRow)
+  val providersPerRow = ceilDiv(providers.size, rowCount)
+  val rows = providers.chunked(providersPerRow)
+  return SocialButtonRows(rows = rows, lastUsedProviderPresent = false)
+}
+
+@VisibleForTesting
+internal data class SocialButtonRows<T>(
+  val rows: List<List<T>>,
+  val lastUsedProviderPresent: Boolean,
+)
+
+private fun ceilDiv(value: Int, divisor: Int): Int = (value + divisor - 1) / divisor

--- a/source/ui/src/test/java/com/clerk/ui/core/button/social/SocialButtonLayoutTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/core/button/social/SocialButtonLayoutTest.kt
@@ -1,0 +1,41 @@
+package com.clerk.ui.core.button.social
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SocialButtonLayoutTest {
+  @Test
+  fun returnsEmptyRowsWhenNoProvidersAreAvailable() {
+    val result = distributeSocialButtonsIntoRows(providers = emptyList<Int>())
+
+    assertEquals(emptyList(), result.rows)
+    assertFalse(result.lastUsedProviderPresent)
+  }
+
+  @Test
+  fun distributesProvidersEvenlyAcrossRows() {
+    val result = distributeSocialButtonsIntoRows(providers = listOf(1, 2, 3, 4, 5, 6))
+
+    assertEquals(listOf(listOf(1, 2, 3), listOf(4, 5, 6)), result.rows)
+    assertFalse(result.lastUsedProviderPresent)
+  }
+
+  @Test
+  fun separatesLastUsedProviderIntoFirstRow() {
+    val result =
+      distributeSocialButtonsIntoRows(providers = listOf(1, 2, 3, 4, 5), lastUsedProvider = 3)
+
+    assertEquals(listOf(listOf(3), listOf(1, 2, 4, 5)), result.rows)
+    assertTrue(result.lastUsedProviderPresent)
+  }
+
+  @Test
+  fun leavesProvidersTogetherWhenWithinRowLimitAndLastUsedProviderIsAbsent() {
+    val result = distributeSocialButtonsIntoRows(providers = listOf(1, 2, 3, 4, 5))
+
+    assertEquals(listOf(listOf(1, 2, 3, 4, 5)), result.rows)
+    assertFalse(result.lastUsedProviderPresent)
+  }
+}


### PR DESCRIPTION
### Motivation
- Mobile social button layout diverged from the web components and needs to use identical distribution and last-used-provider behavior to provide consistent UX across platforms.

### Description
- Add a shared layout utility `distributeSocialButtonsIntoRows` in `SocialButtonLayout.kt` that mirrors the web logic (max 5 per row, balanced splitting, last-used provider separation, and empty-list handling).
- Update `ClerkSocialRow` to use the new distribution logic and render one/two-provider rows as full-width block buttons while rendering larger rows as icon-only equal-width buttons.
- Update `AuthStartView` to pass the full `socialProviders` list and `lastUsedProvider` into `ClerkSocialRow` so the Auth start screen follows the unified layout path.
- Add unit tests in `SocialButtonLayoutTest.kt` covering empty lists, even distribution, last-used provider separation, and within-limit behavior.

### Testing
- Ran formatting with `./gradlew spotlessApply` / `./gradlew spotlessCheck` which completed successfully. 
- Added `SocialButtonLayoutTest` unit tests; running `./gradlew :source:ui:testDebugUnitTest --tests 'com.clerk.ui.core.button.social.SocialButtonLayoutTest'` was blocked in CI by a missing Java 21 toolchain in the environment. 
- Running `./gradlew :source:ui:detekt` was blocked by a missing Java 17 toolchain in the environment, and a full `./gradlew detekt` run failed for the same reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e73d9cc508322b5c6ed787e50a9ed)