### PR TITLE
Align Android session token fetching with edge minter behavior

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -34,6 +34,7 @@ import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.organizations.Organization
 import com.clerk.api.organizations.OrganizationMembership
 import com.clerk.api.session.Session
+import com.clerk.api.session.SessionTokenFetcher
 import com.clerk.api.session.SessionTokensCache
 import com.clerk.api.sharedsession.SharedSessionSyncCoordinator
 import com.clerk.api.sharedsession.SharedSessionSyncProvider
@@ -831,6 +832,7 @@ object Clerk {
     StorageHelper.deleteValue(StorageKey.CACHED_CLERK_STATE)
     clearSessionAndUserState()
     resetAuthFlowState()
+    SessionTokenFetcher.shared.reset()
     SessionTokensCache.clear()
     SSOService.cancelPendingAuthentication()
     ExternalAccountService.cancelPendingExternalAccountConnection()
@@ -1018,14 +1020,14 @@ object Clerk {
   private fun cacheStateIfReady() {
     val cachedEnvironment = environment
     val cachedClient = _clientFlow.value
-    val cachedResources =
-      cachedClient?.let { client ->
-        cachedEnvironment?.let { environment -> client to environment }
-      }
+    val cachedResources = cachedClient?.let { client ->
+      cachedEnvironment?.let { environment -> client to environment }
+    }
     val cachedPublishableKey = publishableKey
     val cachedBaseUrl = runCatching { baseUrl }.getOrNull()
-    val cachedConfiguration =
-      cachedPublishableKey?.let { key -> cachedBaseUrl?.let { url -> key to url } }
+    val cachedConfiguration = cachedPublishableKey?.let { key ->
+      cachedBaseUrl?.let { url -> key to url }
+    }
     val cachedServerFetchAtMillis = lastClientServerFetchAtMillis
     val state =
       if (
@@ -1131,8 +1133,9 @@ object Clerk {
   }
 
   private fun Client.withResolvedActiveSession(previousSession: Session?): Client {
-    val currentActiveSessionId =
-      lastActiveSessionId?.takeIf { activeSessionId -> sessions.any { it.id == activeSessionId } }
+    val currentActiveSessionId = lastActiveSessionId?.takeIf { activeSessionId ->
+      sessions.any { it.id == activeSessionId }
+    }
     val resolvedActiveSessionId =
       currentActiveSessionId
         ?: previousSession?.id?.takeIf { previousSessionId ->
@@ -1316,8 +1319,9 @@ fun Map<String, UserSettings.SocialConfig>.toOAuthProvidersList(): List<OAuthPro
     .filter { it.enabled && it.authenticatable }
     .map { OAuthProvider.fromStrategy(it.strategy) }
 
-fun SignIn.identifyingFirstFactor(strategy: String): Factor? =
-  supportedFirstFactors?.firstOrNull { it.strategy == strategy && it.safeIdentifier == identifier }
+fun SignIn.identifyingFirstFactor(strategy: String): Factor? = supportedFirstFactors?.firstOrNull {
+  it.strategy == strategy && it.safeIdentifier == identifier
+}
 
 val SignIn.resetPasswordFactor: Factor?
   get() =

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
@@ -21,6 +21,7 @@ import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.fold
 import com.clerk.api.session.GetTokenOptions
+import com.clerk.api.session.SessionTokenFetcher
 import com.clerk.api.session.SessionTokensCache
 import com.clerk.api.session.fetchToken
 import com.clerk.api.sso.SSOService
@@ -268,34 +269,33 @@ internal class ConfigurationManager {
   private fun launchInitialization(
     options: ClerkConfigurationOptions?,
     configuredVersion: Int,
-  ): Job =
-    scope.launch {
-      val attempt =
-        RefreshAttempt(
-          options = options,
-          retryCount = 0,
-          expectedConfigurationVersion = configuredVersion,
-        )
-      Clerk.trustedDevices.retryPendingLocalCredentialCleanup()
-      Clerk.sharedSessionSyncCoordinator?.reloadFromSharedStorage()
-      val deviceIdInitJob = async { DeviceIdGenerator.initialize() }
-      val dataRefreshJob = async {
-        refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
-      }
+  ): Job = scope.launch {
+    val attempt =
+      RefreshAttempt(
+        options = options,
+        retryCount = 0,
+        expectedConfigurationVersion = configuredVersion,
+      )
+    Clerk.trustedDevices.retryPendingLocalCredentialCleanup()
+    Clerk.sharedSessionSyncCoordinator?.reloadFromSharedStorage()
+    val deviceIdInitJob = async { DeviceIdGenerator.initialize() }
+    val dataRefreshJob = async {
+      refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+    }
 
-      deviceIdInitJob.await()
-      AppLifecycleListener.configure {
-        if (hasConfigured) {
-          scope.launch {
-            Clerk.sharedSessionSyncCoordinator?.reloadFromSharedStorage()
-            deferForegroundRefreshDuringPendingAuth()
-            refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
-            startTokenRefresh()
-          }
+    deviceIdInitJob.await()
+    AppLifecycleListener.configure {
+      if (hasConfigured) {
+        scope.launch {
+          Clerk.sharedSessionSyncCoordinator?.reloadFromSharedStorage()
+          deferForegroundRefreshDuringPendingAuth()
+          refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+          startTokenRefresh()
         }
       }
-      dataRefreshJob.await()
     }
+    dataRefreshJob.await()
+  }
 
   fun isConfigured(): Boolean = hasConfigured
 
@@ -336,29 +336,28 @@ internal class ConfigurationManager {
 
     // Cancel any ongoing jobs
     refreshJob?.cancel()
-    refreshJob =
-      scope.launch {
-        while (isActive) {
-          try {
-            val session = Clerk.session
-            if (session != null) {
-              if (Clerk.debugMode) {
-                ClerkLog.d("Refreshing token for session: ${session.id}")
-              }
-              // Use async to avoid blocking the refresh loop
-              async { session.fetchToken(GetTokenOptions(skipCache = false)) }
-            } else {
-              if (Clerk.debugMode) {
-                ClerkLog.d("No session available for token refresh")
-              }
+    refreshJob = scope.launch {
+      while (isActive) {
+        try {
+          val session = Clerk.session
+          if (session != null) {
+            if (Clerk.debugMode) {
+              ClerkLog.d("Refreshing token for session: ${session.id}")
             }
-          } catch (e: Exception) {
-            ClerkLog.w("Token refresh failed: ${e.message}")
+            // Use async to avoid blocking the refresh loop
+            async { session.fetchToken(GetTokenOptions(skipCache = false)) }
+          } else {
+            if (Clerk.debugMode) {
+              ClerkLog.d("No session available for token refresh")
+            }
           }
-
-          delay(REFRESH_TOKEN_INTERVAL.seconds)
+        } catch (e: Exception) {
+          ClerkLog.w("Token refresh failed: ${e.message}")
         }
+
+        delay(REFRESH_TOKEN_INTERVAL.seconds)
       }
+    }
   }
 
   suspend fun updateDeviceToken(deviceToken: String): ClerkResult<Unit, ClerkErrorResponse> {
@@ -383,6 +382,7 @@ internal class ConfigurationManager {
     StorageHelper.deleteValue(StorageKey.DEVICE_TOKEN)
     Clerk.updateClient(Client())
     Clerk.clearSessionAndUserState()
+    SessionTokenFetcher.shared.reset()
     SessionTokensCache.clear()
 
     val result =

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/SessionApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/SessionApi.kt
@@ -9,6 +9,7 @@ import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
 import com.clerk.api.session.SessionVerification
 import retrofit2.http.DELETE
+import retrofit2.http.Field
 import retrofit2.http.FieldMap
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
@@ -76,8 +77,12 @@ internal interface SessionApi {
    *   failure
    */
   @POST(ApiPaths.Client.Sessions.TOKENS)
+  @FormUrlEncoded
   suspend fun tokens(
-    @Path(ApiParams.ID) sessionId: String
+    @Path(ApiParams.ID) sessionId: String,
+    @Field("organization_id") organizationId: String = "",
+    @Field("token") token: String? = null,
+    @Field("force_origin") forceOrigin: String? = null,
   ): ClerkResult<TokenResource, ClerkErrorResponse>
 
   /**

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/AuthConfig.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/AuthConfig.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.Serializable
  *
  * @property singleSessionMode Whether the application is configured for single session mode. When
  *   true, only one active session is allowed per user at a time.
+ * @property sessionMinter Whether session token minting at the edge is enabled.
  * @property nativeSettings Native-app specific settings, such as trusted-device sign-in.
  */
 @Serializable
@@ -20,6 +21,9 @@ internal data class AuthConfig(
    * session is allowed per user at a time.
    */
   @SerialName("single_session_mode") val singleSessionMode: Boolean,
+
+  /** Whether session token minting at the edge is enabled. */
+  @SerialName("session_minter") val sessionMinter: Boolean = false,
 
   /** Native-app specific settings, such as trusted-device sign-in. */
   @SerialName("native_settings") val nativeSettings: NativeSettings = NativeSettings(),

--- a/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
@@ -212,7 +212,7 @@ suspend fun Session.delete(): ClerkResult<Session, ClerkErrorResponse> {
 suspend fun Session.fetchToken(
   options: GetTokenOptions = GetTokenOptions()
 ): ClerkResult<TokenResource, ClerkErrorResponse> {
-  val token = SessionTokenFetcher().getToken(this, options)
+  val token = SessionTokenFetcher.shared.getToken(this, options)
   return if (token != null) {
     ClerkResult.success(token)
   } else {

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
@@ -46,17 +46,24 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
     val session: Session,
     val cacheKey: String,
     val sessionMinterEnabled: Boolean,
+    val runtimeGeneration: Long,
   )
 
   /** Map of cache keys to deferred token fetch tasks for request deduplication */
   private val tokenTasks = ConcurrentHashMap<String, Deferred<TokenResource?>>()
+  private val runtimeLock = Any()
+  private var runtimeGeneration = 0L
 
   /**
    * Releases deduplicated waiters and removes requests registered by the previous Clerk runtime.
    */
   internal fun reset() {
-    tokenTasks.values.forEach { it.cancel() }
-    tokenTasks.clear()
+    val tasksToCancel =
+      synchronized(runtimeLock) {
+        runtimeGeneration += 1
+        tokenTasks.values.toList().also { tokenTasks.clear() }
+      }
+    tasksToCancel.forEach { it.cancel() }
   }
 
   /**
@@ -129,8 +136,12 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
       session = currentSession,
       cacheKey = currentSession.tokenCacheKey(template),
       sessionMinterEnabled = Clerk.environment?.authConfig?.sessionMinter == true,
+      runtimeGeneration = synchronized(runtimeLock) { runtimeGeneration },
     )
   }
+
+  private fun isCurrentRuntime(context: FetchContext): Boolean =
+    synchronized(runtimeLock) { context.runtimeGeneration == runtimeGeneration }
 
   /**
    * Internal method to fetch a token from cache or network.
@@ -144,69 +155,91 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
    * @return The token resource, or null if the fetch failed
    */
   private suspend fun fetchToken(context: FetchContext, options: GetTokenOptions): TokenResource? {
-    val session = context.session
-    val cacheKey = context.cacheKey
-
-    if (options.template == null) {
-      session.lastActiveToken
-        ?.takeIf {
-          TokenFreshness.matches(it, session.id, session.lastActiveOrganizationId)
-        }
-        ?.let { SessionTokensCache.hydrate(cacheKey, it) }
-    }
-
-    // Check cache first (unless skipped)
-    if (!options.skipCache) {
-      SessionTokensCache.getToken(cacheKey)?.let { token ->
-        ClerkLog.d("Found cached token for session ${session.id}")
-        if (isTokenValid(token, options.expirationBuffer)) {
-          ClerkLog.d("Cached token is still valid for session ${session.id}")
-          return token
-        } else {
-          ClerkLog.d("Cached token is expired for session ${session.id}")
+    return if (!isCurrentRuntime(context)) {
+      null
+    } else {
+      if (options.template == null) {
+        synchronized(runtimeLock) {
+          if (context.runtimeGeneration == runtimeGeneration) {
+            val session = context.session
+            session.lastActiveToken
+              ?.takeIf { TokenFreshness.matches(it, session.id, session.lastActiveOrganizationId) }
+              ?.let { SessionTokensCache.hydrate(context.cacheKey, it) }
+          }
         }
       }
-    }
 
-    // Fetch from network
-    return try {
-      val tokensRequest =
-        if (options.template != null) {
-          ClerkApi.session.tokens(session.id, options.template)
+      val validCachedToken =
+        if (options.skipCache) {
+          null
         } else {
-          val cachedToken = SessionTokensCache.getToken(cacheKey)
-          val previousToken =
-            cachedToken?.let {
-              TokenFreshness.pickFreshest(
-                existing = session.lastActiveToken,
-                incoming = it,
-              )
-            } ?: session.lastActiveToken
-          ClerkApi.session.tokens(
-            sessionId = session.id,
-            organizationId = session.lastActiveOrganizationId.orEmpty(),
-            token = previousToken?.jwt.takeIf { context.sessionMinterEnabled },
-            forceOrigin = "true".takeIf { context.sessionMinterEnabled && options.skipCache },
-          )
+          SessionTokensCache.getToken(context.cacheKey)?.takeIf { token ->
+            ClerkLog.d("Found cached token for session ${context.session.id}")
+            isTokenValid(token, options.expirationBuffer).also { isValid ->
+              val cacheStatus = if (isValid) "still valid" else "expired"
+              ClerkLog.d("Cached token is $cacheStatus for session ${context.session.id}")
+            }
+          }
         }
+
+      validCachedToken?.takeIf { isCurrentRuntime(context) }
+        ?: if (!isCurrentRuntime(context)) {
+          null
+        } else {
+          try {
+            reconcileTokenResponse(context, requestToken(context, options))
+          } catch (e: CancellationException) {
+            throw e
+          } catch (e: Exception) {
+            ClerkLog.e("Failed to fetch token: ${e.message}")
+            null
+          }
+        }
+    }
+  }
+
+  private suspend fun requestToken(
+    context: FetchContext,
+    options: GetTokenOptions,
+  ): ClerkResult<TokenResource, ClerkErrorResponse> {
+    val session = context.session
+    return if (options.template != null) {
+      ClerkApi.session.tokens(session.id, options.template)
+    } else {
+      val cachedToken = SessionTokensCache.getToken(context.cacheKey)
+      val previousToken =
+        cachedToken?.let {
+          TokenFreshness.pickFreshest(existing = session.lastActiveToken, incoming = it)
+        } ?: session.lastActiveToken
+      ClerkApi.session.tokens(
+        sessionId = session.id,
+        organizationId = session.lastActiveOrganizationId.orEmpty(),
+        token = previousToken?.jwt.takeIf { context.sessionMinterEnabled },
+        forceOrigin = "true".takeIf { context.sessionMinterEnabled && options.skipCache },
+      )
+    }
+  }
+
+  private fun reconcileTokenResponse(
+    context: FetchContext,
+    tokensRequest: ClerkResult<TokenResource, ClerkErrorResponse>,
+  ): TokenResource? =
+    synchronized(runtimeLock) {
+      if (context.runtimeGeneration != runtimeGeneration) return@synchronized null
 
       when (tokensRequest) {
         is ClerkResult.Success -> {
-          SessionTokensCache.storeIfFresher(cacheKey, tokensRequest.value)
+          SessionTokensCache.storeIfFresher(context.cacheKey, tokensRequest.value)
+          // Match Clerk JS: each forced refresh returns its own mint while the shared cache stays
+          // monotonic when responses complete out of order.
           tokensRequest.value
         }
         is ClerkResult.Failure -> {
-          handleSessionInvalidationOnFailure(session, tokensRequest)
+          handleSessionInvalidationOnFailure(context.session, tokensRequest)
           null
         }
       }
-    } catch (e: CancellationException) {
-      throw e
-    } catch (e: Exception) {
-      ClerkLog.e("Failed to fetch token: ${e.message}")
-      null
     }
-  }
 
   private fun handleSessionInvalidationOnFailure(
     session: Session,

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
@@ -10,7 +10,6 @@ import com.clerk.api.network.serialization.ClerkResult
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
 
 /**
  * Internal service for fetching and managing session tokens.
@@ -50,20 +49,21 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
   )
 
   /** Map of cache keys to deferred token fetch tasks for request deduplication */
-  private val tokenTasks = ConcurrentHashMap<String, Deferred<TokenResource?>>()
+  private val tokenTasks = ConcurrentHashMap<String, CompletableDeferred<TokenResource?>>()
   private val runtimeLock = Any()
   private var runtimeGeneration = 0L
 
   /**
-   * Releases deduplicated waiters and removes requests registered by the previous Clerk runtime.
+   * Releases deduplicated waiters with a null result and removes requests registered by the
+   * previous Clerk runtime.
    */
   internal fun reset() {
-    val tasksToCancel =
+    val tasksToRelease =
       synchronized(runtimeLock) {
         runtimeGeneration += 1
         tokenTasks.values.toList().also { tokenTasks.clear() }
       }
-    tasksToCancel.forEach { it.cancel() }
+    tasksToRelease.forEach { it.complete(null) }
   }
 
   /**

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
@@ -26,8 +26,10 @@ import kotlinx.coroutines.Deferred
  * @param jwtManager The JWT manager used for token parsing and validation
  */
 internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManagerImpl()) {
-  private companion object {
-    val sessionInvalidationErrorCodes =
+  internal companion object {
+    internal val shared: SessionTokenFetcher by lazy { SessionTokenFetcher() }
+
+    private val sessionInvalidationErrorCodes =
       setOf(
         "session_revoked",
         "session_expired",
@@ -40,8 +42,22 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
       )
   }
 
+  private data class FetchContext(
+    val session: Session,
+    val cacheKey: String,
+    val sessionMinterEnabled: Boolean,
+  )
+
   /** Map of cache keys to deferred token fetch tasks for request deduplication */
   private val tokenTasks = ConcurrentHashMap<String, Deferred<TokenResource?>>()
+
+  /**
+   * Releases deduplicated waiters and removes requests registered by the previous Clerk runtime.
+   */
+  internal fun reset() {
+    tokenTasks.values.forEach { it.cancel() }
+    tokenTasks.clear()
+  }
 
   /**
    * Retrieves a token for the specified session with the given options.
@@ -76,19 +92,24 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
     session: Session,
     options: GetTokenOptions,
   ): TokenResource? {
-    val cacheKey = session.tokenCacheKey(options.template)
+    val context = makeFetchContext(session, options.template)
     ClerkLog.d(
-      "Fetching token for session ${session.id} with options: $options and cache key: $cacheKey"
+      "Fetching token for session ${context.session.id} with options: $options and cache key: " +
+        context.cacheKey
     )
 
-    return tokenTasks[cacheKey]?.await()
+    if (options.skipCache) {
+      return fetchToken(context, options)
+    }
+
+    return tokenTasks[context.cacheKey]?.await()
       ?: run {
         val deferred = CompletableDeferred<TokenResource?>()
-        val existingTask = tokenTasks.putIfAbsent(cacheKey, deferred)
+        val existingTask = tokenTasks.putIfAbsent(context.cacheKey, deferred)
 
         existingTask?.await()
           ?: try {
-            fetchToken(session, options).also { deferred.complete(it) }
+            fetchToken(context, options).also { deferred.complete(it) }
           } catch (e: CancellationException) {
             deferred.cancel(e)
             throw e
@@ -96,9 +117,19 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
             deferred.completeExceptionally(t)
             throw t
           } finally {
-            tokenTasks.remove(cacheKey, deferred)
+            tokenTasks.remove(context.cacheKey, deferred)
           }
       }
+  }
+
+  private fun makeFetchContext(session: Session, template: String?): FetchContext {
+    val currentSession =
+      Clerk.clientFlow.value?.sessions?.firstOrNull { it.id == session.id } ?: session
+    return FetchContext(
+      session = currentSession,
+      cacheKey = currentSession.tokenCacheKey(template),
+      sessionMinterEnabled = Clerk.environment?.authConfig?.sessionMinter == true,
+    )
   }
 
   /**
@@ -112,8 +143,17 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
    * @param options Options controlling the fetch behavior
    * @return The token resource, or null if the fetch failed
    */
-  private suspend fun fetchToken(session: Session, options: GetTokenOptions): TokenResource? {
-    val cacheKey = session.tokenCacheKey(options.template)
+  private suspend fun fetchToken(context: FetchContext, options: GetTokenOptions): TokenResource? {
+    val session = context.session
+    val cacheKey = context.cacheKey
+
+    if (options.template == null) {
+      session.lastActiveToken
+        ?.takeIf {
+          TokenFreshness.matches(it, session.id, session.lastActiveOrganizationId)
+        }
+        ?.let { SessionTokensCache.hydrate(cacheKey, it) }
+    }
 
     // Check cache first (unless skipped)
     if (!options.skipCache) {
@@ -134,12 +174,25 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
         if (options.template != null) {
           ClerkApi.session.tokens(session.id, options.template)
         } else {
-          ClerkApi.session.tokens(session.id)
+          val cachedToken = SessionTokensCache.getToken(cacheKey)
+          val previousToken =
+            cachedToken?.let {
+              TokenFreshness.pickFreshest(
+                existing = session.lastActiveToken,
+                incoming = it,
+              )
+            } ?: session.lastActiveToken
+          ClerkApi.session.tokens(
+            sessionId = session.id,
+            organizationId = session.lastActiveOrganizationId.orEmpty(),
+            token = previousToken?.jwt.takeIf { context.sessionMinterEnabled },
+            forceOrigin = "true".takeIf { context.sessionMinterEnabled && options.skipCache },
+          )
         }
 
       when (tokensRequest) {
         is ClerkResult.Success -> {
-          SessionTokensCache.setToken(cacheKey, tokensRequest.value)
+          SessionTokensCache.storeIfFresher(cacheKey, tokensRequest.value)
           tokensRequest.value
         }
         is ClerkResult.Failure -> {
@@ -228,10 +281,11 @@ data class GetTokenOptions(
 /**
  * Extension function to generate a cache key for session tokens.
  *
- * This function creates a unique cache key based on the session ID and optional template name. This
- * ensures that tokens for different templates are cached separately.
+ * This function creates a unique cache key based on the session ID and either its active
+ * organization or the optional template name.
  *
  * @param template Optional template name to include in the cache key
  * @return A unique cache key string for the session and template combination
  */
-internal fun Session.tokenCacheKey(template: String?): String = template?.let { "$id-$it" } ?: id
+internal fun Session.tokenCacheKey(template: String?): String =
+  template?.let { "$id-template-$it" } ?: "$id-organization-${lastActiveOrganizationId.orEmpty()}"

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionTokenFetcher.kt
@@ -83,23 +83,24 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
   suspend fun getToken(
     session: Session,
     options: GetTokenOptions = GetTokenOptions(),
-  ): TokenResource? =
-    when {
-      session.status == Session.SessionStatus.PENDING -> {
+  ): TokenResource? {
+    val context = makeFetchContext(session, options.template)
+    return when {
+      context.session.status == Session.SessionStatus.PENDING -> {
         ClerkLog.w(
-          "Cannot fetch token for session ${session.id}: session is in pending state. " +
+          "Cannot fetch token for session ${context.session.id}: session is in pending state. " +
             "The user has tasks to complete before the session can be activated."
         )
         null
       }
-      else -> fetchTokenWithDeduplication(session, options)
+      else -> fetchTokenWithDeduplication(context, options)
     }
+  }
 
   private suspend fun fetchTokenWithDeduplication(
-    session: Session,
+    context: FetchContext,
     options: GetTokenOptions,
   ): TokenResource? {
-    val context = makeFetchContext(session, options.template)
     ClerkLog.d(
       "Fetching token for session ${context.session.id} with options: $options and cache key: " +
         context.cacheKey
@@ -109,24 +110,23 @@ internal class SessionTokenFetcher(private val jwtManager: JWTManager = JWTManag
       return fetchToken(context, options)
     }
 
-    return tokenTasks[context.cacheKey]?.await()
-      ?: run {
-        val deferred = CompletableDeferred<TokenResource?>()
-        val existingTask = tokenTasks.putIfAbsent(context.cacheKey, deferred)
-
-        existingTask?.await()
-          ?: try {
-            fetchToken(context, options).also { deferred.complete(it) }
-          } catch (e: CancellationException) {
-            deferred.cancel(e)
-            throw e
-          } catch (t: Throwable) {
-            deferred.completeExceptionally(t)
-            throw t
-          } finally {
-            tokenTasks.remove(context.cacheKey, deferred)
-          }
+    val deferred = CompletableDeferred<TokenResource?>()
+    val existingTask = tokenTasks.putIfAbsent(context.cacheKey, deferred)
+    return if (existingTask != null) {
+      existingTask.await()
+    } else {
+      try {
+        fetchToken(context, options).also { deferred.complete(it) }
+      } catch (e: CancellationException) {
+        deferred.cancel(e)
+        throw e
+      } catch (t: Throwable) {
+        deferred.completeExceptionally(t)
+        throw t
+      } finally {
+        tokenTasks.remove(context.cacheKey, deferred)
       }
+    }
   }
 
   private fun makeFetchContext(session: Session, template: String?): FetchContext {

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionTokensCache.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionTokensCache.kt
@@ -6,12 +6,46 @@ import java.util.concurrent.ConcurrentHashMap
 internal object SessionTokensCache {
   private val cache = ConcurrentHashMap<String, TokenResource>()
 
+  internal data class StoreResult(
+    val canonicalToken: TokenResource,
+    val didChangeCanonicalToken: Boolean,
+  )
+
   /** Returns a session token for the given cache key. */
   internal fun getToken(cacheKey: String): TokenResource? = cache[cacheKey]
 
   /** Sets a session token for the given cache key. */
   internal fun setToken(cacheKey: String, token: TokenResource) {
     cache[cacheKey] = token
+  }
+
+  /** Reconciles a session snapshot without replacing an equally fresh canonical token. */
+  internal fun hydrate(cacheKey: String, token: TokenResource) {
+    cache.compute(cacheKey) { _, existing ->
+      TokenFreshness.pickFreshest(
+        existing = existing,
+        incoming = token,
+        tieBreaker = TokenFreshness.TieBreaker.EXISTING,
+      )
+    }
+  }
+
+  /** Atomically stores [token] unless the cache already contains a fresher token. */
+  internal fun storeIfFresher(
+    cacheKey: String,
+    token: TokenResource,
+    nowMillis: Long = System.currentTimeMillis(),
+  ): StoreResult {
+    var didChangeCanonicalToken = false
+    val canonicalToken =
+      checkNotNull(
+        cache.compute(cacheKey) { _, existing ->
+          TokenFreshness.pickFreshest(existing, token, nowMillis).also { canonical ->
+            didChangeCanonicalToken = existing?.jwt != canonical.jwt
+          }
+        }
+      )
+    return StoreResult(canonicalToken, didChangeCanonicalToken)
   }
 
   /** Removes a session token for the given cache key. */

--- a/source/api/src/main/kotlin/com/clerk/api/session/TokenFreshness.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/TokenFreshness.kt
@@ -35,15 +35,11 @@ internal object TokenFreshness {
     }
   }
 
-  internal fun matches(
-    token: TokenResource,
-    sessionId: String,
-    organizationId: String?,
-  ): Boolean {
+  internal fun matches(token: TokenResource, sessionId: String, organizationId: String?): Boolean {
     val jwt = decode(token.jwt)
     val tokenSessionId = jwt?.getClaim("sid")?.asString()
     return if (jwt == null || tokenSessionId == null) {
-      true
+      false
     } else {
       tokenSessionId == sessionId && jwt.organizationId().orEmpty() == organizationId.orEmpty()
     }

--- a/source/api/src/main/kotlin/com/clerk/api/session/TokenFreshness.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/TokenFreshness.kt
@@ -1,0 +1,128 @@
+package com.clerk.api.session
+
+import com.auth0.android.jwt.JWT
+import com.clerk.api.network.model.token.TokenResource
+
+/** Chooses the canonical token when session minter responses arrive out of order. */
+internal object TokenFreshness {
+  private data class DecodedToken(val resource: TokenResource, val jwt: JWT)
+
+  internal enum class TieBreaker {
+    EXISTING,
+    INCOMING,
+  }
+
+  internal fun pickFreshest(
+    existing: TokenResource?,
+    incoming: TokenResource,
+    nowMillis: Long = System.currentTimeMillis(),
+    tieBreaker: TieBreaker = TieBreaker.INCOMING,
+  ): TokenResource {
+    existing ?: return incoming
+
+    val existingJwt = decode(existing.jwt)
+    val incomingJwt = decode(incoming.jwt)
+    return when {
+      existingJwt != null && incomingJwt != null ->
+        pickFreshestDecoded(
+          existing = DecodedToken(existing, existingJwt),
+          incoming = DecodedToken(incoming, incomingJwt),
+          nowMillis = nowMillis,
+          tieBreaker = tieBreaker,
+        )
+      existingJwt != null -> existing
+      else -> incoming
+    }
+  }
+
+  internal fun matches(
+    token: TokenResource,
+    sessionId: String,
+    organizationId: String?,
+  ): Boolean {
+    val jwt = decode(token.jwt)
+    val tokenSessionId = jwt?.getClaim("sid")?.asString()
+    return if (jwt == null || tokenSessionId == null) {
+      true
+    } else {
+      tokenSessionId == sessionId && jwt.organizationId().orEmpty() == organizationId.orEmpty()
+    }
+  }
+
+  private fun pickFreshestDecoded(
+    existing: DecodedToken,
+    incoming: DecodedToken,
+    nowMillis: Long,
+    tieBreaker: TieBreaker,
+  ): TokenResource =
+    if (!haveMatchingContext(existing.jwt, incoming.jwt)) {
+      incoming.resource
+    } else {
+      pickByExpiration(existing, incoming, nowMillis)
+        ?: pickByOriginIssuedAt(existing, incoming, tieBreaker)
+    }
+
+  private fun haveMatchingContext(existing: JWT, incoming: JWT): Boolean =
+    existing.getClaim("sid").asString() == incoming.getClaim("sid").asString() &&
+      existing.organizationId().orEmpty() == incoming.organizationId().orEmpty()
+
+  private fun pickByExpiration(
+    existing: DecodedToken,
+    incoming: DecodedToken,
+    nowMillis: Long,
+  ): TokenResource? {
+    val existingIsExpired = existing.jwt.expiresAt?.time?.let { it <= nowMillis }
+    val incomingIsExpired = incoming.jwt.expiresAt?.time?.let { it <= nowMillis }
+    return when {
+      existingIsExpired == true && incomingIsExpired == false -> incoming.resource
+      existingIsExpired == false && incomingIsExpired == true -> existing.resource
+      else -> null
+    }
+  }
+
+  private fun pickByOriginIssuedAt(
+    existing: DecodedToken,
+    incoming: DecodedToken,
+    tieBreaker: TieBreaker,
+  ): TokenResource {
+    val existingOriginIssuedAt = existing.jwt.originIssuedAt()
+    val incomingOriginIssuedAt = incoming.jwt.originIssuedAt()
+    return when {
+      existingOriginIssuedAt == null && incomingOriginIssuedAt == null ->
+        pickByIssuedAt(existing, incoming, tieBreaker)
+      existingOriginIssuedAt != null && incomingOriginIssuedAt == null -> existing.resource
+      existingOriginIssuedAt == null -> incoming.resource
+      existingOriginIssuedAt > checkNotNull(incomingOriginIssuedAt) -> existing.resource
+      incomingOriginIssuedAt > existingOriginIssuedAt -> incoming.resource
+      else -> pickByIssuedAt(existing, incoming, tieBreaker)
+    }
+  }
+
+  private fun pickByIssuedAt(
+    existing: DecodedToken,
+    incoming: DecodedToken,
+    tieBreaker: TieBreaker,
+  ): TokenResource {
+    val existingIssuedAt = existing.jwt.issuedAt?.time ?: 0
+    val incomingIssuedAt = incoming.jwt.issuedAt?.time ?: 0
+    return when {
+      existingIssuedAt > incomingIssuedAt -> existing.resource
+      incomingIssuedAt > existingIssuedAt -> incoming.resource
+      tieBreaker == TieBreaker.EXISTING -> existing.resource
+      else -> incoming.resource
+    }
+  }
+
+  private fun decode(token: String): JWT? =
+    try {
+      JWT(token)
+    } catch (_: Exception) {
+      null
+    }
+
+  private fun JWT.originIssuedAt(): Long? = header["oiat"]?.toLongOrNull()
+
+  private fun JWT.organizationId(): String? =
+    getClaim("org_id").asString()
+      ?: runCatching { getClaim("o").asObject(Map::class.java)?.get("id") as? String }.getOrNull()
+}

--- a/source/api/src/test/java/com/clerk/api/network/model/environment/AuthConfigTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/model/environment/AuthConfigTest.kt
@@ -1,0 +1,23 @@
+package com.clerk.api.network.model.environment
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AuthConfigTest {
+  @Test
+  fun `decodes session minter flag`() {
+    val authConfig =
+      Json.decodeFromString<AuthConfig>("""{"single_session_mode":false,"session_minter":true}""")
+
+    assertTrue(authConfig.sessionMinter)
+  }
+
+  @Test
+  fun `defaults session minter to false when omitted`() {
+    val authConfig = Json.decodeFromString<AuthConfig>("""{"single_session_mode":false}""")
+
+    assertFalse(authConfig.sessionMinter)
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
@@ -4,6 +4,7 @@ import com.auth0.android.jwt.JWT
 import com.clerk.api.Clerk
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.api.SessionApi
+import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.environment.AuthConfig
 import com.clerk.api.network.model.environment.Environment
 import com.clerk.api.network.model.error.ClerkErrorResponse
@@ -24,8 +25,10 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -80,6 +83,7 @@ class SessionTokenFetcherTest {
   @After
   fun tearDown() {
     unmockkAll()
+    SessionTokensCache.clear()
   }
 
   @Test
@@ -393,6 +397,33 @@ class SessionTokenFetcherTest {
   }
 
   @Test
+  fun `concurrent waiters share a null token result without retrying`() = runTest {
+    // Given
+    val requestStarted = CompletableDeferred<Unit>()
+    val releaseRequest = CompletableDeferred<Unit>()
+    val errorResponse = ClerkErrorResponse(errors = emptyList(), clerkTraceId = "trace_shared")
+    coEvery { SessionTokensCache.getToken(any()) } returns null
+    coEvery { mockClerkApiService.tokens("session_123") } coAnswers
+      {
+        requestStarted.complete(Unit)
+        releaseRequest.await()
+        ClerkResult.apiFailure(errorResponse)
+      }
+
+    // When
+    val first = async { sessionTokenFetcher.getToken(mockSession) }
+    requestStarted.await()
+    val second = async { sessionTokenFetcher.getToken(mockSession) }
+    yield()
+    releaseRequest.complete(Unit)
+
+    // Then
+    assertNull(first.await())
+    assertNull(second.await())
+    coVerify(exactly = 1) { mockClerkApiService.tokens("session_123") }
+  }
+
+  @Test
   fun `forced refreshes return their own responses while cache retains canonical token`() =
     runTest {
       // Given
@@ -555,6 +586,44 @@ class SessionTokenFetcherTest {
     assertNull(result)
     coVerify(exactly = 0) { SessionTokensCache.getToken(any()) }
     coVerify(exactly = 0) { mockClerkApiService.tokens(any()) }
+  }
+
+  @Test
+  fun `getToken uses pending status from current client snapshot`() = runTest {
+    // Given - the caller holds a stale active session while the current snapshot is pending
+    val pendingSession = mockk<Session>(relaxed = true)
+    every { pendingSession.id } returns "session_123"
+    every { pendingSession.status } returns Session.SessionStatus.PENDING
+    every { Clerk.clientFlow } returns MutableStateFlow(Client(sessions = listOf(pendingSession)))
+
+    // When
+    val result = sessionTokenFetcher.getToken(mockSession)
+
+    // Then
+    assertNull(result)
+    coVerify(exactly = 0) { mockClerkApiService.tokens(any()) }
+  }
+
+  @Test
+  fun `getToken uses active status from current client snapshot`() = runTest {
+    // Given - the caller holds a stale pending session while the current snapshot is active
+    val activeSession = mockk<Session>(relaxed = true)
+    every { mockSession.status } returns Session.SessionStatus.PENDING
+    every { activeSession.id } returns "session_123"
+    every { activeSession.status } returns Session.SessionStatus.ACTIVE
+    every { Clerk.clientFlow } returns MutableStateFlow(Client(sessions = listOf(activeSession)))
+    coEvery { SessionTokensCache.getToken(any()) } returns null
+    coEvery { mockClerkApiService.tokens("session_123") } returns
+      ClerkResult.success(mockTokenResource)
+    coEvery { SessionTokensCache.storeIfFresher(any(), mockTokenResource, any()) } returns
+      SessionTokensCache.StoreResult(mockTokenResource, true)
+
+    // When
+    val result = sessionTokenFetcher.getToken(mockSession)
+
+    // Then
+    assertEquals(mockTokenResource, result)
+    coVerify(exactly = 1) { mockClerkApiService.tokens("session_123") }
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
@@ -21,9 +21,11 @@ import io.mockk.verify
 import java.util.Date
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -211,9 +213,8 @@ class SessionTokenFetcherTest {
         forceOrigin = "true",
       )
     } returns ClerkResult.success(mockTokenResource)
-    every {
-      SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any())
-    } returns SessionTokensCache.StoreResult(mockTokenResource, true)
+    every { SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any()) } returns
+      SessionTokensCache.StoreResult(mockTokenResource, true)
 
     // When
     val result = sessionTokenFetcher.getToken(mockSession, GetTokenOptions(skipCache = true))
@@ -392,46 +393,79 @@ class SessionTokenFetcherTest {
   }
 
   @Test
-  fun `forced refreshes are not deduplicated`() = runTest {
+  fun `forced refreshes return their own responses while cache retains canonical token`() =
+    runTest {
+      // Given
+      val cacheKey = "session_123-organization-"
+      val firstCallStarted = CompletableDeferred<Unit>()
+      val releaseFirstCall = CompletableDeferred<Unit>()
+      val callCount = AtomicInteger()
+      val secondToken = mockk<TokenResource>(relaxed = true)
+      coEvery { SessionTokensCache.getToken(cacheKey) } returns null
+      coEvery { mockClerkApiService.tokens("session_123") } coAnswers
+        {
+          if (callCount.getAndIncrement() == 0) {
+            firstCallStarted.complete(Unit)
+            releaseFirstCall.await()
+            ClerkResult.success(mockTokenResource)
+          } else {
+            ClerkResult.success(secondToken)
+          }
+        }
+      coEvery { SessionTokensCache.storeIfFresher(cacheKey, any(), any()) } answers
+        {
+          val token = secondArg<TokenResource>()
+          if (token === secondToken) {
+            SessionTokensCache.StoreResult(secondToken, true)
+          } else {
+            SessionTokensCache.StoreResult(secondToken, false)
+          }
+        }
+
+      // When
+      val first = async {
+        sessionTokenFetcher.getToken(mockSession, GetTokenOptions(skipCache = true))
+      }
+      firstCallStarted.await()
+      val second = async {
+        sessionTokenFetcher.getToken(mockSession, GetTokenOptions(skipCache = true))
+      }
+      val secondResult = second.await()
+      releaseFirstCall.complete(Unit)
+      val firstResult = first.await()
+
+      // Then - each forced request returns its own mint for JS parity, even when the cache rejects
+      // the first request's late response as stale.
+      assertEquals(mockTokenResource, firstResult)
+      assertEquals(secondToken, secondResult)
+      coVerify(exactly = 2) { mockClerkApiService.tokens("session_123") }
+    }
+
+  @Test
+  fun `reset fences a late forced refresh response from the previous runtime`() = runTest {
     // Given
-    val cacheKey = "session_123-organization-"
-    val firstCallStarted = CompletableDeferred<Unit>()
-    val releaseFirstCall = CompletableDeferred<Unit>()
-    val callCount = AtomicInteger()
-    val secondToken = mockk<TokenResource>(relaxed = true)
-    coEvery { SessionTokensCache.getToken(cacheKey) } returns null
+    val requestStarted = CompletableDeferred<Unit>()
+    val releaseResponse = CompletableDeferred<Unit>()
+    coEvery { SessionTokensCache.getToken(any()) } returns null
     coEvery { mockClerkApiService.tokens("session_123") } coAnswers
       {
-        if (callCount.getAndIncrement() == 0) {
-          firstCallStarted.complete(Unit)
-          releaseFirstCall.await()
-          ClerkResult.success(mockTokenResource)
-        } else {
-          ClerkResult.success(secondToken)
-        }
+        requestStarted.complete(Unit)
+        withContext(NonCancellable) { releaseResponse.await() }
+        ClerkResult.success(mockTokenResource)
       }
-    coEvery { SessionTokensCache.storeIfFresher(cacheKey, any(), any()) } answers
-      {
-        val token = secondArg<TokenResource>()
-        SessionTokensCache.StoreResult(token, true)
-      }
+
+    val request = async {
+      sessionTokenFetcher.getToken(mockSession, GetTokenOptions(skipCache = true))
+    }
+    requestStarted.await()
 
     // When
-    val first = async {
-      sessionTokenFetcher.getToken(mockSession, GetTokenOptions(skipCache = true))
-    }
-    firstCallStarted.await()
-    val second = async {
-      sessionTokenFetcher.getToken(mockSession, GetTokenOptions(skipCache = true))
-    }
-    val secondResult = second.await()
-    releaseFirstCall.complete(Unit)
-    val firstResult = first.await()
+    sessionTokenFetcher.reset()
+    releaseResponse.complete(Unit)
 
     // Then
-    assertEquals(mockTokenResource, firstResult)
-    assertEquals(secondToken, secondResult)
-    coVerify(exactly = 2) { mockClerkApiService.tokens("session_123") }
+    assertNull(request.await())
+    coVerify(exactly = 0) { SessionTokensCache.storeIfFresher(any(), any(), any()) }
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
@@ -4,6 +4,8 @@ import com.auth0.android.jwt.JWT
 import com.clerk.api.Clerk
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.api.SessionApi
+import com.clerk.api.network.model.environment.AuthConfig
+import com.clerk.api.network.model.environment.Environment
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.model.token.TokenResource
@@ -17,6 +19,8 @@ import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.util.Date
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
@@ -67,6 +71,7 @@ class SessionTokenFetcherTest {
     every { Clerk.clearSessionAndUserState() } returns Unit
 
     // Mock SessionTokensCache
+    SessionTokensCache.clear()
     mockkObject(SessionTokensCache)
   }
 
@@ -78,7 +83,7 @@ class SessionTokenFetcherTest {
   @Test
   fun `getToken returns cached token if valid and cache not skipped`() = runTest {
     // Given
-    val cacheKey = "session_123"
+    val cacheKey = "session_123-organization-"
     val futureTime = Date(System.currentTimeMillis() + 120000) // 2 minutes from now
 
     every { mockTokenResource.jwt } returns "valid.jwt.token"
@@ -97,13 +102,14 @@ class SessionTokenFetcherTest {
   @Test
   fun `getToken fetches from network if cache is empty`() = runTest {
     // Given
-    val cacheKey = "session_123"
+    val cacheKey = "session_123-organization-"
     val setTokenSlot = slot<TokenResource>()
 
     coEvery { SessionTokensCache.getToken(cacheKey) } returns null
     coEvery { mockClerkApiService.tokens("session_123") } returns
       ClerkResult.success(mockTokenResource)
-    coEvery { SessionTokensCache.setToken(cacheKey, capture(setTokenSlot)) } returns Unit
+    coEvery { SessionTokensCache.storeIfFresher(cacheKey, capture(setTokenSlot), any()) } returns
+      SessionTokensCache.StoreResult(mockTokenResource, true)
 
     // When
     val result = sessionTokenFetcher.getToken(mockSession)
@@ -112,14 +118,14 @@ class SessionTokenFetcherTest {
     assertEquals(mockTokenResource, result)
     coVerify { SessionTokensCache.getToken(cacheKey) }
     coVerify { mockClerkApiService.tokens("session_123") }
-    coVerify { SessionTokensCache.setToken(cacheKey, mockTokenResource) }
+    coVerify { SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any()) }
     assertEquals(mockTokenResource, setTokenSlot.captured)
   }
 
   @Test
   fun `getToken fetches from network if cached token is expired`() = runTest {
     // Given
-    val cacheKey = "session_123"
+    val cacheKey = "session_123-organization-"
     val pastTime = Date(System.currentTimeMillis() - 60000) // 1 minute ago
     val freshToken = mockk<TokenResource>(relaxed = true)
 
@@ -127,7 +133,8 @@ class SessionTokenFetcherTest {
     every { mockJWT.expiresAt } returns pastTime
     coEvery { SessionTokensCache.getToken(cacheKey) } returns mockTokenResource
     coEvery { mockClerkApiService.tokens("session_123") } returns ClerkResult.success(freshToken)
-    coEvery { SessionTokensCache.setToken(cacheKey, freshToken) } returns Unit
+    coEvery { SessionTokensCache.storeIfFresher(cacheKey, freshToken, any()) } returns
+      SessionTokensCache.StoreResult(freshToken, true)
 
     // When
     val result = sessionTokenFetcher.getToken(mockSession)
@@ -136,20 +143,21 @@ class SessionTokenFetcherTest {
     assertEquals(freshToken, result)
     coVerify { SessionTokensCache.getToken(cacheKey) }
     coVerify { mockClerkApiService.tokens("session_123") }
-    coVerify { SessionTokensCache.setToken(cacheKey, freshToken) }
+    coVerify { SessionTokensCache.storeIfFresher(cacheKey, freshToken, any()) }
   }
 
   @Test
   fun `getToken uses template in API call when provided`() = runTest {
     // Given
     val template = "custom_template"
-    val cacheKey = "session_123-custom_template"
+    val cacheKey = "session_123-template-custom_template"
     val options = GetTokenOptions(template = template)
 
     coEvery { SessionTokensCache.getToken(cacheKey) } returns null
     coEvery { mockClerkApiService.tokens("session_123", template) } returns
       ClerkResult.success(mockTokenResource)
-    coEvery { SessionTokensCache.setToken(cacheKey, mockTokenResource) } returns Unit
+    coEvery { SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any()) } returns
+      SessionTokensCache.StoreResult(mockTokenResource, true)
 
     // When
     val result = sessionTokenFetcher.getToken(mockSession, options)
@@ -157,27 +165,69 @@ class SessionTokenFetcherTest {
     // Then
     assertEquals(mockTokenResource, result)
     coVerify { mockClerkApiService.tokens("session_123", template) }
-    coVerify { SessionTokensCache.setToken(cacheKey, mockTokenResource) }
+    coVerify { SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any()) }
   }
 
   @Test
-  fun `getToken skips cache when skipCache is true`() = runTest {
+  fun `getToken bypasses cached result when skipCache is true`() = runTest {
     // Given
     val options = GetTokenOptions(skipCache = true)
-    val cacheKey = "session_123"
+    val cacheKey = "session_123-organization-"
 
+    coEvery { SessionTokensCache.getToken(cacheKey) } returns null
     coEvery { mockClerkApiService.tokens("session_123") } returns
       ClerkResult.success(mockTokenResource)
-    coEvery { SessionTokensCache.setToken(cacheKey, mockTokenResource) } returns Unit
+    coEvery { SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any()) } returns
+      SessionTokensCache.StoreResult(mockTokenResource, true)
 
     // When
     val result = sessionTokenFetcher.getToken(mockSession, options)
 
     // Then
     assertEquals(mockTokenResource, result)
-    coVerify(exactly = 0) { SessionTokensCache.getToken(any()) }
+    coVerify { SessionTokensCache.getToken(cacheKey) }
     coVerify { mockClerkApiService.tokens("session_123") }
-    coVerify { SessionTokensCache.setToken(cacheKey, mockTokenResource) }
+    coVerify { SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any()) }
+  }
+
+  @Test
+  fun `session minter passes previous token and forces origin for forced refresh`() = runTest {
+    // Given
+    val cacheKey = "session_123-organization-org_123"
+    val previousToken = TokenResource("previous.token.value")
+    val environment = mockk<Environment>()
+    every { environment.authConfig } returns
+      AuthConfig(singleSessionMode = false, sessionMinter = true)
+    every { Clerk.environment } returns environment
+    every { mockSession.lastActiveOrganizationId } returns "org_123"
+    every { mockSession.lastActiveToken } returns previousToken
+    every { SessionTokensCache.hydrate(cacheKey, previousToken) } returns Unit
+    every { SessionTokensCache.getToken(cacheKey) } returns null
+    coEvery {
+      mockClerkApiService.tokens(
+        sessionId = "session_123",
+        organizationId = "org_123",
+        token = previousToken.jwt,
+        forceOrigin = "true",
+      )
+    } returns ClerkResult.success(mockTokenResource)
+    every {
+      SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any())
+    } returns SessionTokensCache.StoreResult(mockTokenResource, true)
+
+    // When
+    val result = sessionTokenFetcher.getToken(mockSession, GetTokenOptions(skipCache = true))
+
+    // Then
+    assertEquals(mockTokenResource, result)
+    coVerify {
+      mockClerkApiService.tokens(
+        sessionId = "session_123",
+        organizationId = "org_123",
+        token = previousToken.jwt,
+        forceOrigin = "true",
+      )
+    }
   }
 
   @Test
@@ -201,7 +251,7 @@ class SessionTokenFetcherTest {
     // Then
     assertNull(result)
     coVerify { mockClerkApiService.tokens("session_123") }
-    coVerify(exactly = 0) { SessionTokensCache.setToken(any(), any()) }
+    coVerify(exactly = 0) { SessionTokensCache.storeIfFresher(any(), any(), any()) }
     verify(exactly = 0) { Clerk.clearSessionAndUserState() }
   }
 
@@ -266,7 +316,7 @@ class SessionTokenFetcherTest {
     // Given
     val customBuffer = 120L // 2 minutes
     val options = GetTokenOptions(expirationBuffer = customBuffer)
-    val cacheKey = "session_123"
+    val cacheKey = "session_123-organization-"
     // Token expires in 90 seconds (less than 2-minute buffer)
     val soonExpiredTime = Date(System.currentTimeMillis() + 90000)
 
@@ -275,7 +325,8 @@ class SessionTokenFetcherTest {
     coEvery { SessionTokensCache.getToken(cacheKey) } returns mockTokenResource
     coEvery { mockClerkApiService.tokens("session_123") } returns
       ClerkResult.success(mockTokenResource)
-    coEvery { SessionTokensCache.setToken(cacheKey, mockTokenResource) } returns Unit
+    coEvery { SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any()) } returns
+      SessionTokensCache.StoreResult(mockTokenResource, true)
 
     // When
     val result = sessionTokenFetcher.getToken(mockSession, options)
@@ -289,14 +340,15 @@ class SessionTokenFetcherTest {
   @Test
   fun `getToken handles JWT parsing exception gracefully`() = runTest {
     // Given
-    val cacheKey = "session_123"
+    val cacheKey = "session_123-organization-"
 
     every { mockTokenResource.jwt } returns "invalid.jwt.token"
     every { mockJWTManager.createFromString(any()) } throws RuntimeException("Invalid JWT")
     coEvery { SessionTokensCache.getToken(cacheKey) } returns mockTokenResource
     coEvery { mockClerkApiService.tokens("session_123") } returns
       ClerkResult.success(mockTokenResource)
-    coEvery { SessionTokensCache.setToken(cacheKey, mockTokenResource) } returns Unit
+    coEvery { SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any()) } returns
+      SessionTokensCache.StoreResult(mockTokenResource, true)
 
     // When
     val result = sessionTokenFetcher.getToken(mockSession)
@@ -310,7 +362,7 @@ class SessionTokenFetcherTest {
   @Test
   fun `getToken handles concurrent requests properly`() = runTest {
     // Given
-    val cacheKey = "session_123"
+    val cacheKey = "session_123-organization-"
 
     coEvery { SessionTokensCache.getToken(cacheKey) } returns null
     coEvery { mockClerkApiService.tokens("session_123") } coAnswers
@@ -318,7 +370,8 @@ class SessionTokenFetcherTest {
         delay(100) // Simulate network delay
         ClerkResult.success(mockTokenResource)
       }
-    coEvery { SessionTokensCache.setToken(cacheKey, mockTokenResource) } returns Unit
+    coEvery { SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any()) } returns
+      SessionTokensCache.StoreResult(mockTokenResource, true)
 
     // When - Launch multiple concurrent requests
     val deferred1 = async { sessionTokenFetcher.getToken(mockSession) }
@@ -339,6 +392,49 @@ class SessionTokenFetcherTest {
   }
 
   @Test
+  fun `forced refreshes are not deduplicated`() = runTest {
+    // Given
+    val cacheKey = "session_123-organization-"
+    val firstCallStarted = CompletableDeferred<Unit>()
+    val releaseFirstCall = CompletableDeferred<Unit>()
+    val callCount = AtomicInteger()
+    val secondToken = mockk<TokenResource>(relaxed = true)
+    coEvery { SessionTokensCache.getToken(cacheKey) } returns null
+    coEvery { mockClerkApiService.tokens("session_123") } coAnswers
+      {
+        if (callCount.getAndIncrement() == 0) {
+          firstCallStarted.complete(Unit)
+          releaseFirstCall.await()
+          ClerkResult.success(mockTokenResource)
+        } else {
+          ClerkResult.success(secondToken)
+        }
+      }
+    coEvery { SessionTokensCache.storeIfFresher(cacheKey, any(), any()) } answers
+      {
+        val token = secondArg<TokenResource>()
+        SessionTokensCache.StoreResult(token, true)
+      }
+
+    // When
+    val first = async {
+      sessionTokenFetcher.getToken(mockSession, GetTokenOptions(skipCache = true))
+    }
+    firstCallStarted.await()
+    val second = async {
+      sessionTokenFetcher.getToken(mockSession, GetTokenOptions(skipCache = true))
+    }
+    val secondResult = second.await()
+    releaseFirstCall.complete(Unit)
+    val firstResult = first.await()
+
+    // Then
+    assertEquals(mockTokenResource, firstResult)
+    assertEquals(secondToken, secondResult)
+    coVerify(exactly = 2) { mockClerkApiService.tokens("session_123") }
+  }
+
+  @Test
   fun `getToken handles API exception gracefully`() = runTest {
     // Given
     coEvery { SessionTokensCache.getToken(any()) } returns null
@@ -350,7 +446,7 @@ class SessionTokenFetcherTest {
     // Then
     assertNull(result)
     coVerify { mockClerkApiService.tokens("session_123") }
-    coVerify(exactly = 0) { SessionTokensCache.setToken(any(), any()) }
+    coVerify(exactly = 0) { SessionTokensCache.storeIfFresher(any(), any(), any()) }
   }
 
   @Test
@@ -362,7 +458,7 @@ class SessionTokenFetcherTest {
     val cacheKey = mockSession.tokenCacheKey(null)
 
     // Then
-    assertEquals("session_456", cacheKey)
+    assertEquals("session_456-organization-", cacheKey)
   }
 
   @Test
@@ -375,7 +471,7 @@ class SessionTokenFetcherTest {
     val cacheKey = mockSession.tokenCacheKey(template)
 
     // Then
-    assertEquals("session_456-admin_template", cacheKey)
+    assertEquals("session_456-template-admin_template", cacheKey)
   }
 
   @Test
@@ -386,13 +482,17 @@ class SessionTokenFetcherTest {
     every { session1.id } returns "session_1"
     every { session2.id } returns "session_2"
 
-    coEvery { SessionTokensCache.getToken("session_1") } returns null
-    coEvery { SessionTokensCache.getToken("session_2") } returns null
+    coEvery { SessionTokensCache.getToken("session_1-organization-") } returns null
+    coEvery { SessionTokensCache.getToken("session_2-organization-") } returns null
     coEvery { mockClerkApiService.tokens("session_1") } returns
       ClerkResult.success(mockTokenResource)
     coEvery { mockClerkApiService.tokens("session_2") } returns
       ClerkResult.success(mockTokenResource)
-    coEvery { SessionTokensCache.setToken(any(), any()) } returns Unit
+    coEvery { SessionTokensCache.storeIfFresher(any(), any(), any()) } answers
+      {
+        val token = secondArg<TokenResource>()
+        SessionTokensCache.StoreResult(token, true)
+      }
 
     // When
     sessionTokenFetcher.getToken(session1)
@@ -401,8 +501,12 @@ class SessionTokenFetcherTest {
     // Then
     coVerify { mockClerkApiService.tokens("session_1") }
     coVerify { mockClerkApiService.tokens("session_2") }
-    coVerify { SessionTokensCache.setToken("session_1", mockTokenResource) }
-    coVerify { SessionTokensCache.setToken("session_2", mockTokenResource) }
+    coVerify {
+      SessionTokensCache.storeIfFresher("session_1-organization-", mockTokenResource, any())
+    }
+    coVerify {
+      SessionTokensCache.storeIfFresher("session_2-organization-", mockTokenResource, any())
+    }
   }
 
   @Test
@@ -422,13 +526,14 @@ class SessionTokenFetcherTest {
   @Test
   fun `getToken proceeds normally for active session`() = runTest {
     // Given - a session with ACTIVE status
-    val cacheKey = "session_123"
+    val cacheKey = "session_123-organization-"
 
     every { mockSession.status } returns Session.SessionStatus.ACTIVE
     coEvery { SessionTokensCache.getToken(cacheKey) } returns null
     coEvery { mockClerkApiService.tokens("session_123") } returns
       ClerkResult.success(mockTokenResource)
-    coEvery { SessionTokensCache.setToken(cacheKey, mockTokenResource) } returns Unit
+    coEvery { SessionTokensCache.storeIfFresher(cacheKey, mockTokenResource, any()) } returns
+      SessionTokensCache.StoreResult(mockTokenResource, true)
 
     // When
     val result = sessionTokenFetcher.getToken(mockSession)

--- a/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/SessionTokenFetcherTest.kt
@@ -500,6 +500,34 @@ class SessionTokenFetcherTest {
   }
 
   @Test
+  fun `reset releases shared token waiters with null`() = runTest {
+    // Given
+    val requestStarted = CompletableDeferred<Unit>()
+    val releaseResponse = CompletableDeferred<Unit>()
+    coEvery { SessionTokensCache.getToken(any()) } returns null
+    coEvery { mockClerkApiService.tokens("session_123") } coAnswers
+      {
+        requestStarted.complete(Unit)
+        withContext(NonCancellable) { releaseResponse.await() }
+        ClerkResult.success(mockTokenResource)
+      }
+
+    val owner = async { sessionTokenFetcher.getToken(mockSession) }
+    requestStarted.await()
+    val waiter = async { sessionTokenFetcher.getToken(mockSession) }
+    yield()
+
+    // When
+    sessionTokenFetcher.reset()
+
+    // Then
+    assertNull(waiter.await())
+    releaseResponse.complete(Unit)
+    assertNull(owner.await())
+    coVerify(exactly = 0) { SessionTokensCache.storeIfFresher(any(), any(), any()) }
+  }
+
+  @Test
   fun `getToken handles API exception gracefully`() = runTest {
     // Given
     coEvery { SessionTokensCache.getToken(any()) } returns null

--- a/source/api/src/test/java/com/clerk/api/session/TokenFreshnessTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/TokenFreshnessTest.kt
@@ -72,6 +72,18 @@ class TokenFreshnessTest {
   }
 
   @Test
+  fun `malformed token does not match session context`() {
+    assertFalse(TokenFreshness.matches(TokenResource("malformed"), "session", null))
+  }
+
+  @Test
+  fun `token without session id does not match session context`() {
+    val token = token(sessionId = null, originIssuedAt = 100, issuedAt = 100)
+
+    assertFalse(TokenFreshness.matches(token, "session", null))
+  }
+
+  @Test
   fun `cache cannot be rolled back by a stale response`() {
     val cacheKey = "session-organization-"
     val stale = token(originIssuedAt = 100, issuedAt = 100, signature = "stale")
@@ -118,7 +130,7 @@ class TokenFreshnessTest {
   }
 
   private fun token(
-    sessionId: String = "session",
+    sessionId: String? = "session",
     organizationId: String? = null,
     originIssuedAt: Long?,
     issuedAt: Long,
@@ -134,7 +146,7 @@ class TokenFreshnessTest {
         .joinToString(",")
     val payloadClaims =
       buildList {
-          add("\"sid\":\"$sessionId\"")
+          sessionId?.let { add("\"sid\":\"$it\"") }
           add("\"iat\":$issuedAt")
           add("\"exp\":$expiresAt")
           organizationId?.let { add("\"org_id\":\"$it\"") }

--- a/source/api/src/test/java/com/clerk/api/session/TokenFreshnessTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/TokenFreshnessTest.kt
@@ -1,0 +1,150 @@
+package com.clerk.api.session
+
+import com.clerk.api.network.model.token.TokenResource
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TokenFreshnessTest {
+  @After
+  fun tearDown() {
+    SessionTokensCache.clear()
+  }
+
+  @Test
+  fun `keeps token with higher origin issued at`() {
+    val existing = token(originIssuedAt = 200, issuedAt = 200)
+    val incoming = token(originIssuedAt = 100, issuedAt = 300)
+
+    val result = TokenFreshness.pickFreshest(existing, incoming)
+
+    assertEquals(existing, result)
+  }
+
+  @Test
+  fun `uses issued at to break equal origin issued at`() {
+    val existing = token(originIssuedAt = 200, issuedAt = 300)
+    val incoming = token(originIssuedAt = 200, issuedAt = 400)
+
+    val result = TokenFreshness.pickFreshest(existing, incoming)
+
+    assertEquals(incoming, result)
+  }
+
+  @Test
+  fun `replaces an expired existing token`() {
+    val existing = token(originIssuedAt = 300, issuedAt = 300, expiresAt = 900)
+    val incoming = token(originIssuedAt = 100, issuedAt = 100, expiresAt = 2_000)
+
+    val result = TokenFreshness.pickFreshest(existing, incoming, nowMillis = 1_000_000)
+
+    assertEquals(incoming, result)
+  }
+
+  @Test
+  fun `accepts incoming token when organization changes`() {
+    val existing = token(organizationId = "org_one", originIssuedAt = 300, issuedAt = 300)
+    val incoming = token(organizationId = "org_two", originIssuedAt = 100, issuedAt = 100)
+
+    val result = TokenFreshness.pickFreshest(existing, incoming)
+
+    assertEquals(incoming, result)
+  }
+
+  @Test
+  fun `keeps decodable existing token when incoming cannot be decoded`() {
+    val existing = token(originIssuedAt = 100, issuedAt = 100)
+    val incoming = TokenResource("malformed")
+
+    val result = TokenFreshness.pickFreshest(existing, incoming)
+
+    assertEquals(existing, result)
+  }
+
+  @Test
+  fun `cache cannot be rolled back by a stale response`() {
+    val cacheKey = "session-organization-"
+    val stale = token(originIssuedAt = 100, issuedAt = 100, signature = "stale")
+    val fresh = token(originIssuedAt = 200, issuedAt = 200, signature = "fresh")
+
+    val firstStore = SessionTokensCache.storeIfFresher(cacheKey, fresh)
+    val staleStore = SessionTokensCache.storeIfFresher(cacheKey, stale)
+    val duplicateStore = SessionTokensCache.storeIfFresher(cacheKey, fresh)
+
+    assertTrue(firstStore.didChangeCanonicalToken)
+    assertFalse(staleStore.didChangeCanonicalToken)
+    assertFalse(duplicateStore.didChangeCanonicalToken)
+    assertEquals(fresh, SessionTokensCache.getToken(cacheKey))
+  }
+
+  @Test
+  fun `out of order cache writes retain the freshest response`() = runTest {
+    val cacheKey = "session-organization-"
+    val stale = token(originIssuedAt = 100, issuedAt = 100, signature = "stale")
+    val fresh = token(originIssuedAt = 200, issuedAt = 200, signature = "fresh")
+    val releaseStaleResponse = CompletableDeferred<Unit>()
+    val staleResponse = async {
+      releaseStaleResponse.await()
+      SessionTokensCache.storeIfFresher(cacheKey, stale)
+    }
+
+    SessionTokensCache.storeIfFresher(cacheKey, fresh)
+    releaseStaleResponse.complete(Unit)
+    staleResponse.await()
+
+    assertEquals(fresh, SessionTokensCache.getToken(cacheKey))
+  }
+
+  @Test
+  fun `hydration preserves canonical token on a timestamp tie`() {
+    val cacheKey = "session-organization-"
+    val canonical = token(originIssuedAt = 100, issuedAt = 100, signature = "canonical")
+    val snapshot = token(originIssuedAt = 100, issuedAt = 100, signature = "snapshot")
+    SessionTokensCache.setToken(cacheKey, canonical)
+
+    SessionTokensCache.hydrate(cacheKey, snapshot)
+
+    assertEquals(canonical, SessionTokensCache.getToken(cacheKey))
+  }
+
+  private fun token(
+    sessionId: String = "session",
+    organizationId: String? = null,
+    originIssuedAt: Long?,
+    issuedAt: Long,
+    expiresAt: Long = 4_000_000_000,
+    signature: String = "signature",
+  ): TokenResource {
+    val headerClaims =
+      buildList {
+          add("\"alg\":\"none\"")
+          add("\"typ\":\"JWT\"")
+          originIssuedAt?.let { add("\"oiat\":$it") }
+        }
+        .joinToString(",")
+    val payloadClaims =
+      buildList {
+          add("\"sid\":\"$sessionId\"")
+          add("\"iat\":$issuedAt")
+          add("\"exp\":$expiresAt")
+          organizationId?.let { add("\"org_id\":\"$it\"") }
+        }
+        .joinToString(",")
+    return TokenResource("${encode("{$headerClaims}")}.${encode("{$payloadClaims}")}.$signature")
+  }
+
+  private fun encode(value: String): String =
+    Base64.getUrlEncoder()
+      .withoutPadding()
+      .encodeToString(value.toByteArray(StandardCharsets.UTF_8))
+}


### PR DESCRIPTION
## Summary

- decode the `session_minter` environment flag and send organization, previous-token, and force-origin parameters for default token requests
- scope token caches by organization or template and hydrate them from the current session snapshot
- keep the freshest token when forced refreshes complete out of order while preserving ordinary request deduplication
- reset shared in-flight token state when the Clerk runtime is reset or reconfigured

## Why

Android did not yet implement the session-minter request and freshness behavior used by clerk-js and the corresponding iOS implementation. A late stale response could overwrite a newer canonical session token, and forced refreshes were deduplicated even though each request must reach the token endpoint.

https://github.com/user-attachments/assets/e81356e5-3ca9-46c8-abad-7a520c9d8be5




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved session token fetching for organization-specific sessions.
  * Added support for session minting and forced token refreshes.
  * Enhanced token caching to retain the freshest valid token and prevent stale updates.
  * Session resets and device-token clearing now reliably refresh token state.

* **Bug Fixes**
  * Improved handling of concurrent refresh requests and out-of-order responses.
  * Prevented expired or outdated tokens from replacing valid cached tokens.

* **Tests**
  * Expanded coverage for token freshness, caching, organizations, session minting, and refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->