### PR TITLE
fix(ui): preserve organization logo aspect ratio

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/core/appbar/ClerkTopAppbar.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/appbar/ClerkTopAppbar.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.clerk.api.Clerk
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.R
-import com.clerk.ui.core.avatar.OrganizationAvatar
+import com.clerk.ui.core.avatar.OrganizationLogo
 import com.clerk.ui.core.dimens.dp12
 import com.clerk.ui.core.dimens.dp48
 import com.clerk.ui.core.dimens.dp68
@@ -68,7 +68,7 @@ internal fun ClerkTopAppBar(
       ) {
         val logoContent: (@Composable () -> Unit)? =
           if (hasLogo) {
-            { OrganizationAvatar(clerkTheme = clerkTheme, imageUrl = logoUrl) }
+            { OrganizationLogo(clerkTheme = clerkTheme, imageUrl = logoUrl) }
           } else {
             null
           }

--- a/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
@@ -253,8 +253,9 @@ internal fun OrganizationLogo(
   maxWidth: Dp = dp96,
   height: Dp = dp24,
   clerkTheme: ClerkTheme? = null,
+  imageUrl: String? = Clerk.organizationLogoUrl,
 ) {
-  val url = Clerk.organizationLogoUrl
+  val url = imageUrl
   ClerkMaterialTheme(clerkTheme = clerkTheme) {
     if (url.isNullOrBlank()) {
       Icon(


### PR DESCRIPTION
### Motivation
- The top app bar was rendering the organization logo through the square `OrganizationAvatar` which uses `ContentScale.FillBounds` and squashes wide logos into a square.
- Callers need a way to pass the resolved logo URL so the top bar can render logos without forcing the avatar sizing behavior.

### Description
- Replace `OrganizationAvatar` with `OrganizationLogo` in `ClerkTopAppbar.kt` so the top bar preserves wide-logo aspect ratios.
- Add an `imageUrl: String?` parameter to `OrganizationLogo` and use that value instead of always reading `Clerk.organizationLogoUrl`.
- Preserve the existing default behavior by defaulting `imageUrl` to `Clerk.organizationLogoUrl` so callers are optional and backwards-compatible.

### Testing
- Ran `./gradlew spotlessApply` which completed successfully.
- Ran `./gradlew spotlessCheck` which completed successfully.
- Attempted to run the snapshot test `./gradlew :source:ui:testDebug --tests "com.clerk.snapshot.appbar.ClerkTopAppBarSnapshotTest"` but it was blocked due to the container not having an Android SDK location configured (`ANDROID_HOME` or `local.properties`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5114eb7f848322bd2303979682575c)