### PR TITLE
fix(ui): wire back button on sign-up code and collect-field screens

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/signup/code/SignUpCodeView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/code/SignUpCodeView.kt
@@ -92,6 +92,7 @@ private fun SignUpCodeViewImpl(
     onClickIdentifier = authState::navigateToAuthStartForIdentifierEdit,
     spacingAfterIdentifier = dp28,
     snackbarHostState = snackbarHostState,
+    onBackPressed = authState::navigateBack,
   ) {
     Spacers.Vertical.Spacer32()
     ClerkCodeInputField(

--- a/source/ui/src/main/java/com/clerk/ui/signup/collectfield/SignUpCollectFieldView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signup/collectfield/SignUpCollectFieldView.kt
@@ -87,6 +87,7 @@ private fun SignUpCollectFieldViewImpl(
     subtitle = collectFieldHelper.subtitle(collectField),
     hasLogo = false,
     snackbarHostState = snackbarHostState,
+    onBackPressed = { authState.navigateBack() },
   ) {
     Column(
       modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## Summary of changes

The back button on two sign-up screens renders but does nothing.

ClerkThemedAuthScaffold defaults to onBackPressed: () -> Unit = {} with hasBackButton: Boolean = true,
so any call site that omits onBackPressed draws a chevron that silently no-ops. 
SignUpCodeView and SignUpCollectFieldView both omitted it — every other auth screen passes authState::navigateBack. System back/gesture works on these screens, which is why only the button appears broken.

Verified on samples/prebuilt-ui: back now returns from the code screen to auth start, and from the
create-password screen to the code screen. Sign-in flow unchanged.

PS: this issue of non-working back-button only effects android, because the verification chain is different between the two native platforms.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire back button on sign-up code and collect-field screens
> Passes `onBackPressed` callbacks wired to `authState.navigateBack()` in [SignUpCodeView.kt](https://github.com/clerk/clerk-android/pull/823/files#diff-0a15917bc6e0d845aa1e3ad9eeb67318a379c7962f09c73e0364908d28e23e89) and [SignUpCollectFieldView.kt](https://github.com/clerk/clerk-android/pull/823/files#diff-fb6f8da7c4ca19aeb558a02a7c706402be8836eaa0c2f61f240444db7b9b90bf). Previously, the back button had no effect on these screens.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c715b3.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added consistent back-navigation support to the sign-up verification and information-entry screens.
  * Pressing the back button now returns users to the previous authentication step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->