### PR TITLE
Add logo mask support and tint Clerk footer logo

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/core/extensions/LogoUrlExtensions.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/extensions/LogoUrlExtensions.kt
@@ -1,11 +1,14 @@
 package com.clerk.ui.core.extensions
 
+private val supportsMaskImage = setOf("apple", "github", "okx_wallet", "vercel", "x", "linear")
+
 /**
- * Returns a new URL string for a dark mode variant of an image if [isInDarkMode] is true.
+ * Returns a new URL string for a dark mode variant of an image if [isInDarkMode] is true and the
+ * logo supports dark mode masking.
  *
- * This function assumes the original URL points to a `.png` file. It replaces the `.png` extension
- * with `-dark.png` to form the new URL. If [isInDarkMode] is false, it returns the original string
- * unchanged.
+ * This function assumes the original URL points to a supported `.png` file. It replaces the `.png`
+ * extension with `-dark.png` to form the new URL. If [isInDarkMode] is false, or the logo is not in
+ * the supported mask list, it returns the original string unchanged.
  *
  * Example: `"https://img.clerk.com/logo.png".withDarkVariant(true)` returns
  * `"https://img.clerk.com/logo-dark.png"` `"https://img.clerk.com/logo.png".withDarkVariant(false)`
@@ -15,9 +18,17 @@ package com.clerk.ui.core.extensions
  * @return The modified URL string for dark mode, or the original string otherwise.
  */
 internal fun String.withDarkVariant(isInDarkMode: Boolean): String {
-  return if (isInDarkMode) {
-    this.replace(".png", "-dark.png")
-  } else {
-    this
-  }
+  if (!isInDarkMode || !supportsDarkModeMask()) return this
+
+  val suffixStart = indexOfFirst { it == '?' || it == '#' }.takeUnless { it == -1 } ?: length
+  return substring(0, suffixStart).removeSuffix(".png") + "-dark.png" + substring(suffixStart)
+}
+
+private fun String.supportsDarkModeMask(): Boolean {
+  val path = substringBefore("?").substringBefore("#")
+  val fileName = path.substringAfterLast("/")
+  if (!fileName.endsWith(".png")) return false
+
+  val logoSlug = fileName.removeSuffix(".png")
+  return logoSlug in supportsMaskImage
 }

--- a/source/ui/src/main/java/com/clerk/ui/core/footer/SecuredByClerkView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/footer/SecuredByClerkView.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -40,7 +41,11 @@ internal fun SecuredByClerkView(
           style = ClerkMaterialTheme.typography.bodyMedium,
           color = ClerkMaterialTheme.colors.mutedForeground,
         )
-        Image(painter = painterResource(R.drawable.ic_clerk_logo), contentDescription = "Clerk")
+        Image(
+          painter = painterResource(R.drawable.ic_clerk_logo),
+          contentDescription = "Clerk",
+          colorFilter = ColorFilter.tint(ClerkMaterialTheme.colors.mutedForeground),
+        )
       }
     }
   }

--- a/source/ui/src/test/java/com/clerk/ui/core/extensions/LogoUrlExtensionsTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/core/extensions/LogoUrlExtensionsTest.kt
@@ -1,0 +1,41 @@
+package com.clerk.ui.core.extensions
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LogoUrlExtensionsTest {
+
+  @Test
+  fun usesDarkVariantForSupportedMaskImagesInDarkMode() {
+    listOf("apple", "github", "okx_wallet", "vercel", "x", "linear").forEach { logo ->
+      assertEquals(
+        "https://img.clerk.com/static/$logo-dark.png",
+        "https://img.clerk.com/static/$logo.png".withDarkVariant(isInDarkMode = true),
+      )
+    }
+  }
+
+  @Test
+  fun keepsUnsupportedLogosUnchangedInDarkMode() {
+    assertEquals(
+      "https://img.clerk.com/static/google.png",
+      "https://img.clerk.com/static/google.png".withDarkVariant(isInDarkMode = true),
+    )
+  }
+
+  @Test
+  fun keepsSupportedLogosUnchangedInLightMode() {
+    assertEquals(
+      "https://img.clerk.com/static/github.png",
+      "https://img.clerk.com/static/github.png".withDarkVariant(isInDarkMode = false),
+    )
+  }
+
+  @Test
+  fun preservesUrlSuffixWhenUsingDarkVariant() {
+    assertEquals(
+      "https://img.clerk.com/static/vercel-dark.png?width=64#icon",
+      "https://img.clerk.com/static/vercel.png?width=64#icon".withDarkVariant(isInDarkMode = true),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Restrict dark-mode logo URL swapping to the supported mask logo set
- Preserve query and fragment suffixes when generating dark variants
- Tint the "Secured by Clerk" footer logo to match muted foreground color
- Add unit coverage for supported, unsupported, light-mode, and suffix-preserving cases

<img height="700" alt="image" src="https://github.com/user-attachments/assets/76fe4cb7-c9df-41b1-b5bb-94d298b031ab" />
<img height="700" alt="image" src="https://github.com/user-attachments/assets/feb26cbb-6cbd-4d4c-be84-66358964633a" />

