### PR TITLE
fix(ci): support detekt checks for fork pull requests

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -15,7 +15,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
-          ref: ${{ github.head_ref }}
 
       - name: detekt
         uses: alaegin/Detekt-Action@v1.23.8


### PR DESCRIPTION
Let actions/checkout use the pull request merge ref so contributor branches are fetched from the correct repository context.

## Summary of changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix detekt CI workflow to support fork pull requests
> Removes the explicit `ref: ${{ github.head_ref }}` parameter from the `actions/checkout` step in [detekt.yml](.github/workflows/detekt.yml), allowing the action to use its default ref. `github.head_ref` is unavailable for fork PRs, which caused the checkout to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9249f1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code quality workflow to use the default repository checkout behavior.
  * Retained shallow checkouts to keep workflow execution efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->