### PR TITLE
fix: harden automatic passkey sign-in gating and error suppression

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -309,6 +309,9 @@ object Clerk {
   val passkeyIsEnabled: Boolean
     get() = environment?.passkeyIsEnabled ?: false
 
+  val passkeyFirstFactorIsEnabled: Boolean
+    get() = environment?.passkeyFirstFactorIsEnabled ?: false
+
   val passkeyAutofillIsEnabled: Boolean
     get() = environment?.userSettings?.passkeySettings?.allowAutofill ?: false
 

--- a/source/api/src/main/kotlin/com/clerk/api/credentials/CredentialFlowException.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/credentials/CredentialFlowException.kt
@@ -96,10 +96,13 @@ private val ClerkResult.Failure<ClerkErrorResponse>.credentialFlowUiMessage: Str
 val ClerkResult.Failure<ClerkErrorResponse>.shouldSuppressCredentialFlowError: Boolean
   get() = (throwable as? CredentialFlowException)?.suppressUserFacingError == true
 
+/**
+ * Automatic credential flows start without user intent, so failures from the credential ceremony
+ * itself are logged instead of presented. Server rejections of a credential the user selected
+ * arrive as API failures and remain presentable.
+ */
 val ClerkResult.Failure<ClerkErrorResponse>.shouldSuppressAutomaticCredentialFlowError: Boolean
-  get() =
-    throwable is CredentialFlowException.UserCancelled ||
-      throwable is CredentialFlowException.NoSavedCredential
+  get() = throwable is CredentialFlowException || throwable is GetCredentialException
 
 val ClerkResult.Failure<ClerkErrorResponse>.shouldFallbackToOAuthFromGoogleOneTap: Boolean
   get() = throwable is CredentialFlowException.NoGoogleAccount

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/UserApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/UserApi.kt
@@ -441,6 +441,7 @@ internal interface UserApi {
    * @param passkeyId The ID of the passkey to verify
    * @param strategy The verification strategy (defaults to "passkey")
    * @param publicKeyCredential The WebAuthn public key credential data
+   * @param sessionId Optional session ID. Defaults to current session ID from [Clerk.session]
    * @return [ClerkResult] containing the verified [Passkey] on success or [ClerkErrorResponse] on
    *   failure
    */
@@ -450,6 +451,7 @@ internal interface UserApi {
     @Path(ApiParams.PASSKEY_ID) passkeyId: String,
     @Field(ApiParams.STRATEGY) strategy: String = "passkey",
     @Field("public_key_credential") publicKeyCredential: String,
+    @Query(ApiParams.CLERK_SESSION_ID) sessionId: String? = Clerk.session?.id,
   ): ClerkResult<Passkey, ClerkErrorResponse>
 
   /**

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/Environment.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/Environment.kt
@@ -17,6 +17,17 @@ internal data class Environment(
   val passkeyIsEnabled: Boolean
     get() = userSettings.attributes.any { (key, value) -> key == "passkey" && value.enabled }
 
+  /**
+   * Whether the instance accepts a passkey as a first factor when signing in. An instance can
+   * enable passkeys for registration and verification while leaving them out of the sign-in
+   * factors, so this is narrower than [passkeyIsEnabled].
+   */
+  val passkeyFirstFactorIsEnabled: Boolean
+    get() =
+      userSettings.attributes.any { (key, value) ->
+        key == "passkey" && value.enabled && value.usedForFirstFactor
+      }
+
   val mfaIsEnabled: Boolean
     get() = userSettings.attributes.any { (_, value) -> value.enabled && value.usedForSecondFactor }
 

--- a/source/api/src/test/java/com/clerk/api/network/model/environment/EnvironmentPasskeyFirstFactorTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/model/environment/EnvironmentPasskeyFirstFactorTest.kt
@@ -1,0 +1,86 @@
+package com.clerk.api.network.model.environment
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EnvironmentPasskeyFirstFactorTest {
+
+  private fun environment(passkeyEnabled: Boolean, usedForFirstFactor: Boolean): Environment {
+    return Environment(
+      authConfig = AuthConfig(singleSessionMode = false),
+      displayConfig =
+        DisplayConfig(
+          applicationName = "Test App",
+          branded = true,
+          logoImageUrl = "https://example.com/logo.png",
+          homeUrl = "/",
+          privacyPolicyUrl = null,
+          termsUrl = null,
+          googleOneTapClientId = null,
+        ),
+      userSettings =
+        UserSettings(
+          attributes =
+            mapOf(
+              "passkey" to
+                UserSettings.AttributesConfig(
+                  enabled = passkeyEnabled,
+                  required = false,
+                  usedForFirstFactor = usedForFirstFactor,
+                  firstFactors = if (usedForFirstFactor) listOf("passkey") else emptyList(),
+                  usedForSecondFactor = false,
+                  secondFactors = emptyList(),
+                  verifications = listOf("passkey"),
+                  verifyAtSignUp = false,
+                )
+            ),
+          signUp =
+            UserSettings.SignUpUserSettings(
+              customActionRequired = false,
+              progressive = false,
+              mode = "public",
+              legalConsentEnabled = false,
+            ),
+          social = emptyMap(),
+          actions = UserSettings.Actions(),
+          passkeySettings = null,
+        ),
+    )
+  }
+
+  @Test
+  fun `enabled when passkey is a first factor`() {
+    val environment = environment(passkeyEnabled = true, usedForFirstFactor = true)
+
+    assertTrue(environment.passkeyIsEnabled)
+    assertTrue(environment.passkeyFirstFactorIsEnabled)
+  }
+
+  @Test
+  fun `disabled when passkey is registration only`() {
+    val environment = environment(passkeyEnabled = true, usedForFirstFactor = false)
+
+    assertTrue(environment.passkeyIsEnabled)
+    assertFalse(environment.passkeyFirstFactorIsEnabled)
+  }
+
+  @Test
+  fun `disabled when passkey attribute is disabled`() {
+    val environment = environment(passkeyEnabled = false, usedForFirstFactor = true)
+
+    assertFalse(environment.passkeyIsEnabled)
+    assertFalse(environment.passkeyFirstFactorIsEnabled)
+  }
+
+  @Test
+  fun `disabled when passkey attribute is absent`() {
+    val environment =
+      environment(passkeyEnabled = true, usedForFirstFactor = true).let {
+        it.copy(userSettings = it.userSettings.copy(attributes = emptyMap()))
+      }
+
+    assertFalse(environment.passkeyIsEnabled)
+    assertFalse(environment.passkeyFirstFactorIsEnabled)
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
@@ -8,6 +8,7 @@ import androidx.credentials.GetCredentialResponse
 import androidx.credentials.PasswordCredential
 import androidx.credentials.PublicKeyCredential
 import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialUnknownException
 import androidx.credentials.exceptions.NoCredentialException
 import com.clerk.api.Clerk
 import com.clerk.api.credentials.CredentialFlowException
@@ -279,8 +280,29 @@ class PasskeyAuthenticationServiceTest {
   }
 
   @Test
-  fun `automatic credential flow does not suppress provider unavailable`() {
+  fun `automatic credential flow suppresses provider unavailable`() {
     val result = ClerkResult.unknownFailure(CredentialFlowException.ProviderUnavailable())
+
+    assertTrue(result.shouldSuppressAutomaticCredentialFlowError)
+  }
+
+  @Test
+  fun `automatic credential flow suppresses missing activity`() {
+    val result = ClerkResult.unknownFailure(CredentialFlowException.MissingActivity())
+
+    assertTrue(result.shouldSuppressAutomaticCredentialFlowError)
+  }
+
+  @Test
+  fun `automatic credential flow suppresses unclassified credential ceremony failures`() {
+    val result = ClerkResult.unknownFailure(GetCredentialUnknownException("asset links mismatch"))
+
+    assertTrue(result.shouldSuppressAutomaticCredentialFlowError)
+  }
+
+  @Test
+  fun `automatic credential flow does not suppress non-credential failures`() {
+    val result = ClerkResult.unknownFailure(IllegalStateException("serialization failed"))
 
     assertFalse(result.shouldSuppressAutomaticCredentialFlowError)
   }

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
@@ -8,6 +8,7 @@ import androidx.credentials.GetCredentialResponse
 import androidx.credentials.PasswordCredential
 import androidx.credentials.PublicKeyCredential
 import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException
 import androidx.credentials.exceptions.GetCredentialUnknownException
 import androidx.credentials.exceptions.NoCredentialException
 import com.clerk.api.Clerk
@@ -242,6 +243,87 @@ class PasskeyAuthenticationServiceTest {
     assertTrue(
       (result as ClerkResult.Failure).throwable is CredentialFlowException.NoSavedCredential
     )
+    verify(exactly = 1) { Clerk.updateClient(client.copy(signIn = null)) }
+  }
+
+  @Test
+  fun `automatic signInWithPasskey clears sign in on ProviderUnavailable`() = runTest {
+    val nonce = """{"challenge":"test-challenge"}"""
+    val client = Client(id = "client_123", signIn = mockSignIn)
+
+    every { mockSignIn.id } returns "sign_in_123"
+    every { mockSignIn.firstFactorVerification } returns mockVerification
+    every { mockVerification.nonce } returns nonce
+    every { Clerk.clientInitialized } returns true
+    every { Clerk.client } returns client
+    every { Clerk.updateClient(any()) } just runs
+
+    coEvery { ClerkApi.signIn.createSignIn(any()) } returns ClerkResult.success(mockSignIn)
+    coEvery { mockCredentialManager.getCredential(any(), any()) } throws
+      GetCredentialProviderConfigurationException("Provider not configured")
+
+    val result =
+      GoogleCredentialAuthenticationService.signInWithGoogleCredential(
+        credentialTypes = listOf(SignIn.CredentialType.PASSKEY),
+        preferImmediatelyAvailableCredentials = true,
+      )
+
+    assertTrue(result is ClerkResult.Failure)
+    assertTrue((result as ClerkResult.Failure).throwable is CredentialFlowException.ProviderUnavailable)
+    verify(exactly = 1) { Clerk.updateClient(client.copy(signIn = null)) }
+  }
+
+  @Test
+  fun `automatic signInWithPasskey clears sign in on MissingActivity`() = runTest {
+    val nonce = """{"challenge":"test-challenge"}"""
+    val client = Client(id = "client_123", signIn = mockSignIn)
+
+    every { mockSignIn.id } returns "sign_in_123"
+    every { mockSignIn.firstFactorVerification } returns mockVerification
+    every { mockVerification.nonce } returns nonce
+    every { Clerk.clientInitialized } returns true
+    every { Clerk.client } returns client
+    every { Clerk.updateClient(any()) } just runs
+
+    coEvery { ClerkApi.signIn.createSignIn(any()) } returns ClerkResult.success(mockSignIn)
+    coEvery { mockCredentialManager.getCredential(any(), any()) } throws
+      GetCredentialUnknownException("Activity-based context is required")
+
+    val result =
+      GoogleCredentialAuthenticationService.signInWithGoogleCredential(
+        credentialTypes = listOf(SignIn.CredentialType.PASSKEY),
+        preferImmediatelyAvailableCredentials = true,
+      )
+
+    assertTrue(result is ClerkResult.Failure)
+    assertTrue((result as ClerkResult.Failure).throwable is CredentialFlowException.MissingActivity)
+    verify(exactly = 1) { Clerk.updateClient(client.copy(signIn = null)) }
+  }
+
+  @Test
+  fun `automatic signInWithPasskey clears sign in on GetCredentialUnknownException`() = runTest {
+    val nonce = """{"challenge":"test-challenge"}"""
+    val client = Client(id = "client_123", signIn = mockSignIn)
+
+    every { mockSignIn.id } returns "sign_in_123"
+    every { mockSignIn.firstFactorVerification } returns mockVerification
+    every { mockVerification.nonce } returns nonce
+    every { Clerk.clientInitialized } returns true
+    every { Clerk.client } returns client
+    every { Clerk.updateClient(any()) } just runs
+
+    coEvery { ClerkApi.signIn.createSignIn(any()) } returns ClerkResult.success(mockSignIn)
+    coEvery { mockCredentialManager.getCredential(any(), any()) } throws
+      GetCredentialUnknownException("asset links mismatch")
+
+    val result =
+      GoogleCredentialAuthenticationService.signInWithGoogleCredential(
+        credentialTypes = listOf(SignIn.CredentialType.PASSKEY),
+        preferImmediatelyAvailableCredentials = true,
+      )
+
+    assertTrue(result is ClerkResult.Failure)
+    assertTrue((result as ClerkResult.Failure).throwable is GetCredentialUnknownException)
     verify(exactly = 1) { Clerk.updateClient(client.copy(signIn = null)) }
   }
 

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewHelper.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewHelper.kt
@@ -75,7 +75,7 @@ internal class AuthStartViewHelper {
 
   val passkeySignInConfigIsEnabled: Boolean
     get() =
-      (testPasskeyIsEnabled ?: Clerk.passkeyIsEnabled) &&
+      (testPasskeyIsEnabled ?: Clerk.passkeyFirstFactorIsEnabled) &&
         (testPasskeyAutofillIsEnabled ?: Clerk.passkeyAutofillIsEnabled)
 
   fun getKeyboardType(isPhoneNumberFieldActive: Boolean): KeyboardType {


### PR DESCRIPTION
## Problem

The automatic passkey sign-in that `AuthStartView` kicks off when the sign-in screen appears has two gaps, both siblings of what clerk-ios fixed in clerk/clerk-ios#528 and clerk/clerk-ios#530 after a customer's App Store submission was rejected over an unprompted error dialog.

1. **It fires even when passkeys aren't a sign-in factor.** The gate checked only that the passkey attribute is enabled, so an instance using passkeys purely for registration or reverification still sent a doomed `POST /v1/client/sign_ins` with `strategy=passkey` on every screen appearance.

2. **Most ceremony failures surface to users who did nothing.** Suppression covered exactly `UserCancelled` and `NoSavedCredential`. Everything else — `ProviderUnavailable` (no working credential provider: emulators, some OEMs), `MissingActivity`, and unclassified `GetCredentialException`s such as an asset links mismatch — popped an error dialog on top of an untouched sign-in form. The asset links case means a developer misconfiguration is shown to end users in production.

## Changes

- Added `Environment.passkeyFirstFactorIsEnabled` (enabled **and** `used_for_first_factor`), exposed on `Clerk`, and used it to gate the automatic flow. `UserProfileSecurityView` keeps the broader `passkeyIsEnabled` — managing passkeys in the profile is separate from whether they're a sign-in factor.
- Broadened `shouldSuppressAutomaticCredentialFlowError` to suppress any `CredentialFlowException` or `GetCredentialException`. These are logged, never presented. API failures — including the server rejecting a credential the user actually selected — still present. User-initiated flows (`shouldSuppressCredentialFlowError`) are unchanged.
- Since `clearSuppressedAutomaticSignInAttempt` keys off the same property, abandoned automatic attempts are now also cleaned up for the newly suppressed failure types, so they can't shadow a subsequent real sign-in.

## Behavior change

`ProviderUnavailable` and `MissingActivity` in the *automatic* flow were previously shown to users; they're now log-only. The existing test asserting the old behavior was flipped intentionally.

## Testing

- Flipped `automatic credential flow does not suppress provider unavailable` to assert suppression; added cases for `MissingActivity`, unclassified `GetCredentialException`, and a non-credential throwable that must still present.
- Added `EnvironmentPasskeyFirstFactorTest` covering the enabled × used_for_first_factor matrix, mirroring the clerk-ios tests.
- `spotlessCheck` and the touched test classes (`PasskeyAuthenticationServiceTest`, `EnvironmentPasskeyFirstFactorTest`) pass locally on JDK 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden automatic passkey sign-in gating and credential error suppression
> - Adds `passkeyFirstFactorIsEnabled` to `Environment` and `Clerk` to distinguish passkeys configured as a first sign-in factor from passkeys enabled for other purposes.
> - Changes `AuthStartViewHelper.passkeySignInConfigIsEnabled` to gate on `Clerk.passkeyFirstFactorIsEnabled` instead of `Clerk.passkeyIsEnabled`, so passkey sign-in UI is only shown when passkeys are a valid first factor.
> - Expands `shouldSuppressAutomaticCredentialFlowError` to suppress all `CredentialFlowException` and `GetCredentialException` failures (previously only `UserCancelled` and `NoSavedCredential`), so credential ceremony errors in automatic flows no longer surface to users.
> - Behavioral Change: automatic passkey flows now silently swallow a broader set of credential errors; server/API rejections are still surfaced.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #818 opened
>
> - Added optional `sessionId` query parameter to passkey verification method in `UserApi` [0e29fa0]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ee7288.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting when passkeys are enabled as a first authentication factor.
  * Passkey-first sign-in configuration now respects the environment’s first-factor settings.
  * Passkey verification can target a specified session.

* **Bug Fixes**
  * Improved handling and suppression of expected automatic credential-flow errors.
  * Automatic passkey sign-in now clears the active sign-in after credential-provider failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->