### PR TITLE
Add shared session synchronization across Android apps

### DIFF
--- a/source/api/src/main/AndroidManifest.xml
+++ b/source/api/src/main/AndroidManifest.xml
@@ -1,10 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <queries>
+        <intent>
+            <action android:name="com.clerk.api.action.SHARED_SESSION_SYNC" />
+        </intent>
+    </queries>
+
     <application android:supportsRtl="true">
+
+        <!--
+          Reads are restricted at runtime to callers signed with the same certificate. A fixed
+          manifest permission cannot be used here because permission names are global across every
+          app that embeds the Clerk library.
+        -->
+        <provider
+            android:name="com.clerk.api.sharedsession.SharedSessionSyncProvider"
+            android:authorities="${applicationId}.clerk.shared-session-sync"
+            android:exported="true"
+            android:grantUriPermissions="false"
+            tools:ignore="ExportedContentProvider">
+            <intent-filter>
+                <action android:name="com.clerk.api.action.SHARED_SESSION_SYNC" />
+            </intent-filter>
+        </provider>
 
         <activity
             android:name="com.clerk.api.sso.SSOManagerActivity"

--- a/source/api/src/main/AndroidManifest.xml
+++ b/source/api/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <provider
             android:name="com.clerk.api.sharedsession.SharedSessionSyncProvider"
             android:authorities="${applicationId}.clerk.shared-session-sync"
+            android:enabled="false"
             android:exported="true"
             android:grantUriPermissions="false"
             tools:ignore="ExportedContentProvider">

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -31,6 +31,7 @@ import com.clerk.api.organizations.Organization
 import com.clerk.api.organizations.OrganizationMembership
 import com.clerk.api.session.Session
 import com.clerk.api.session.SessionTokensCache
+import com.clerk.api.sharedsession.SharedSessionSyncCoordinator
 import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.SSOService
@@ -57,6 +58,10 @@ object Clerk {
 
   /** Internal configuration manager responsible for SDK initialization and API client setup. */
   private val configurationManager = ConfigurationManager()
+
+  /** Coordinates persisted Clerk state between same-signed sibling apps when enabled. */
+  internal var sharedSessionSyncCoordinator: SharedSessionSyncCoordinator? = null
+    private set
 
   /**
    * Enable for additional debugging signals and logging.
@@ -142,6 +147,10 @@ object Clerk {
 
   /** Internal environment configuration containing display settings and authentication options. */
   internal var environment: Environment? = null
+
+  /** Receipt time for the latest authoritative client response used to reject stale snapshots. */
+  internal var lastClientServerFetchAtMillis: Long? = null
+    private set
 
   /**
    * The Client object representing the current device and its authentication state.
@@ -734,6 +743,7 @@ object Clerk {
   fun reset() {
     configurationManager.reset()
     StorageHelper.deleteValue(StorageKey.DEVICE_TOKEN)
+    StorageHelper.deleteValue(StorageKey.SHARED_SESSION_SYNC_SNAPSHOT)
     clearSessionAndUserState()
     SessionTokensCache.clear()
     SSOService.cancelPendingAuthentication()
@@ -743,6 +753,7 @@ object Clerk {
     ClerkApi.reset()
     updateClient(Client())
     _clientFlow.value = null
+    lastClientServerFetchAtMillis = null
     environment = null
     publishableKey = null
     baseUrl = ""
@@ -784,6 +795,16 @@ object Clerk {
       is ClerkResult.Failure -> result
     }
   }
+
+  /**
+   * Reloads Clerk authentication state persisted by a same-signed sibling app.
+   *
+   * Shared-session sync must be enabled through [ClerkConfigurationOptions.sharedSessionSync]. The
+   * method returns `true` when the in-memory client, environment, or device-token generation
+   * changed.
+   */
+  suspend fun reloadFromSharedStorage(): Boolean =
+    sharedSessionSyncCoordinator?.reloadFromSharedStorage(force = true) ?: false
 
   /**
    * Provides the current foreground [Activity] to Clerk explicitly.
@@ -894,9 +915,11 @@ object Clerk {
    * @param environment The updated environment configuration.
    */
   internal fun updateEnvironment(environment: Environment) {
+    val previousEnvironment = this.environment
     this.environment = environment
     _organizationLogoUrlFlow.value = environment.displayConfig.logoImageUrl
     _multiSessionModeIsEnabled.value = !environment.authConfig.singleSessionMode
+    sharedSessionSyncCoordinator?.handleEnvironmentChange(previousEnvironment, environment)
   }
 
   internal fun credentialActivity(): Activity? = currentActivity?.get()
@@ -909,9 +932,21 @@ object Clerk {
    * @param client The updated client configuration.
    */
   internal fun updateClient(client: Client) {
+    val resolvedClient = client.withResolvedActiveSession(previousSession = _session.value)
+    val serverFetchAtMillis =
+      if (_clientFlow.value == resolvedClient) {
+        lastClientServerFetchAtMillis ?: System.currentTimeMillis()
+      } else {
+        System.currentTimeMillis()
+      }
+    updateClient(client = client, serverFetchAtMillis = serverFetchAtMillis)
+  }
+
+  internal fun updateClient(client: Client, serverFetchAtMillis: Long) {
     val updatedClient = client.withResolvedActiveSession(previousSession = _session.value)
 
     this.client = updatedClient
+    lastClientServerFetchAtMillis = serverFetchAtMillis
     _clientFlow.value = updatedClient
     // Only update state if flows are initialized (not during static initialization)
     try {
@@ -919,6 +954,39 @@ object Clerk {
     } catch (e: Exception) {
       ClerkLog.e("${e.message}")
     }
+    sharedSessionSyncCoordinator?.handleClientChange(updatedClient, serverFetchAtMillis)
+  }
+
+  internal fun configureSharedSessionSync(
+    context: Context,
+    publishableKey: String,
+    config: SharedSessionSyncConfig?,
+  ) {
+    stopSharedSessionSync()
+    if (config == null) return
+
+    sharedSessionSyncCoordinator =
+      SharedSessionSyncCoordinator(context = context, publishableKey = publishableKey).also {
+        coordinator ->
+        coordinator.start()
+      }
+  }
+
+  internal fun stopSharedSessionSync() {
+    sharedSessionSyncCoordinator?.close()
+    sharedSessionSyncCoordinator = null
+  }
+
+  internal fun fenceClientResponsesAfterSharedDeviceTokenChange() {
+    configurationManager.fenceClientResponsesAfterSharedDeviceTokenChange()
+  }
+
+  internal fun isClientResponseCurrent(
+    requestDeviceToken: String?,
+    responseDeviceToken: String?,
+  ): Boolean {
+    val currentDeviceToken = StorageHelper.loadValue(StorageKey.DEVICE_TOKEN)
+    return currentDeviceToken == (responseDeviceToken ?: requestDeviceToken)
   }
 
   private fun Client.withResolvedActiveSession(previousSession: Session?): Client {
@@ -1008,11 +1076,14 @@ object Clerk {
  *   for applications that run behind a reverse proxy. Must be a full URL (for example,
  *   https://proxy.example.com/__clerk).
  * @property telemetryEnabled Whether to enable telemetry for this SDK instance.
+ * @property sharedSessionSync Optional configuration for synchronizing Clerk state between
+ *   same-signed sibling apps that use the same publishable key.
  */
 data class ClerkConfigurationOptions(
   val enableDebugMode: Boolean = false,
   val proxyUrl: String? = null,
   val telemetryEnabled: Boolean = true,
+  val sharedSessionSync: SharedSessionSyncConfig? = null,
 ) {
   private var _customHeaders: Map<String, String> = emptyMap()
 

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -32,6 +32,7 @@ import com.clerk.api.organizations.OrganizationMembership
 import com.clerk.api.session.Session
 import com.clerk.api.session.SessionTokensCache
 import com.clerk.api.sharedsession.SharedSessionSyncCoordinator
+import com.clerk.api.sharedsession.SharedSessionSyncProvider
 import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.SSOService
@@ -963,7 +964,10 @@ object Clerk {
     config: SharedSessionSyncConfig?,
   ) {
     stopSharedSessionSync()
-    if (config == null) return
+    if (config == null) {
+      SharedSessionSyncProvider.setEnabled(context, false)
+      return
+    }
 
     sharedSessionSyncCoordinator =
       SharedSessionSyncCoordinator(context = context, publishableKey = publishableKey).also {

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -805,7 +805,7 @@ object Clerk {
    * changed.
    */
   suspend fun reloadFromSharedStorage(): Boolean =
-    sharedSessionSyncCoordinator?.reloadFromSharedStorage(force = true) ?: false
+    sharedSessionSyncCoordinator?.reloadFromSharedStorage() ?: false
 
   /**
    * Provides the current foreground [Activity] to Clerk explicitly.

--- a/source/api/src/main/kotlin/com/clerk/api/SharedSessionSyncConfig.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/SharedSessionSyncConfig.kt
@@ -20,6 +20,6 @@ package com.clerk.api
 class SharedSessionSyncConfig private constructor() {
   companion object {
     /** Enables shared-session synchronization for this Clerk instance. */
-    @JvmField val enabled = SharedSessionSyncConfig()
+    val enabled = SharedSessionSyncConfig()
   }
 }

--- a/source/api/src/main/kotlin/com/clerk/api/SharedSessionSyncConfig.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/SharedSessionSyncConfig.kt
@@ -1,0 +1,25 @@
+package com.clerk.api
+
+/**
+ * Enables Clerk authentication-state synchronization between sibling Android apps.
+ *
+ * Participating apps must use the same Clerk publishable key, include the Clerk API artifact, and
+ * be signed with the same signing certificate. Clerk discovers matching sibling apps and shares
+ * only its client, environment, and device-token state through a signature-checked content
+ * provider.
+ *
+ * Example:
+ * ```kotlin
+ * Clerk.initialize(
+ *   context = applicationContext,
+ *   publishableKey = "pk_...",
+ *   options = ClerkConfigurationOptions(sharedSessionSync = SharedSessionSyncConfig.enabled),
+ * )
+ * ```
+ */
+class SharedSessionSyncConfig private constructor() {
+  companion object {
+    /** Enables shared-session synchronization for this Clerk instance. */
+    @JvmField val enabled = SharedSessionSyncConfig()
+  }
+}

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
@@ -127,6 +127,9 @@ internal class ConfigurationManager {
   /** Monotonic token used to ignore stale refreshes from an older configuration. */
   @Volatile private var configurationVersion = 0
 
+  /** Monotonic fence used to discard responses started with an older shared device token. */
+  @Volatile private var sharedDeviceTokenFenceGeneration = 0
+
   private enum class RefreshMode {
     INITIALIZATION,
     DEVICE_TOKEN_UPDATE,
@@ -214,6 +217,11 @@ internal class ConfigurationManager {
     Clerk.applicationId = context.applicationContext.packageName
 
     ensureStorageInitialized()
+    Clerk.configureSharedSessionSync(
+      context = context.applicationContext,
+      publishableKey = publishableKey,
+      config = options?.sharedSessionSync,
+    )
     ClerkApi.configure(
       baseUrl = Clerk.baseUrl,
       context = context.applicationContext,
@@ -227,37 +235,40 @@ internal class ConfigurationManager {
   private fun launchInitialization(
     options: ClerkConfigurationOptions?,
     configuredVersion: Int,
-  ): Job =
-    scope.launch {
-      val attempt =
-        RefreshAttempt(
-          options = options,
-          retryCount = 0,
-          expectedConfigurationVersion = configuredVersion,
-        )
-      val deviceIdInitJob = async { DeviceIdGenerator.initialize() }
-      val dataRefreshJob = async {
-        refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
-      }
+  ): Job = scope.launch {
+    val attempt =
+      RefreshAttempt(
+        options = options,
+        retryCount = 0,
+        expectedConfigurationVersion = configuredVersion,
+      )
+    Clerk.sharedSessionSyncCoordinator?.reloadFromSharedStorage(force = true)
+    val deviceIdInitJob = async { DeviceIdGenerator.initialize() }
+    val dataRefreshJob = async {
+      refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+    }
 
-      deviceIdInitJob.await()
-      AppLifecycleListener.configure {
-        if (hasConfigured) {
-          scope.launch {
-            deferForegroundRefreshDuringPendingSso()
-            refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
-            startTokenRefresh()
-          }
+    deviceIdInitJob.await()
+    AppLifecycleListener.configure {
+      if (hasConfigured) {
+        scope.launch {
+          Clerk.sharedSessionSyncCoordinator?.reloadFromSharedStorage(force = false)
+          deferForegroundRefreshDuringPendingSso()
+          refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+          startTokenRefresh()
         }
       }
-      dataRefreshJob.await()
     }
+    dataRefreshJob.await()
+  }
 
   fun isConfigured(): Boolean = hasConfigured
 
   @Synchronized
   fun reset() {
     configurationVersion += 1
+    sharedDeviceTokenFenceGeneration += 1
+    Clerk.stopSharedSessionSync()
     scope.coroutineContext.cancelChildren()
     initializationJob?.cancel()
     refreshJob?.cancel()
@@ -274,6 +285,10 @@ internal class ConfigurationManager {
     AppLifecycleListener.stop()
   }
 
+  fun fenceClientResponsesAfterSharedDeviceTokenChange() {
+    sharedDeviceTokenFenceGeneration += 1
+  }
+
   private fun startTokenRefresh() {
     ClerkLog.d(
       "startTokenRefresh() called - debugMode: ${Clerk.debugMode}, hasConfigured: $hasConfigured"
@@ -286,29 +301,28 @@ internal class ConfigurationManager {
 
     // Cancel any ongoing jobs
     refreshJob?.cancel()
-    refreshJob =
-      scope.launch {
-        while (isActive) {
-          try {
-            val session = Clerk.session
-            if (session != null) {
-              if (Clerk.debugMode) {
-                ClerkLog.d("Refreshing token for session: ${session.id}")
-              }
-              // Use async to avoid blocking the refresh loop
-              async { session.fetchToken(GetTokenOptions(skipCache = false)) }
-            } else {
-              if (Clerk.debugMode) {
-                ClerkLog.d("No session available for token refresh")
-              }
+    refreshJob = scope.launch {
+      while (isActive) {
+        try {
+          val session = Clerk.session
+          if (session != null) {
+            if (Clerk.debugMode) {
+              ClerkLog.d("Refreshing token for session: ${session.id}")
             }
-          } catch (e: Exception) {
-            ClerkLog.w("Token refresh failed: ${e.message}")
+            // Use async to avoid blocking the refresh loop
+            async { session.fetchToken(GetTokenOptions(skipCache = false)) }
+          } else {
+            if (Clerk.debugMode) {
+              ClerkLog.d("No session available for token refresh")
+            }
           }
-
-          delay(REFRESH_TOKEN_INTERVAL.seconds)
+        } catch (e: Exception) {
+          ClerkLog.w("Token refresh failed: ${e.message}")
         }
+
+        delay(REFRESH_TOKEN_INTERVAL.seconds)
       }
+    }
   }
 
   suspend fun updateDeviceToken(deviceToken: String): ClerkResult<Unit, ClerkErrorResponse> {
@@ -477,10 +491,23 @@ internal class ConfigurationManager {
     skipClientId: Boolean,
   ): ClerkResult<Unit, ClerkErrorResponse> {
     return withTimeout((API_TIMEOUT_SECONDS * TIMEOUT_MULTIPLIER)) {
+      val expectedDeviceTokenFenceGeneration = sharedDeviceTokenFenceGeneration
       val (clientResult, environmentResult) = fetchRefreshData(skipClientId)
 
       if (attempt.expectedConfigurationVersion != configurationVersion || !hasConfigured) {
         return@withTimeout staleConfigurationFailure()
+      }
+
+      if (expectedDeviceTokenFenceGeneration != sharedDeviceTokenFenceGeneration) {
+        ClerkLog.d("Discarding refresh started before a shared device-token change")
+        scope.launch {
+          refreshClientAndEnvironment(
+            attempt = currentRefreshAttempt(),
+            mode = RefreshMode.DEVICE_TOKEN_UPDATE,
+            skipClientId = true,
+          )
+        }
+        return@withTimeout ClerkResult.success(Unit)
       }
 
       handleClientResult(clientResult)

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
@@ -242,7 +242,7 @@ internal class ConfigurationManager {
         retryCount = 0,
         expectedConfigurationVersion = configuredVersion,
       )
-    Clerk.sharedSessionSyncCoordinator?.reloadFromSharedStorage(force = true)
+    Clerk.sharedSessionSyncCoordinator?.reloadFromSharedStorage()
     val deviceIdInitJob = async { DeviceIdGenerator.initialize() }
     val dataRefreshJob = async {
       refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
@@ -252,7 +252,7 @@ internal class ConfigurationManager {
     AppLifecycleListener.configure {
       if (hasConfigured) {
         scope.launch {
-          Clerk.sharedSessionSyncCoordinator?.reloadFromSharedStorage(force = false)
+          Clerk.sharedSessionSyncCoordinator?.reloadFromSharedStorage()
           deferForegroundRefreshDuringPendingSso()
           refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
           startTokenRefresh()

--- a/source/api/src/main/kotlin/com/clerk/api/network/middleware/incoming/ClientSyncingMiddleware.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/middleware/incoming/ClientSyncingMiddleware.kt
@@ -1,6 +1,7 @@
 package com.clerk.api.network.middleware.incoming
 
 import com.clerk.api.Clerk
+import com.clerk.api.Constants.Http.AUTHORIZATION_HEADER
 import com.clerk.api.auth.AuthEvent
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.ApiPaths
@@ -8,6 +9,9 @@ import com.clerk.api.network.model.client.Client
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
 import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -19,12 +23,15 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 
+private const val SERVER_DATE_HEADER = "Date"
+private const val SERVER_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
+
 /**
  * Network middleware that automatically syncs the Clerk client state from API responses.
  *
- * This middleware intercepts successful JSON responses and checks for a "client" field in the
- * response body. If found, it deserializes the client data and updates the global [Clerk.client]
- * state.
+ * This middleware intercepts successful JSON responses and checks for either a direct client
+ * response or a piggybacked "client" field. If found, it deserializes the client data and updates
+ * the global [Clerk.client] state.
  *
  * @property json The JSON serializer used for deserializing the client data.
  */
@@ -39,6 +46,21 @@ internal class ClientSyncingMiddleware(private val json: Json) : Interceptor {
     val request = chain.request()
     val response = chain.proceed(request)
 
+    if (
+      !Clerk.isClientResponseCurrent(
+        requestDeviceToken = response.request.header(AUTHORIZATION_HEADER),
+        responseDeviceToken = response.header(AUTHORIZATION_HEADER),
+      )
+    ) {
+      ClerkLog.d("Client sync skipped for a response using a stale shared device token")
+      return response
+    }
+
+    return syncResponse(request = request, response = response)
+  }
+
+  @Suppress("NestedBlockDepth")
+  private fun syncResponse(request: Request, response: Response): Response {
     // Only process JSON responses
     val body = response.body
     if (response.isSuccessful && body.contentType()?.subtype == "json") {
@@ -47,26 +69,11 @@ internal class ClientSyncingMiddleware(private val json: Json) : Interceptor {
         try {
           // Parse the response to extract client if present
           val jsonElement = json.parseToJsonElement(it)
-          if (jsonElement is JsonObject && jsonElement.containsKey("client")) {
-            val clientJson = jsonElement["client"]
-            when (clientJson) {
-              is JsonNull -> {
-                if (jsonElement.containsKey("response")) {
-                  ClerkLog.d("Client sync skipped null piggyback client")
-                } else {
-                  ClerkLog.d("Client sync cleared by explicit null client")
-                  Clerk.updateClient(Client())
-                }
-              }
-              null -> Unit
-              else -> {
-                // Extract and set the client
-                val client = json.decodeFromJsonElement<Client>(clientJson)
-                ClerkLog.d("Client synced: ${client.id}")
-                Clerk.updateClient(client)
-              }
-            }
-          }
+          syncClientFromResponse(
+            request = request,
+            jsonElement = jsonElement,
+            serverFetchAtMillis = response.serverFetchAtMillis(),
+          )
 
           if (jsonElement is JsonObject) {
             emitAuthEvents(request = request, jsonObject = jsonElement)
@@ -86,6 +93,35 @@ internal class ClientSyncingMiddleware(private val json: Json) : Interceptor {
     }
 
     return response
+  }
+
+  private fun syncClientFromResponse(
+    request: Request,
+    jsonElement: JsonElement,
+    serverFetchAtMillis: Long,
+  ) {
+    if (jsonElement !is JsonObject) return
+
+    if (jsonElement.containsKey("client")) {
+      val clientJson = jsonElement["client"]
+      when (clientJson) {
+        is JsonNull -> {
+          if (jsonElement.containsKey("response")) {
+            ClerkLog.d("Client sync skipped null piggyback client")
+          } else {
+            ClerkLog.d("Client sync cleared by explicit null client")
+            Clerk.updateClient(Client(), serverFetchAtMillis)
+          }
+        }
+        null -> Unit
+        else -> syncClerkClient(json.decodeFromJsonElement(clientJson), serverFetchAtMillis)
+      }
+      return
+    }
+
+    if (request.method == "GET" && request.url.encodedPath.endsWith("/${ApiPaths.Client.BASE}")) {
+      syncClerkClient(json.decodeFromJsonElement(jsonElement), serverFetchAtMillis)
+    }
   }
 
   private fun emitAuthEvents(request: Request, jsonObject: JsonObject) {
@@ -155,4 +191,20 @@ internal class ClientSyncingMiddleware(private val json: Json) : Interceptor {
   private fun isSignUpCreationRequest(path: String, method: String): Boolean {
     return method == "POST" && path.endsWith("/${ApiPaths.Client.SignUp.BASE}")
   }
+}
+
+private fun syncClerkClient(client: Client, serverFetchAtMillis: Long) {
+  ClerkLog.d("Client synced: ${client.id}")
+  Clerk.updateClient(client, serverFetchAtMillis)
+}
+
+private fun Response.serverFetchAtMillis(): Long {
+  val serverDate = header(SERVER_DATE_HEADER) ?: return System.currentTimeMillis()
+  return runCatching {
+      SimpleDateFormat(SERVER_DATE_FORMAT, Locale.US)
+        .apply { timeZone = TimeZone.getTimeZone("GMT") }
+        .parse(serverDate)
+        ?.time
+    }
+    .getOrNull() ?: System.currentTimeMillis()
 }

--- a/source/api/src/main/kotlin/com/clerk/api/network/middleware/incoming/DeviceTokenSavingMiddleware.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/middleware/incoming/DeviceTokenSavingMiddleware.kt
@@ -1,6 +1,7 @@
 package com.clerk.api.network.middleware.incoming
 
 import com.clerk.api.Constants.Http.AUTHORIZATION_HEADER
+import com.clerk.api.log.ClerkLog
 import com.clerk.api.storage.StorageHelper
 import com.clerk.api.storage.StorageKey
 import okhttp3.Interceptor
@@ -22,9 +23,15 @@ internal class DeviceTokenSavingMiddleware : Interceptor {
   override fun intercept(chain: Interceptor.Chain): Response {
     val response = chain.proceed(chain.request())
     val deviceToken = response.header(AUTHORIZATION_HEADER)
+    val requestDeviceToken = response.request.header(AUTHORIZATION_HEADER)
+    val currentDeviceToken = StorageHelper.loadValue(StorageKey.DEVICE_TOKEN)
 
-    // Save the device token to storage whenever it's present in the response
-    deviceToken?.let { token -> StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, token) }
+    // Do not let a response that started with an older shared token overwrite the newer token.
+    if (deviceToken != null && currentDeviceToken == requestDeviceToken) {
+      StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, deviceToken)
+    } else if (deviceToken != null) {
+      ClerkLog.d("Device token update skipped for a stale shared-session response")
+    }
 
     return response
   }

--- a/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncCoordinator.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncCoordinator.kt
@@ -1,0 +1,279 @@
+package com.clerk.api.sharedsession
+
+import android.content.Context
+import com.clerk.api.Clerk
+import com.clerk.api.log.ClerkLog
+import com.clerk.api.network.model.client.Client
+import com.clerk.api.network.model.environment.Environment
+import com.clerk.api.storage.StorageHelper
+import com.clerk.api.storage.StorageKey
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@Suppress("TooManyFunctions")
+internal class SharedSessionSyncCoordinator
+internal constructor(
+  private val instanceId: String,
+  private val transport: SharedSessionSyncTransport,
+  private val clock: () -> Long = System::currentTimeMillis,
+) {
+  constructor(
+    context: Context,
+    publishableKey: String,
+  ) : this(
+    instanceId = SharedSessionSyncSnapshot.instanceId(publishableKey),
+    transport = ContentProviderSharedSessionSyncTransport(context),
+  )
+
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+  private val stateLock = Any()
+  private var localSnapshot: SharedSessionSyncSnapshot? = null
+  private var isApplyingSharedStorage = false
+  private val storageListener = { key: StorageKey, previous: String?, value: String? ->
+    if (key == StorageKey.DEVICE_TOKEN) {
+      handleDeviceTokenChange(previous = previous, value = value)
+    }
+  }
+
+  fun start() {
+    StorageHelper.valueChangeListener = storageListener
+    transport.start { scope.launch { reloadFromSharedStorage(force = false) } }
+  }
+
+  fun close() {
+    if (StorageHelper.valueChangeListener === storageListener) {
+      StorageHelper.valueChangeListener = null
+    }
+    transport.close()
+    scope.cancel()
+  }
+
+  suspend fun reloadFromSharedStorage(force: Boolean): Boolean =
+    withContext(Dispatchers.IO) { reloadBlocking(force) }
+
+  fun handleClientChange(client: Client, serverFetchAtMillis: Long) {
+    synchronized(stateLock) {
+      if (isApplyingSharedStorage) return
+      val state =
+        if (client == Client()) SharedSessionSyncSnapshot.State.CLEARED
+        else SharedSessionSyncSnapshot.State.SET
+      val authSnapshot =
+        SharedSessionSyncSnapshot.AuthSnapshot(
+          state = state,
+          version = UUID.randomUUID().toString(),
+          serverFetchAtMillis = serverFetchAtMillis,
+          client = client.takeIf { state == SharedSessionSyncSnapshot.State.SET },
+        )
+      persistLocalSnapshot(baseSnapshot().copy(auth = authSnapshot), notifyPeers = true)
+    }
+  }
+
+  fun handleEnvironmentChange(previous: Environment?, environment: Environment) {
+    synchronized(stateLock) {
+      if (isApplyingSharedStorage || previous == environment) return
+      val environmentSnapshot =
+        SharedSessionSyncSnapshot.EnvironmentSnapshot(
+          version = UUID.randomUUID().toString(),
+          changedAtMillis = clock(),
+          value = environment,
+        )
+      persistLocalSnapshot(
+        baseSnapshot().copy(environment = environmentSnapshot),
+        notifyPeers = true,
+      )
+    }
+  }
+
+  @Suppress("UNUSED_PARAMETER")
+  private fun reloadBlocking(force: Boolean): Boolean {
+    val storedLocalSnapshot = transport.loadLocalSnapshot()?.takeIf(::isCompatible)
+    val peerSnapshots = transport.loadPeerSnapshots().filter(::isCompatible)
+
+    synchronized(stateLock) {
+      localSnapshot = storedLocalSnapshot ?: localSnapshot
+      val snapshots = listOfNotNull(localSnapshot) + peerSnapshots
+      if (snapshots.isEmpty()) return false
+
+      var didChange = false
+      selectLatestAuthSnapshot(snapshots)?.let { incoming ->
+        didChange = applyAuthSnapshot(incoming) || didChange
+      }
+      snapshots
+        .mapNotNull { it.environment }
+        .maxByOrNull { it.changedAtMillis }
+        ?.let { incoming -> didChange = applyEnvironmentSnapshot(incoming) || didChange }
+      snapshots
+        .mapNotNull { it.deviceToken }
+        .maxByOrNull { it.changedAtMillis }
+        ?.let { incoming -> didChange = applyDeviceTokenSnapshot(incoming) || didChange }
+      return didChange
+    }
+  }
+
+  private fun applyAuthSnapshot(incoming: SharedSessionSyncSnapshot.AuthSnapshot): Boolean {
+    val current = currentAuthSnapshot()
+    return when (decideSharedClientSnapshot(incoming = incoming, current = current)) {
+      SharedSessionSyncClientDecision.APPLY -> {
+        val changed =
+          current?.state != incoming.state ||
+            current.client != incoming.client ||
+            current.serverFetchAtMillis != incoming.serverFetchAtMillis
+        applyingSharedStorage {
+          Clerk.updateClient(
+            client = incoming.client ?: Client(),
+            serverFetchAtMillis = incoming.serverFetchAtMillis ?: clock(),
+          )
+        }
+        replicateSnapshot(baseSnapshot().copy(auth = incoming))
+        changed
+      }
+      SharedSessionSyncClientDecision.IGNORE -> {
+        if (localSnapshot?.auth?.version != incoming.version) {
+          replicateSnapshot(baseSnapshot().copy(auth = incoming))
+        }
+        false
+      }
+      SharedSessionSyncClientDecision.REJECT_STALE -> {
+        repairSharedAuthSnapshot()
+        false
+      }
+    }
+  }
+
+  private fun applyEnvironmentSnapshot(
+    incoming: SharedSessionSyncSnapshot.EnvironmentSnapshot
+  ): Boolean {
+    val localEnvironment = localSnapshot?.environment
+    if (localEnvironment != null && localEnvironment.changedAtMillis > incoming.changedAtMillis) {
+      return false
+    }
+
+    val changed = Clerk.environment != incoming.value
+    if (changed) {
+      applyingSharedStorage { Clerk.updateEnvironment(incoming.value) }
+    }
+    if (localEnvironment?.version != incoming.version) {
+      replicateSnapshot(baseSnapshot().copy(environment = incoming))
+    }
+    return changed
+  }
+
+  @Suppress("ReturnCount")
+  private fun applyDeviceTokenSnapshot(
+    incoming: SharedSessionSyncSnapshot.DeviceTokenSnapshot
+  ): Boolean {
+    val localDeviceToken = localSnapshot?.deviceToken
+    if (localDeviceToken != null && localDeviceToken.changedAtMillis > incoming.changedAtMillis) {
+      return false
+    }
+    if (localDeviceToken?.version == incoming.version) return false
+
+    val previousToken = StorageHelper.loadValue(StorageKey.DEVICE_TOKEN)
+    applyingSharedStorage {
+      when (incoming.state) {
+        SharedSessionSyncSnapshot.State.SET -> {
+          incoming.value?.let { value -> StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, value) }
+        }
+        SharedSessionSyncSnapshot.State.CLEARED ->
+          StorageHelper.deleteValue(StorageKey.DEVICE_TOKEN)
+      }
+    }
+    Clerk.fenceClientResponsesAfterSharedDeviceTokenChange()
+    replicateSnapshot(baseSnapshot().copy(deviceToken = incoming))
+    return previousToken != incoming.value || localDeviceToken?.version != incoming.version
+  }
+
+  private fun handleDeviceTokenChange(previous: String?, value: String?) {
+    synchronized(stateLock) {
+      if (isApplyingSharedStorage || previous == value) return
+      val deviceTokenSnapshot =
+        SharedSessionSyncSnapshot.DeviceTokenSnapshot(
+          state =
+            if (value == null) SharedSessionSyncSnapshot.State.CLEARED
+            else SharedSessionSyncSnapshot.State.SET,
+          version = UUID.randomUUID().toString(),
+          changedAtMillis = clock(),
+          value = value,
+        )
+      persistLocalSnapshot(
+        baseSnapshot().copy(deviceToken = deviceTokenSnapshot),
+        notifyPeers = true,
+      )
+    }
+  }
+
+  private fun repairSharedAuthSnapshot() {
+    val current = currentAuthSnapshot() ?: return
+    val repaired = current.copy(version = UUID.randomUUID().toString())
+    persistLocalSnapshot(baseSnapshot().copy(auth = repaired), notifyPeers = true)
+  }
+
+  private fun currentAuthSnapshot(): SharedSessionSyncSnapshot.AuthSnapshot? {
+    val currentClient = Clerk.clientFlow.value
+    val serverFetchAtMillis = Clerk.lastClientServerFetchAtMillis
+    if (currentClient == null && serverFetchAtMillis == null) return null
+
+    val state =
+      if (currentClient == null || currentClient == Client()) {
+        SharedSessionSyncSnapshot.State.CLEARED
+      } else {
+        SharedSessionSyncSnapshot.State.SET
+      }
+    return SharedSessionSyncSnapshot.AuthSnapshot(
+      state = state,
+      version = localSnapshot?.auth?.version.orEmpty(),
+      serverFetchAtMillis = serverFetchAtMillis,
+      client = currentClient.takeIf { state == SharedSessionSyncSnapshot.State.SET },
+    )
+  }
+
+  private fun selectLatestAuthSnapshot(
+    snapshots: List<SharedSessionSyncSnapshot>
+  ): SharedSessionSyncSnapshot.AuthSnapshot? {
+    return snapshots
+      .mapNotNull { it.auth }
+      .reduceOrNull { latest, candidate ->
+        when (decideSharedClientSnapshot(incoming = candidate, current = latest)) {
+          SharedSessionSyncClientDecision.APPLY -> candidate
+          SharedSessionSyncClientDecision.IGNORE,
+          SharedSessionSyncClientDecision.REJECT_STALE -> latest
+        }
+      }
+  }
+
+  private fun baseSnapshot(): SharedSessionSyncSnapshot =
+    localSnapshot
+      ?: transport.loadLocalSnapshot()?.takeIf(::isCompatible)
+      ?: SharedSessionSyncSnapshot(instanceId = instanceId)
+
+  private fun persistLocalSnapshot(snapshot: SharedSessionSyncSnapshot, notifyPeers: Boolean) {
+    localSnapshot = snapshot
+    runCatching { transport.saveLocalSnapshot(snapshot, notifyPeers) }
+      .onFailure { error ->
+        ClerkLog.w("Failed to persist shared Clerk session state: ${error.message}")
+      }
+  }
+
+  private fun replicateSnapshot(snapshot: SharedSessionSyncSnapshot) {
+    persistLocalSnapshot(snapshot = snapshot, notifyPeers = false)
+  }
+
+  private fun isCompatible(snapshot: SharedSessionSyncSnapshot): Boolean =
+    snapshot.schemaVersion == SharedSessionSyncSnapshot.CURRENT_SCHEMA_VERSION &&
+      snapshot.instanceId == instanceId
+
+  private inline fun applyingSharedStorage(block: () -> Unit) {
+    val wasApplyingSharedStorage = isApplyingSharedStorage
+    isApplyingSharedStorage = true
+    try {
+      block()
+    } finally {
+      isApplyingSharedStorage = wasApplyingSharedStorage
+    }
+  }
+}

--- a/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncCoordinator.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncCoordinator.kt
@@ -42,7 +42,7 @@ internal constructor(
 
   fun start() {
     StorageHelper.valueChangeListener = storageListener
-    transport.start { scope.launch { reloadFromSharedStorage(force = false) } }
+    transport.start { scope.launch { reloadFromSharedStorage() } }
   }
 
   fun close() {
@@ -53,8 +53,7 @@ internal constructor(
     scope.cancel()
   }
 
-  suspend fun reloadFromSharedStorage(force: Boolean): Boolean =
-    withContext(Dispatchers.IO) { reloadBlocking(force) }
+  suspend fun reloadFromSharedStorage(): Boolean = withContext(Dispatchers.IO) { reloadBlocking() }
 
   fun handleClientChange(client: Client, serverFetchAtMillis: Long) {
     synchronized(stateLock) {
@@ -89,8 +88,7 @@ internal constructor(
     }
   }
 
-  @Suppress("UNUSED_PARAMETER")
-  private fun reloadBlocking(force: Boolean): Boolean {
+  private fun reloadBlocking(): Boolean {
     val storedLocalSnapshot = transport.loadLocalSnapshot()?.takeIf(::isCompatible)
     val peerSnapshots = transport.loadPeerSnapshots().filter(::isCompatible)
 

--- a/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncProvider.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncProvider.kt
@@ -1,0 +1,87 @@
+package com.clerk.api.sharedsession
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.pm.PackageManager
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.os.Binder
+import android.os.CancellationSignal
+import android.os.Process
+import com.clerk.api.storage.StorageHelper
+import com.clerk.api.storage.StorageKey
+
+/** Read-only IPC boundary for same-signed sibling apps participating in shared-session sync. */
+internal class SharedSessionSyncProvider : ContentProvider() {
+  override fun onCreate(): Boolean {
+    val providerContext = context ?: return false
+    StorageHelper.initialize(providerContext)
+    return true
+  }
+
+  override fun query(
+    uri: Uri,
+    projection: Array<out String>?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+    sortOrder: String?,
+  ): Cursor {
+    enforceSameSignature()
+    require(uri.path == SharedSessionSyncContract.SNAPSHOT_PATH) { "Unsupported URI: $uri" }
+    require(selection == null && selectionArgs == null && sortOrder == null) {
+      "Shared-session snapshots do not support query parameters"
+    }
+
+    return MatrixCursor(arrayOf(SharedSessionSyncContract.SNAPSHOT_COLUMN), 1).apply {
+      addRow(arrayOf(StorageHelper.loadValue(StorageKey.SHARED_SESSION_SYNC_SNAPSHOT)))
+    }
+  }
+
+  override fun query(
+    uri: Uri,
+    projection: Array<out String>?,
+    queryArgs: android.os.Bundle?,
+    cancellationSignal: CancellationSignal?,
+  ): Cursor = query(uri, projection, null, null, null)
+
+  override fun getType(uri: Uri): String = SharedSessionSyncContract.MIME_TYPE
+
+  override fun insert(uri: Uri, values: ContentValues?): Uri? = readOnly()
+
+  override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int =
+    readOnly()
+
+  override fun update(
+    uri: Uri,
+    values: ContentValues?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+  ): Int = readOnly()
+
+  private fun enforceSameSignature() {
+    val providerContext = requireNotNull(context)
+    val callingUid = Binder.getCallingUid()
+    if (callingUid == Process.myUid()) return
+
+    val result = providerContext.packageManager.checkSignatures(callingUid, Process.myUid())
+    if (result != PackageManager.SIGNATURE_MATCH) {
+      throw SecurityException("Shared Clerk session state is available only to same-signed apps")
+    }
+  }
+
+  private fun <T> readOnly(): T {
+    throw UnsupportedOperationException("Shared Clerk session state is read-only")
+  }
+}
+
+internal object SharedSessionSyncContract {
+  const val DISCOVERY_ACTION = "com.clerk.api.action.SHARED_SESSION_SYNC"
+  const val AUTHORITY_SUFFIX = ".clerk.shared-session-sync"
+  const val SNAPSHOT_PATH = "/snapshot"
+  const val SNAPSHOT_COLUMN = "snapshot"
+  const val MIME_TYPE = "vnd.android.cursor.item/vnd.com.clerk.shared-session-sync"
+
+  fun snapshotUri(authority: String): Uri =
+    Uri.Builder().scheme("content").authority(authority).path(SNAPSHOT_PATH).build()
+}

--- a/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncProvider.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncProvider.kt
@@ -1,7 +1,9 @@
 package com.clerk.api.sharedsession
 
+import android.content.ComponentName
 import android.content.ContentProvider
 import android.content.ContentValues
+import android.content.Context
 import android.content.pm.PackageManager
 import android.database.Cursor
 import android.database.MatrixCursor
@@ -72,6 +74,20 @@ internal class SharedSessionSyncProvider : ContentProvider() {
 
   private fun <T> readOnly(): T {
     throw UnsupportedOperationException("Shared Clerk session state is read-only")
+  }
+
+  companion object {
+    internal fun setEnabled(context: Context, enabled: Boolean) {
+      context.applicationContext.packageManager.setComponentEnabledSetting(
+        ComponentName(context.applicationContext, SharedSessionSyncProvider::class.java),
+        if (enabled) {
+          PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+        } else {
+          PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        },
+        PackageManager.DONT_KILL_APP,
+      )
+    }
   }
 }
 

--- a/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncSnapshot.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncSnapshot.kt
@@ -1,0 +1,153 @@
+package com.clerk.api.sharedsession
+
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.client.Client
+import com.clerk.api.network.model.environment.Environment
+import java.security.MessageDigest
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class SharedSessionSyncSnapshot(
+  val schemaVersion: Int = CURRENT_SCHEMA_VERSION,
+  val instanceId: String,
+  val auth: AuthSnapshot? = null,
+  val environment: EnvironmentSnapshot? = null,
+  val deviceToken: DeviceTokenSnapshot? = null,
+) {
+  @Serializable
+  data class AuthSnapshot(
+    val state: State,
+    val version: String,
+    val serverFetchAtMillis: Long? = null,
+    val client: Client? = null,
+  )
+
+  @Serializable
+  data class EnvironmentSnapshot(
+    val version: String,
+    val changedAtMillis: Long,
+    val value: Environment,
+  )
+
+  @Serializable
+  data class DeviceTokenSnapshot(
+    val state: State,
+    val version: String,
+    val changedAtMillis: Long,
+    val value: String? = null,
+  )
+
+  @Serializable
+  enum class State {
+    @SerialName("set") SET,
+    @SerialName("cleared") CLEARED,
+  }
+
+  companion object {
+    const val CURRENT_SCHEMA_VERSION = 1
+
+    fun instanceId(publishableKey: String): String {
+      val digest =
+        MessageDigest.getInstance("SHA-256").digest(publishableKey.toByteArray(Charsets.UTF_8))
+      return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
+    }
+
+    fun encode(snapshot: SharedSessionSyncSnapshot): String =
+      ClerkApi.json.encodeToString(serializer(), snapshot)
+
+    fun decode(value: String): SharedSessionSyncSnapshot =
+      ClerkApi.json.decodeFromString(serializer(), value)
+  }
+}
+
+internal enum class SharedSessionSyncClientDecision {
+  APPLY,
+  IGNORE,
+  REJECT_STALE,
+}
+
+@Suppress("CyclomaticComplexMethod", "ReturnCount")
+internal fun decideSharedClientSnapshot(
+  incoming: SharedSessionSyncSnapshot.AuthSnapshot,
+  current: SharedSessionSyncSnapshot.AuthSnapshot?,
+): SharedSessionSyncClientDecision {
+  if (current == null) {
+    return SharedSessionSyncClientDecision.APPLY
+  }
+
+  if (incoming.state == SharedSessionSyncSnapshot.State.CLEARED) {
+    return decideSharedClientClear(incoming = incoming, current = current)
+  }
+
+  val incomingClient = incoming.client ?: return SharedSessionSyncClientDecision.IGNORE
+  val currentClient = current.client
+  val incomingFetchAt = incoming.serverFetchAtMillis
+  val currentFetchAt = current.serverFetchAtMillis
+
+  if (incomingFetchAt != null && currentFetchAt != null) {
+    if (incomingFetchAt > currentFetchAt) return SharedSessionSyncClientDecision.APPLY
+    if (incomingFetchAt < currentFetchAt) return SharedSessionSyncClientDecision.REJECT_STALE
+    if (current.state == SharedSessionSyncSnapshot.State.CLEARED || currentClient == null) {
+      return SharedSessionSyncClientDecision.REJECT_STALE
+    }
+    return decideEqualDateClients(incomingClient = incomingClient, currentClient = currentClient)
+  }
+
+  if (current.state == SharedSessionSyncSnapshot.State.CLEARED || currentClient == null) {
+    return if (currentFetchAt == null || incomingFetchAt != null) {
+      SharedSessionSyncClientDecision.APPLY
+    } else {
+      SharedSessionSyncClientDecision.REJECT_STALE
+    }
+  }
+
+  if (incomingFetchAt != null) return SharedSessionSyncClientDecision.APPLY
+  if (currentFetchAt != null) return SharedSessionSyncClientDecision.REJECT_STALE
+
+  return decideEqualDateClients(incomingClient = incomingClient, currentClient = currentClient)
+}
+
+private fun decideSharedClientClear(
+  incoming: SharedSessionSyncSnapshot.AuthSnapshot,
+  current: SharedSessionSyncSnapshot.AuthSnapshot,
+): SharedSessionSyncClientDecision {
+  val incomingFetchAt = incoming.serverFetchAtMillis
+  val currentFetchAt = current.serverFetchAtMillis
+
+  if (incomingFetchAt == null || currentFetchAt == null) {
+    return if (
+      current.state != SharedSessionSyncSnapshot.State.CLEARED || currentFetchAt != incomingFetchAt
+    ) {
+      SharedSessionSyncClientDecision.APPLY
+    } else {
+      SharedSessionSyncClientDecision.IGNORE
+    }
+  }
+
+  return when {
+    incomingFetchAt > currentFetchAt -> SharedSessionSyncClientDecision.APPLY
+    incomingFetchAt < currentFetchAt -> SharedSessionSyncClientDecision.REJECT_STALE
+    current.state != SharedSessionSyncSnapshot.State.CLEARED ->
+      SharedSessionSyncClientDecision.APPLY
+    else -> SharedSessionSyncClientDecision.IGNORE
+  }
+}
+
+private fun decideEqualDateClients(
+  incomingClient: Client,
+  currentClient: Client,
+): SharedSessionSyncClientDecision {
+  val incomingUpdatedAt = incomingClient.updatedAt
+  val currentUpdatedAt = currentClient.updatedAt
+  if (
+    incomingUpdatedAt != null && currentUpdatedAt != null && incomingUpdatedAt > currentUpdatedAt
+  ) {
+    return SharedSessionSyncClientDecision.APPLY
+  }
+  return if (incomingClient == currentClient) {
+    SharedSessionSyncClientDecision.IGNORE
+  } else {
+    SharedSessionSyncClientDecision.REJECT_STALE
+  }
+}

--- a/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncTransport.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncTransport.kt
@@ -1,0 +1,127 @@
+package com.clerk.api.sharedsession
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.database.ContentObserver
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import com.clerk.api.log.ClerkLog
+import com.clerk.api.storage.StorageHelper
+import com.clerk.api.storage.StorageKey
+
+internal interface SharedSessionSyncTransport {
+  fun loadLocalSnapshot(): SharedSessionSyncSnapshot?
+
+  fun loadPeerSnapshots(): List<SharedSessionSyncSnapshot>
+
+  fun saveLocalSnapshot(snapshot: SharedSessionSyncSnapshot, notifyPeers: Boolean)
+
+  fun start(onPeerChange: () -> Unit)
+
+  fun close()
+}
+
+internal class ContentProviderSharedSessionSyncTransport(context: Context) :
+  SharedSessionSyncTransport {
+  private val context = context.applicationContext
+  private val resolver = this.context.contentResolver
+  private val packageManager = this.context.packageManager
+  private val localUri =
+    SharedSessionSyncContract.snapshotUri(
+      this.context.packageName + SharedSessionSyncContract.AUTHORITY_SUFFIX
+    )
+  private val observers = mutableMapOf<Uri, ContentObserver>()
+  private var peerChangeHandler: (() -> Unit)? = null
+
+  override fun loadLocalSnapshot(): SharedSessionSyncSnapshot? =
+    StorageHelper.loadValue(StorageKey.SHARED_SESSION_SYNC_SNAPSHOT)?.decodeSnapshot()
+
+  override fun loadPeerSnapshots(): List<SharedSessionSyncSnapshot> {
+    val peerUris = discoverPeerUris()
+    registerObservers(peerUris)
+    return peerUris.mapNotNull(::querySnapshot)
+  }
+
+  override fun saveLocalSnapshot(snapshot: SharedSessionSyncSnapshot, notifyPeers: Boolean) {
+    StorageHelper.saveValue(
+      StorageKey.SHARED_SESSION_SYNC_SNAPSHOT,
+      SharedSessionSyncSnapshot.encode(snapshot),
+    )
+    if (notifyPeers) {
+      resolver.notifyChange(localUri, null)
+    }
+  }
+
+  override fun start(onPeerChange: () -> Unit) {
+    peerChangeHandler = onPeerChange
+    registerObservers(discoverPeerUris())
+  }
+
+  override fun close() {
+    observers.values.forEach { observer -> resolver.unregisterContentObserver(observer) }
+    observers.clear()
+    peerChangeHandler = null
+  }
+
+  private fun discoverPeerUris(): List<Uri> {
+    val intent = Intent(SharedSessionSyncContract.DISCOVERY_ACTION)
+    return packageManager
+      .queryIntentContentProviders(intent, 0)
+      .asSequence()
+      .mapNotNull { resolveInfo -> resolveInfo.providerInfo }
+      .filter { providerInfo -> providerInfo.packageName != context.packageName }
+      .filter { providerInfo ->
+        packageManager.checkSignatures(context.packageName, providerInfo.packageName) ==
+          PackageManager.SIGNATURE_MATCH
+      }
+      .flatMap { providerInfo -> providerInfo.authority.orEmpty().split(';').asSequence() }
+      .filter { authority -> authority.isNotBlank() }
+      .map(SharedSessionSyncContract::snapshotUri)
+      .distinct()
+      .toList()
+  }
+
+  private fun registerObservers(peerUris: List<Uri>) {
+    val handler = Handler(Looper.getMainLooper())
+    peerUris.filterNot(observers::containsKey).forEach { uri ->
+      val observer =
+        object : ContentObserver(handler) {
+          override fun onChange(selfChange: Boolean) {
+            onChange(selfChange, null)
+          }
+
+          override fun onChange(selfChange: Boolean, changedUri: Uri?) {
+            peerChangeHandler?.invoke()
+          }
+        }
+      runCatching { resolver.registerContentObserver(uri, false, observer) }
+        .onSuccess { observers[uri] = observer }
+        .onFailure { error ->
+          ClerkLog.w("Failed to observe shared Clerk state at $uri: ${error.message}")
+        }
+    }
+  }
+
+  private fun querySnapshot(uri: Uri): SharedSessionSyncSnapshot? =
+    runCatching {
+        resolver
+          .query(uri, arrayOf(SharedSessionSyncContract.SNAPSHOT_COLUMN), null, null, null)
+          ?.use { cursor ->
+            if (!cursor.moveToFirst()) return@use null
+            val columnIndex = cursor.getColumnIndex(SharedSessionSyncContract.SNAPSHOT_COLUMN)
+            if (columnIndex < 0 || cursor.isNull(columnIndex)) return@use null
+            cursor.getString(columnIndex).decodeSnapshot()
+          }
+      }
+      .onFailure { error ->
+        ClerkLog.w("Failed to read shared Clerk state from $uri: ${error.message}")
+      }
+      .getOrNull()
+
+  private fun String.decodeSnapshot(): SharedSessionSyncSnapshot? =
+    runCatching { SharedSessionSyncSnapshot.decode(this) }
+      .onFailure { error -> ClerkLog.w("Failed to decode shared Clerk state: ${error.message}") }
+      .getOrNull()
+}

--- a/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncTransport.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sharedsession/SharedSessionSyncTransport.kt
@@ -55,6 +55,7 @@ internal class ContentProviderSharedSessionSyncTransport(context: Context) :
   }
 
   override fun start(onPeerChange: () -> Unit) {
+    SharedSessionSyncProvider.setEnabled(context, true)
     peerChangeHandler = onPeerChange
     registerObservers(discoverPeerUris())
   }
@@ -63,6 +64,7 @@ internal class ContentProviderSharedSessionSyncTransport(context: Context) :
     observers.values.forEach { observer -> resolver.unregisterContentObserver(observer) }
     observers.clear()
     peerChangeHandler = null
+    SharedSessionSyncProvider.setEnabled(context, false)
   }
 
   private fun discoverPeerUris(): List<Uri> {

--- a/source/api/src/main/kotlin/com/clerk/api/storage/StorageHelper.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/storage/StorageHelper.kt
@@ -19,6 +19,12 @@ internal object StorageHelper {
 
   @VisibleForTesting internal var storageCipherFactoryOverride: (() -> StorageCipher)? = null
 
+  /** Receives encrypted-storage changes that affect coordinated SDK state. */
+  @Volatile
+  internal var valueChangeListener:
+    ((key: StorageKey, previous: String?, value: String?) -> Unit)? =
+    null
+
   /**
    * Synchronously initializes the secure storage. We do this synchronously because we need to
    * ensure that the storage is initialized before we generate a device ID.
@@ -46,6 +52,7 @@ internal object StorageHelper {
   internal fun saveValue(key: StorageKey, value: String) {
     val prefs = secureStorage
     val cipher = storageCipher
+    val previousValue = if (key == StorageKey.DEVICE_TOKEN) loadValue(key) else null
 
     when {
       prefs == null -> {
@@ -61,6 +68,9 @@ internal object StorageHelper {
         runCatching { ENCRYPTED_VALUE_PREFIX + cipher.encrypt(value) }
           .onSuccess { encryptedValue ->
             prefs.edit(commit = true) { putString(key.name, encryptedValue) }
+            if (key == StorageKey.DEVICE_TOKEN && previousValue != value) {
+              valueChangeListener?.invoke(key, previousValue, value)
+            }
           }
           .onFailure { error ->
             ClerkLog.w("Failed to encrypt value for key ${key.name}: ${error.message}")
@@ -111,7 +121,11 @@ internal object StorageHelper {
       )
       return
     }
+    val previousValue = if (key == StorageKey.DEVICE_TOKEN) loadValue(key) else null
     prefs.edit(commit = true) { remove(key.name) }
+    if (key == StorageKey.DEVICE_TOKEN && previousValue != null) {
+      valueChangeListener?.invoke(key, previousValue, null)
+    }
   }
 
   /**
@@ -121,6 +135,7 @@ internal object StorageHelper {
    */
   @VisibleForTesting
   internal fun reset(context: Context? = null) {
+    valueChangeListener = null
     val prefs = secureStorage
     if (prefs != null) {
       prefs.edit().clear().commit()
@@ -155,4 +170,5 @@ internal enum class StorageKey {
   DEVICE_TOKEN,
   DEVICE_ID,
   PENDING_NATIVE_MAGIC_LINK_FLOW,
+  SHARED_SESSION_SYNC_SNAPSHOT,
 }

--- a/source/api/src/test/java/com/clerk/api/network/middleware/incoming/ClientSyncingMiddlewareTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/middleware/incoming/ClientSyncingMiddlewareTest.kt
@@ -180,6 +180,40 @@ class ClientSyncingMiddlewareTest {
     assertEquals(listOf(session), Clerk.sessionsFlow.value)
   }
 
+  @Test
+  fun `intercept hydrates direct client response with server date`() {
+    val middleware = ClientSyncingMiddleware(json = ClerkApi.json)
+    val request = Request.Builder().url("https://api.clerk.com/v1/client").build()
+    val response =
+      Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .header("Date", "Mon, 13 Jul 2026 18:00:00 GMT")
+        .body(
+          """
+          {
+            "object": "client",
+            "id": "client_server",
+            "sessions": []
+          }
+          """
+            .trimIndent()
+            .toResponseBody("application/json".toMediaType())
+        )
+        .build()
+    val chain = mockk<Interceptor.Chain>()
+    every { chain.request() } returns request
+    every { chain.proceed(request) } returns response
+
+    middleware.intercept(chain)
+    Clerk.updateClient(Clerk.client)
+
+    assertEquals("client_server", Clerk.client.id)
+    assertEquals(1_783_965_600_000L, Clerk.lastClientServerFetchAtMillis)
+  }
+
   private fun testSession(id: String): Session =
     Session(
       id = id,

--- a/source/api/src/test/java/com/clerk/api/network/middleware/incoming/DeviceTokenSavingMiddlewareTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/middleware/incoming/DeviceTokenSavingMiddlewareTest.kt
@@ -1,0 +1,69 @@
+package com.clerk.api.network.middleware.incoming
+
+import android.content.Context
+import com.clerk.api.Constants.Http.AUTHORIZATION_HEADER
+import com.clerk.api.storage.StorageHelper
+import com.clerk.api.storage.StorageKey
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class DeviceTokenSavingMiddlewareTest {
+  private lateinit var context: Context
+
+  @Before
+  fun setUp() {
+    context = RuntimeEnvironment.getApplication()
+    StorageHelper.reset(context)
+  }
+
+  @After
+  fun tearDown() {
+    StorageHelper.reset(context)
+  }
+
+  @Test
+  fun `response token replaces token used by request`() {
+    StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "request-token")
+
+    DeviceTokenSavingMiddleware()
+      .intercept(chain(requestToken = "request-token", responseToken = "response-token"))
+
+    assertEquals("response-token", StorageHelper.loadValue(StorageKey.DEVICE_TOKEN))
+  }
+
+  @Test
+  fun `response started with stale token cannot overwrite shared token`() {
+    StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "shared-token")
+
+    DeviceTokenSavingMiddleware()
+      .intercept(chain(requestToken = "stale-token", responseToken = "rotated-stale-token"))
+
+    assertEquals("shared-token", StorageHelper.loadValue(StorageKey.DEVICE_TOKEN))
+  }
+
+  private fun chain(requestToken: String?, responseToken: String?): Interceptor.Chain {
+    val requestBuilder = Request.Builder().url("https://example.com")
+    requestToken?.let { requestBuilder.header(AUTHORIZATION_HEADER, it) }
+    val request = requestBuilder.build()
+    val responseBuilder =
+      Response.Builder().request(request).protocol(Protocol.HTTP_1_1).code(200).message("OK")
+    responseToken?.let { responseBuilder.header(AUTHORIZATION_HEADER, it) }
+    val response = responseBuilder.build()
+    return mockk {
+      every { request() } returns request
+      every { proceed(request) } returns response
+    }
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/sdk/SharedSessionSyncConfigTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/SharedSessionSyncConfigTest.kt
@@ -1,0 +1,19 @@
+package com.clerk.api.sdk
+
+import com.clerk.api.ClerkConfigurationOptions
+import com.clerk.api.SharedSessionSyncConfig
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class SharedSessionSyncConfigTest {
+  @Test
+  fun `shared session sync is opt in`() {
+    assertNull(ClerkConfigurationOptions().sharedSessionSync)
+    assertSame(
+      SharedSessionSyncConfig.enabled,
+      ClerkConfigurationOptions(sharedSessionSync = SharedSessionSyncConfig.enabled)
+        .sharedSessionSync,
+    )
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncCoordinatorTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncCoordinatorTest.kt
@@ -47,7 +47,7 @@ class SharedSessionSyncCoordinatorTest {
       val coordinator = coordinator(transport)
       coordinator.start()
 
-      val changed = coordinator.reloadFromSharedStorage(force = true)
+      val changed = coordinator.reloadFromSharedStorage()
 
       assertTrue(changed)
       assertEquals("shared", Clerk.client.id)
@@ -65,7 +65,7 @@ class SharedSessionSyncCoordinatorTest {
     val coordinator = coordinator(transport)
     coordinator.start()
 
-    val changed = coordinator.reloadFromSharedStorage(force = true)
+    val changed = coordinator.reloadFromSharedStorage()
 
     assertTrue(changed)
     assertEquals(Client(), Clerk.client)
@@ -86,7 +86,7 @@ class SharedSessionSyncCoordinatorTest {
     val coordinator = coordinator(transport)
     coordinator.start()
 
-    val changed = coordinator.reloadFromSharedStorage(force = false)
+    val changed = coordinator.reloadFromSharedStorage()
 
     assertFalse(changed)
     assertEquals("local", Clerk.client.id)
@@ -134,7 +134,7 @@ class SharedSessionSyncCoordinatorTest {
     val coordinator = coordinator(transport)
     coordinator.start()
 
-    val changed = coordinator.reloadFromSharedStorage(force = false)
+    val changed = coordinator.reloadFromSharedStorage()
 
     assertTrue(changed)
     assertEquals("shared-token", StorageHelper.loadValue(StorageKey.DEVICE_TOKEN))

--- a/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncCoordinatorTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncCoordinatorTest.kt
@@ -1,0 +1,219 @@
+package com.clerk.api.sharedsession
+
+import android.content.Context
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.client.Client
+import com.clerk.api.storage.StorageHelper
+import com.clerk.api.storage.StorageKey
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class SharedSessionSyncCoordinatorTest {
+  private lateinit var context: Context
+
+  @Before
+  fun setUp() {
+    context = RuntimeEnvironment.getApplication()
+    Clerk.reset()
+    StorageHelper.reset(context)
+  }
+
+  @After
+  fun tearDown() {
+    Clerk.reset()
+    StorageHelper.reset(context)
+  }
+
+  @Test
+  fun `public reload behavior applies newer sibling client without echoing notification`() =
+    runTest {
+      val local = Client(id = "local", updatedAt = 1_000)
+      val shared = Client(id = "shared", updatedAt = 2_000)
+      Clerk.updateClient(local, serverFetchAtMillis = 100)
+      val transport =
+        FakeTransport(
+          peers = listOf(snapshot(auth = auth(shared, fetchAt = 200, version = "shared")))
+        )
+      val coordinator = coordinator(transport)
+      coordinator.start()
+
+      val changed = coordinator.reloadFromSharedStorage(force = true)
+
+      assertTrue(changed)
+      assertEquals("shared", Clerk.client.id)
+      assertEquals(200L, Clerk.lastClientServerFetchAtMillis)
+      assertEquals("shared", transport.local?.auth?.version)
+      assertEquals(0, transport.notificationCount)
+      coordinator.close()
+    }
+
+  @Test
+  fun `newer sibling clear removes local auth state`() = runTest {
+    Clerk.updateClient(Client(id = "local", updatedAt = 1_000), serverFetchAtMillis = 100)
+    val transport =
+      FakeTransport(peers = listOf(snapshot(auth = cleared(fetchAt = 200, version = "clear"))))
+    val coordinator = coordinator(transport)
+    coordinator.start()
+
+    val changed = coordinator.reloadFromSharedStorage(force = true)
+
+    assertTrue(changed)
+    assertEquals(Client(), Clerk.client)
+    assertNull(transport.local?.auth?.client)
+    assertEquals(SharedSessionSyncSnapshot.State.CLEARED, transport.local?.auth?.state)
+    coordinator.close()
+  }
+
+  @Test
+  fun `stale sibling snapshot is rejected and repaired from local state`() = runTest {
+    val local = Client(id = "local", updatedAt = 2_000)
+    Clerk.updateClient(local, serverFetchAtMillis = 200)
+    val transport =
+      FakeTransport(
+        peers =
+          listOf(snapshot(auth = auth(Client(id = "shared", updatedAt = 3_000), 100, "stale")))
+      )
+    val coordinator = coordinator(transport)
+    coordinator.start()
+
+    val changed = coordinator.reloadFromSharedStorage(force = false)
+
+    assertFalse(changed)
+    assertEquals("local", Clerk.client.id)
+    assertEquals("local", transport.local?.auth?.client?.id)
+    assertTrue(transport.local?.auth?.version != "stale")
+    assertEquals(1, transport.notificationCount)
+    coordinator.close()
+  }
+
+  @Test
+  fun `local client change publishes opaque revision`() {
+    val transport = FakeTransport()
+    val coordinator = coordinator(transport)
+    coordinator.start()
+
+    coordinator.handleClientChange(
+      client = Client(id = "local", updatedAt = 2_000),
+      serverFetchAtMillis = 200,
+    )
+
+    assertEquals("local", transport.local?.auth?.client?.id)
+    assertTrue(runCatching { java.util.UUID.fromString(transport.local?.auth?.version) }.isSuccess)
+    assertEquals(1, transport.notificationCount)
+    coordinator.close()
+  }
+
+  @Test
+  fun `sibling device token is copied into encrypted local storage`() = runTest {
+    StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "local-token")
+    val transport =
+      FakeTransport(
+        peers =
+          listOf(
+            snapshot(
+              deviceToken =
+                SharedSessionSyncSnapshot.DeviceTokenSnapshot(
+                  state = SharedSessionSyncSnapshot.State.SET,
+                  version = "shared-device",
+                  changedAtMillis = 200,
+                  value = "shared-token",
+                )
+            )
+          )
+      )
+    val coordinator = coordinator(transport)
+    coordinator.start()
+
+    val changed = coordinator.reloadFromSharedStorage(force = false)
+
+    assertTrue(changed)
+    assertEquals("shared-token", StorageHelper.loadValue(StorageKey.DEVICE_TOKEN))
+    assertEquals("shared-device", transport.local?.deviceToken?.version)
+    assertEquals(0, transport.notificationCount)
+    coordinator.close()
+  }
+
+  @Test
+  fun `local device token changes publish set and cleared revisions`() {
+    val transport = FakeTransport()
+    val coordinator = coordinator(transport)
+    coordinator.start()
+
+    StorageHelper.saveValue(StorageKey.DEVICE_TOKEN, "local-token")
+
+    val setVersion = transport.local?.deviceToken?.version
+    assertEquals(SharedSessionSyncSnapshot.State.SET, transport.local?.deviceToken?.state)
+    assertEquals("local-token", transport.local?.deviceToken?.value)
+    assertEquals(1, transport.notificationCount)
+
+    StorageHelper.deleteValue(StorageKey.DEVICE_TOKEN)
+
+    assertEquals(SharedSessionSyncSnapshot.State.CLEARED, transport.local?.deviceToken?.state)
+    assertNull(transport.local?.deviceToken?.value)
+    assertTrue(setVersion != transport.local?.deviceToken?.version)
+    assertEquals(2, transport.notificationCount)
+    coordinator.close()
+  }
+
+  private fun coordinator(transport: FakeTransport): SharedSessionSyncCoordinator =
+    SharedSessionSyncCoordinator(instanceId = INSTANCE_ID, transport = transport, clock = { 500 })
+
+  private fun snapshot(
+    auth: SharedSessionSyncSnapshot.AuthSnapshot? = null,
+    deviceToken: SharedSessionSyncSnapshot.DeviceTokenSnapshot? = null,
+  ) = SharedSessionSyncSnapshot(instanceId = INSTANCE_ID, auth = auth, deviceToken = deviceToken)
+
+  private fun auth(client: Client, fetchAt: Long, version: String) =
+    SharedSessionSyncSnapshot.AuthSnapshot(
+      state = SharedSessionSyncSnapshot.State.SET,
+      version = version,
+      serverFetchAtMillis = fetchAt,
+      client = client,
+    )
+
+  private fun cleared(fetchAt: Long, version: String) =
+    SharedSessionSyncSnapshot.AuthSnapshot(
+      state = SharedSessionSyncSnapshot.State.CLEARED,
+      version = version,
+      serverFetchAtMillis = fetchAt,
+    )
+
+  private class FakeTransport(
+    var local: SharedSessionSyncSnapshot? = null,
+    var peers: List<SharedSessionSyncSnapshot> = emptyList(),
+  ) : SharedSessionSyncTransport {
+    var notificationCount = 0
+    private var handler: (() -> Unit)? = null
+
+    override fun loadLocalSnapshot(): SharedSessionSyncSnapshot? = local
+
+    override fun loadPeerSnapshots(): List<SharedSessionSyncSnapshot> = peers
+
+    override fun saveLocalSnapshot(snapshot: SharedSessionSyncSnapshot, notifyPeers: Boolean) {
+      local = snapshot
+      if (notifyPeers) notificationCount += 1
+    }
+
+    override fun start(onPeerChange: () -> Unit) {
+      handler = onPeerChange
+    }
+
+    override fun close() {
+      handler = null
+    }
+  }
+
+  private companion object {
+    const val INSTANCE_ID = "instance"
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncProviderTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncProviderTest.kt
@@ -1,0 +1,63 @@
+package com.clerk.api.sharedsession
+
+import android.content.Context
+import android.content.Intent
+import com.clerk.api.storage.StorageHelper
+import com.clerk.api.storage.StorageKey
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class SharedSessionSyncProviderTest {
+  private lateinit var context: Context
+
+  @Before
+  fun setUp() {
+    context = RuntimeEnvironment.getApplication()
+    StorageHelper.reset(context)
+  }
+
+  @After
+  fun tearDown() {
+    StorageHelper.reset(context)
+  }
+
+  @Test
+  fun `merged manifest exposes discoverable read-only snapshot provider`() {
+    val providers =
+      context.packageManager.queryIntentContentProviders(
+        Intent(SharedSessionSyncContract.DISCOVERY_ACTION),
+        0,
+      )
+    val expectedAuthority = context.packageName + SharedSessionSyncContract.AUTHORITY_SUFFIX
+    val provider = providers.firstOrNull { it.providerInfo.authority == expectedAuthority }
+
+    assertNotNull(provider)
+    assertTrue(provider!!.providerInfo.exported)
+
+    StorageHelper.saveValue(StorageKey.SHARED_SESSION_SYNC_SNAPSHOT, "snapshot-json")
+    val cursor =
+      context.contentResolver.query(
+        SharedSessionSyncContract.snapshotUri(expectedAuthority),
+        arrayOf(SharedSessionSyncContract.SNAPSHOT_COLUMN),
+        null,
+        null,
+        null,
+      )
+
+    cursor.use {
+      assertTrue(it!!.moveToFirst())
+      assertEquals(
+        "snapshot-json",
+        it.getString(it.getColumnIndexOrThrow(SharedSessionSyncContract.SNAPSHOT_COLUMN)),
+      )
+    }
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncProviderTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncProviderTest.kt
@@ -6,6 +6,7 @@ import com.clerk.api.storage.StorageHelper
 import com.clerk.api.storage.StorageKey
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -26,17 +27,29 @@ class SharedSessionSyncProviderTest {
 
   @After
   fun tearDown() {
+    SharedSessionSyncProvider.setEnabled(context, false)
     StorageHelper.reset(context)
   }
 
   @Test
-  fun `merged manifest exposes discoverable read-only snapshot provider`() {
-    val providers =
-      context.packageManager.queryIntentContentProviders(
-        Intent(SharedSessionSyncContract.DISCOVERY_ACTION),
-        0,
-      )
-    val expectedAuthority = context.packageName + SharedSessionSyncContract.AUTHORITY_SUFFIX
+  fun `provider is discoverable only while shared session sync is enabled`() {
+    assertFalse(discoveredProviders().any { it.providerInfo.authority == expectedAuthority() })
+
+    SharedSessionSyncProvider.setEnabled(context, true)
+
+    val providers = discoveredProviders()
+    val expectedAuthority = expectedAuthority()
+    val provider = providers.firstOrNull { it.providerInfo.authority == expectedAuthority }
+
+    assertNotNull(provider)
+    assertTrue(provider!!.providerInfo.exported)
+  }
+
+  @Test
+  fun `enabled provider exposes read-only snapshot`() {
+    SharedSessionSyncProvider.setEnabled(context, true)
+    val providers = discoveredProviders()
+    val expectedAuthority = expectedAuthority()
     val provider = providers.firstOrNull { it.providerInfo.authority == expectedAuthority }
 
     assertNotNull(provider)
@@ -60,4 +73,13 @@ class SharedSessionSyncProviderTest {
       )
     }
   }
+
+  private fun discoveredProviders() =
+    context.packageManager.queryIntentContentProviders(
+      Intent(SharedSessionSyncContract.DISCOVERY_ACTION),
+      0,
+    )
+
+  private fun expectedAuthority(): String =
+    context.packageName + SharedSessionSyncContract.AUTHORITY_SUFFIX
 }

--- a/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncPublicApiTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncPublicApiTest.kt
@@ -9,6 +9,7 @@ import com.clerk.api.storage.StorageKey
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -63,6 +64,16 @@ class SharedSessionSyncPublicApiTest {
     assertTrue(changed)
     assertEquals(sharedClient, Clerk.client)
     assertEquals(200L, Clerk.lastClientServerFetchAtMillis)
+  }
+
+  @Test
+  fun `enabled config exposes a companion getter to published aar consumers`() {
+    val getter = SharedSessionSyncConfig.Companion::class.java.getMethod("getEnabled")
+
+    assertSame(
+      SharedSessionSyncConfig.enabled,
+      getter.invoke(SharedSessionSyncConfig.Companion),
+    )
   }
 
   private companion object {

--- a/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncPublicApiTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncPublicApiTest.kt
@@ -1,0 +1,71 @@
+package com.clerk.api.sharedsession
+
+import android.content.Context
+import com.clerk.api.Clerk
+import com.clerk.api.SharedSessionSyncConfig
+import com.clerk.api.network.model.client.Client
+import com.clerk.api.storage.StorageHelper
+import com.clerk.api.storage.StorageKey
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class SharedSessionSyncPublicApiTest {
+  private lateinit var context: Context
+
+  @Before
+  fun setUp() {
+    context = RuntimeEnvironment.getApplication()
+    Clerk.reset()
+    StorageHelper.reset(context)
+  }
+
+  @After
+  fun tearDown() {
+    Clerk.reset()
+    StorageHelper.reset(context)
+  }
+
+  @Test
+  fun `reloadFromSharedStorage applies persisted matching snapshot`() = runTest {
+    Clerk.updateClient(Client(id = "local", updatedAt = 1_000), serverFetchAtMillis = 100)
+    val sharedClient = Client(id = "shared", updatedAt = 2_000)
+    val snapshot =
+      SharedSessionSyncSnapshot(
+        instanceId = SharedSessionSyncSnapshot.instanceId(PUBLISHABLE_KEY),
+        auth =
+          SharedSessionSyncSnapshot.AuthSnapshot(
+            state = SharedSessionSyncSnapshot.State.SET,
+            version = "shared-version",
+            serverFetchAtMillis = 200,
+            client = sharedClient,
+          ),
+      )
+    StorageHelper.saveValue(
+      StorageKey.SHARED_SESSION_SYNC_SNAPSHOT,
+      SharedSessionSyncSnapshot.encode(snapshot),
+    )
+    Clerk.configureSharedSessionSync(
+      context = context,
+      publishableKey = PUBLISHABLE_KEY,
+      config = SharedSessionSyncConfig.enabled,
+    )
+
+    val changed = Clerk.reloadFromSharedStorage()
+
+    assertTrue(changed)
+    assertEquals(sharedClient, Clerk.client)
+    assertEquals(200L, Clerk.lastClientServerFetchAtMillis)
+  }
+
+  private companion object {
+    const val PUBLISHABLE_KEY = "pk_test_shared_session_sync"
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncSnapshotTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sharedsession/SharedSessionSyncSnapshotTest.kt
@@ -1,0 +1,109 @@
+package com.clerk.api.sharedsession
+
+import com.clerk.api.network.model.client.Client
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SharedSessionSyncSnapshotTest {
+  @Test
+  fun `newer server fetch applies`() {
+    val current = auth(client = Client(id = "local", updatedAt = 3_000), fetchAt = 100)
+    val incoming = auth(client = Client(id = "shared", updatedAt = 2_000), fetchAt = 200)
+
+    assertEquals(
+      SharedSessionSyncClientDecision.APPLY,
+      decideSharedClientSnapshot(incoming, current),
+    )
+  }
+
+  @Test
+  fun `older server fetch is rejected even with newer client updated at`() {
+    val current = auth(client = Client(id = "local", updatedAt = 2_000), fetchAt = 200)
+    val incoming = auth(client = Client(id = "shared", updatedAt = 3_000), fetchAt = 100)
+
+    assertEquals(
+      SharedSessionSyncClientDecision.REJECT_STALE,
+      decideSharedClientSnapshot(incoming, current),
+    )
+  }
+
+  @Test
+  fun `equal fetch uses client updated at as tie breaker`() {
+    val current = auth(client = Client(id = "local", updatedAt = 2_000), fetchAt = 200)
+    val incoming = auth(client = Client(id = "shared", updatedAt = 3_000), fetchAt = 200)
+
+    assertEquals(
+      SharedSessionSyncClientDecision.APPLY,
+      decideSharedClientSnapshot(incoming, current),
+    )
+  }
+
+  @Test
+  fun `equal fetch does not resurrect client over clear`() {
+    val current = cleared(fetchAt = 200)
+    val incoming = auth(client = Client(id = "shared", updatedAt = 3_000), fetchAt = 200)
+
+    assertEquals(
+      SharedSessionSyncClientDecision.REJECT_STALE,
+      decideSharedClientSnapshot(incoming, current),
+    )
+  }
+
+  @Test
+  fun `newer clear applies`() {
+    val current = auth(client = Client(id = "local", updatedAt = 2_000), fetchAt = 100)
+
+    assertEquals(
+      SharedSessionSyncClientDecision.APPLY,
+      decideSharedClientSnapshot(cleared(fetchAt = 200), current),
+    )
+  }
+
+  @Test
+  fun `matching snapshot is ignored`() {
+    val client = Client(id = "client", updatedAt = 2_000)
+    val current = auth(client = client, fetchAt = 200)
+    val incoming = current.copy(version = "incoming")
+
+    assertEquals(
+      SharedSessionSyncClientDecision.IGNORE,
+      decideSharedClientSnapshot(incoming, current),
+    )
+  }
+
+  @Test
+  fun `snapshot codec round trips typed state`() {
+    val snapshot =
+      SharedSessionSyncSnapshot(
+        instanceId = "instance",
+        auth = auth(client = Client(id = "client", updatedAt = 2_000), fetchAt = 200),
+        deviceToken =
+          SharedSessionSyncSnapshot.DeviceTokenSnapshot(
+            state = SharedSessionSyncSnapshot.State.SET,
+            version = "device-version",
+            changedAtMillis = 300,
+            value = "device-token",
+          ),
+      )
+
+    assertEquals(
+      snapshot,
+      SharedSessionSyncSnapshot.decode(SharedSessionSyncSnapshot.encode(snapshot)),
+    )
+  }
+
+  private fun auth(client: Client, fetchAt: Long) =
+    SharedSessionSyncSnapshot.AuthSnapshot(
+      state = SharedSessionSyncSnapshot.State.SET,
+      version = "version-$fetchAt",
+      serverFetchAtMillis = fetchAt,
+      client = client,
+    )
+
+  private fun cleared(fetchAt: Long) =
+    SharedSessionSyncSnapshot.AuthSnapshot(
+      state = SharedSessionSyncSnapshot.State.CLEARED,
+      version = "version-$fetchAt",
+      serverFetchAtMillis = fetchAt,
+    )
+}


### PR DESCRIPTION
## Summary of changes

Ports the shared-session synchronization behavior from [clerk/clerk-ios#508](https://github.com/clerk/clerk-ios/pull/508) to Android.

- Adds opt-in configuration through `ClerkConfigurationOptions(sharedSessionSync = SharedSessionSyncConfig.enabled)`
- Adds `Clerk.reloadFromSharedStorage()` for explicit reconciliation
- Synchronizes client, environment, and device-token state between same-signed apps using a signature-checked `ContentProvider`
- Partitions snapshots by publishable key and rejects stale snapshots or network responses
- Adds response fencing so an older in-flight request cannot overwrite a device token received from a sibling app
- Adds coordinator, provider, snapshot, middleware, and public API regression tests

Android does not have an equivalent to iOS keychain access groups and Darwin notifications, so this implementation uses Android's same-signer IPC boundary and content observers while preserving the source PR's opt-in and stale-state semantics.

https://github.com/user-attachments/assets/fcf1b609-1f65-44cf-ae7e-95889c71d3f5


