### PR TITLE
fix(ui): stabilize auth view model coroutine tests

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -21,6 +21,7 @@ import com.clerk.api.signup.SignUp
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.ResultType
 import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -42,7 +43,8 @@ private const val INVITATION_ACCOUNT_NOT_EXISTS = "invitation_account_not_exists
  * Clerk SDK to perform operations like creating sign-in/sign-up attempts, and handling social
  * provider authentication.
  */
-internal class AuthStartViewModel : ViewModel() {
+internal class AuthStartViewModel(private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO) :
+  ViewModel() {
 
   private val _state = MutableStateFlow<AuthState>(AuthState.Idle)
   /**
@@ -71,7 +73,7 @@ internal class AuthStartViewModel : ViewModel() {
 
     ClerkLog.d("Starting automatic passkey sign-in")
     val job =
-      viewModelScope.launch(Dispatchers.IO, start = CoroutineStart.LAZY) {
+      viewModelScope.launch(ioDispatcher, start = CoroutineStart.LAZY) {
         try {
           when (
             val result =
@@ -171,7 +173,7 @@ internal class AuthStartViewModel : ViewModel() {
     transferable: Boolean = true,
     unsafeMetadata: Map<String, Any>? = null,
   ) {
-    viewModelScope.launch(Dispatchers.IO) {
+    viewModelScope.launch(ioDispatcher) {
       _state.value = AuthState.Loading
       val resolvedIdentifier = if (isPhoneNumberFieldActive) phoneNumber else identifier
 
@@ -198,7 +200,7 @@ internal class AuthStartViewModel : ViewModel() {
     unsafeMetadata: Map<String, Any>?,
   ) {
     _state.value = AuthState.Loading
-    viewModelScope.launch(Dispatchers.IO) {
+    viewModelScope.launch(ioDispatcher) {
       SignUp.create(
           signUpParams(
             isPhoneNumberFieldActive = isPhoneNumberFieldActive,
@@ -253,7 +255,7 @@ internal class AuthStartViewModel : ViewModel() {
     startOAuthWithSignUp: Boolean,
     unsafeMetadata: Map<String, Any>?,
   ) {
-    viewModelScope.launch(Dispatchers.IO) {
+    viewModelScope.launch(ioDispatcher) {
       SignIn.authenticateWithGoogleOneTap(transferable)
         .onSuccess {
           withContext(Dispatchers.Main) {

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -45,7 +45,7 @@ class AuthViewModelTest {
   @Before
   fun setUp() {
     Dispatchers.setMain(testDispatcher)
-    viewModel = AuthStartViewModel()
+    viewModel = AuthStartViewModel(ioDispatcher = testDispatcher)
   }
 
   @After
@@ -128,13 +128,13 @@ class AuthViewModelTest {
 
       viewModel.startAutomaticPasskeySignIn()
 
-      coVerify(timeout = 1_000, exactly = 1) {
+      testDispatcher.scheduler.advanceUntilIdle()
+      coVerify(exactly = 1) {
         SignIn.create(
           any<SignIn.CreateParams.Strategy.Passkey>(),
           preferImmediatelyAvailableCredentials = true,
         )
       }
-      testDispatcher.scheduler.advanceUntilIdle()
       expectNoEvents()
     }
   }
@@ -158,13 +158,13 @@ class AuthViewModelTest {
 
       viewModel.startAutomaticPasskeySignIn()
 
-      coVerify(timeout = 1_000, exactly = 1) {
+      testDispatcher.scheduler.advanceUntilIdle()
+      coVerify(exactly = 1) {
         SignIn.create(
           any<SignIn.CreateParams.Strategy.Passkey>(),
           preferImmediatelyAvailableCredentials = true,
         )
       }
-      testDispatcher.scheduler.advanceUntilIdle()
       expectNoEvents()
     }
   }
@@ -566,8 +566,9 @@ class AuthViewModelTest {
       transferable = true,
       preferGoogleOneTap = true,
     )
+    testDispatcher.scheduler.advanceUntilIdle()
 
-    coVerify(timeout = 1_000, exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
+    coVerify(exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
     coVerify(exactly = 0) { SignIn.authenticateWithRedirect(any(), any()) }
   }
 
@@ -592,9 +593,9 @@ class AuthViewModelTest {
       transferable = true,
       preferGoogleOneTap = true,
     )
-
-    coVerify(timeout = 1_000, exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
     testDispatcher.scheduler.advanceUntilIdle()
-    coVerify(timeout = 1_000, exactly = 1) { SignIn.authenticateWithRedirect(any(), true) }
+
+    coVerify(exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
+    coVerify(exactly = 1) { SignIn.authenticateWithRedirect(any(), true) }
   }
 }


### PR DESCRIPTION
## Summary

- inject the IO dispatcher used by `AuthStartViewModel`
- run auth ViewModel unit tests on a shared test scheduler
- replace wall-clock MockK timeouts with deterministic scheduler advancement

## Root cause

The Google One Tap fallback test launched work on the real `Dispatchers.IO` and resumed on a paused test `Dispatchers.Main`. Under CI load, the test could advance Main before the IO coroutine queued its continuation, leaving the OAuth fallback paused until the verification timed out.

This targets the Renovate branch for #799, where the flake was observed.

## Validation

- failing test passed 10/10 forced reruns
- `./gradlew :source:ui:testDebugUnitTest`
- `./gradlew spotlessCheck`
- pre-commit `:source:ui:lintDebug`

## Note

`:source:ui:detekt` still reports seven pre-existing findings in unrelated files.