### PR TITLE
fix: repair passkey rename flow

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/network/api/UserApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/UserApi.kt
@@ -402,22 +402,26 @@ internal interface UserApi {
    * Retrieves a specific passkey by its ID.
    *
    * @param passkeyId The ID of the passkey to retrieve
+   * @param sessionId Optional session ID. Defaults to current session ID from [Clerk.session]
    * @return [ClerkResult] containing the [Passkey] on success or [ClerkErrorResponse] on failure
    */
   @GET(ApiPaths.User.Passkey.WITH_ID)
   suspend fun getPasskey(
-    @Path(ApiParams.PASSKEY_ID) passkeyId: String
+    @Path(ApiParams.PASSKEY_ID) passkeyId: String,
+    @Query(ApiParams.CLERK_SESSION_ID) sessionId: String? = Clerk.session?.id,
   ): ClerkResult<Passkey, ClerkErrorResponse>
 
   /**
    * Deletes a specific passkey.
    *
    * @param passkeyId The ID of the passkey to delete
+   * @param sessionId Optional session ID. Defaults to current session ID from [Clerk.session]
    * @return [ClerkResult] containing [DeletedObject] on success or [ClerkErrorResponse] on failure
    */
   @DELETE(ApiPaths.User.Passkey.WITH_ID)
   suspend fun deletePasskey(
-    @Path(ApiParams.PASSKEY_ID) passkeyId: String
+    @Path(ApiParams.PASSKEY_ID) passkeyId: String,
+    @Query(ApiParams.CLERK_SESSION_ID) sessionId: String? = Clerk.session?.id,
   ): ClerkResult<DeletedObject, ClerkErrorResponse>
 
   /**
@@ -425,6 +429,7 @@ internal interface UserApi {
    *
    * @param passkeyId The ID of the passkey to update
    * @param name Optional: New name for the passkey
+   * @param sessionId Optional session ID. Defaults to current session ID from [Clerk.session]
    * @return [ClerkResult] containing the updated [Passkey] on success or [ClerkErrorResponse] on
    *   failure
    */
@@ -433,6 +438,7 @@ internal interface UserApi {
   suspend fun updatePasskey(
     @Path(ApiParams.PASSKEY_ID) passkeyId: String,
     @Field("name") name: String? = null,
+    @Query(ApiParams.CLERK_SESSION_ID) sessionId: String? = Clerk.session?.id,
   ): ClerkResult<Passkey, ClerkErrorResponse>
 
   /**

--- a/source/api/src/test/java/com/clerk/api/network/api/UserApiTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/api/UserApiTest.kt
@@ -1,0 +1,38 @@
+package com.clerk.api.network.api
+
+import com.clerk.api.network.ApiParams
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import retrofit2.http.Query
+
+class UserApiTest {
+
+  @Test
+  fun `passkey endpoints include clerk session id query`() {
+    val passkeyMethods =
+      listOf(
+        "createPasskey",
+        "getPasskey",
+        "deletePasskey",
+        "updatePasskey",
+        "attemptPasskeyVerification",
+      )
+
+    passkeyMethods.forEach { methodName ->
+      assertTrue(
+        method(methodName).hasQuery(ApiParams.CLERK_SESSION_ID),
+        "$methodName should include _clerk_session_id",
+      )
+    }
+  }
+
+  private fun method(name: String): java.lang.reflect.Method {
+    return UserApi::class.java.methods.single { it.name == name }
+  }
+
+  private fun java.lang.reflect.Method.hasQuery(value: String): Boolean {
+    return parameterAnnotations.any { annotations ->
+      annotations.filterIsInstance<Query>().any { it.value == value }
+    }
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/security/passkey/rename/UserProfilePasskeyRenameView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/security/passkey/rename/UserProfilePasskeyRenameView.kt
@@ -44,14 +44,20 @@ private fun UserProfilePasskeyRenameViewImpl(
   viewModel: UserProfilePasskeyRenameViewModel = viewModel(),
 ) {
   val userProfileState = LocalUserProfileState.current
-  var passkeyNameInput by rememberSaveable { mutableStateOf(passkeyName) }
-  var originalPasskeyName by rememberSaveable { mutableStateOf(passkeyName) }
+  var passkeyNameInput by rememberSaveable(passkeyId) { mutableStateOf(passkeyName) }
+  val originalPasskeyName = rememberSaveable(passkeyId) { passkeyName }
+  val updatedPasskeyName =
+    updatedPasskeyNameOrNull(
+      passkeyNameInput = passkeyNameInput,
+      originalPasskeyName = originalPasskeyName,
+    )
   val state by viewModel.state.collectAsStateWithLifecycle()
   val errorMessage = (state as? UserProfilePasskeyRenameViewModel.State.Error)?.message
 
   LaunchedEffect(state) {
     if (state is UserProfilePasskeyRenameViewModel.State.Success) {
       userProfileState.navigateBack()
+      viewModel.resetState()
     }
   }
 
@@ -77,10 +83,21 @@ private fun UserProfilePasskeyRenameViewImpl(
     ClerkButton(
       modifier = Modifier.fillMaxWidth(),
       text = stringResource(R.string.save),
-      isEnabled = passkeyName.isNotBlank() && passkeyName != originalPasskeyName,
+      isEnabled = updatedPasskeyName != null,
       isLoading = state is UserProfilePasskeyRenameViewModel.State.Loading,
-      onClick = { viewModel.renamePasskey(passkeyId = passkeyId, newName = passkeyName) },
+      onClick = {
+        updatedPasskeyName?.let { viewModel.renamePasskey(passkeyId = passkeyId, newName = it) }
+      },
     )
+  }
+}
+
+internal fun updatedPasskeyNameOrNull(
+  passkeyNameInput: String,
+  originalPasskeyName: String,
+): String? {
+  return passkeyNameInput.takeIf {
+    passkeyNameInput.isNotBlank() && passkeyNameInput != originalPasskeyName
   }
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/security/passkey/rename/UserProfilePasskeyRenameViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/security/passkey/rename/UserProfilePasskeyRenameViewModel.kt
@@ -28,6 +28,10 @@ internal class UserProfilePasskeyRenameViewModel : ViewModel() {
     }
   }
 
+  fun resetState() {
+    _state.value = State.Idle
+  }
+
   sealed interface State {
     data object Idle : State
 

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/passkey/rename/UserProfilePasskeyRenameViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/passkey/rename/UserProfilePasskeyRenameViewModelTest.kt
@@ -1,0 +1,61 @@
+package com.clerk.ui.userprofile.security.passkey.rename
+
+import app.cash.turbine.test
+import com.clerk.api.Clerk
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.passkeys.Passkey
+import com.clerk.api.passkeys.update
+import com.clerk.api.user.User
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserProfilePasskeyRenameViewModelTest {
+
+  @get:org.junit.Rule val dispatcherRule = MainDispatcherRule()
+
+  @BeforeTest
+  fun setUp() {
+    mockkObject(Clerk)
+    mockkStatic("com.clerk.api.passkeys.PasskeyKt")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    unmockkStatic("com.clerk.api.passkeys.PasskeyKt")
+    unmockkAll()
+  }
+
+  @Test
+  fun `successful rename state can be reset before reopening`() = runTest {
+    val passkey = mockk<Passkey>()
+    val user = mockk<User>()
+    every { passkey.id } returns "passkey_123"
+    every { user.passkeys } returns listOf(passkey)
+    every { Clerk.user } returns user
+    coEvery { passkey.update(name = "Work laptop") } returns ClerkResult.success(passkey)
+
+    val viewModel = UserProfilePasskeyRenameViewModel()
+    viewModel.state.test {
+      assertEquals(UserProfilePasskeyRenameViewModel.State.Idle, awaitItem())
+
+      viewModel.renamePasskey(passkeyId = "passkey_123", newName = "Work laptop")
+      assertEquals(UserProfilePasskeyRenameViewModel.State.Success, awaitItem())
+
+      viewModel.resetState()
+      assertEquals(UserProfilePasskeyRenameViewModel.State.Idle, awaitItem())
+    }
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/security/passkey/rename/UserProfilePasskeyRenameViewTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/security/passkey/rename/UserProfilePasskeyRenameViewTest.kt
@@ -1,0 +1,36 @@
+package com.clerk.ui.userprofile.security.passkey.rename
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UserProfilePasskeyRenameViewTest {
+
+  @Test
+  fun `updated passkey name is null when input is unchanged`() {
+    assertNull(
+      updatedPasskeyNameOrNull(
+        passkeyNameInput = "Personal phone",
+        originalPasskeyName = "Personal phone",
+      )
+    )
+  }
+
+  @Test
+  fun `updated passkey name is null when input is blank`() {
+    assertNull(
+      updatedPasskeyNameOrNull(passkeyNameInput = " ", originalPasskeyName = "Personal phone")
+    )
+  }
+
+  @Test
+  fun `updated passkey name returns changed input`() {
+    assertEquals(
+      "Work laptop",
+      updatedPasskeyNameOrNull(
+        passkeyNameInput = "Work laptop",
+        originalPasskeyName = "Personal phone",
+      ),
+    )
+  }
+}


### PR DESCRIPTION
## Summary of changes

- Use the edited passkey name to enable Save and submit rename requests.
- Include the active Clerk session ID on passkey get, update, and delete requests.
- Reset the rename ViewModel after success so the screen can be reopened for subsequent renames.
- Add regression coverage for form validation, authenticated passkey endpoints, and success-state reset.

## Why

MOBILE-600 identified that the rename form compared and submitted the immutable route parameter instead of the editable input, leaving Save disabled. Runtime testing also exposed two related issues: passkey update requests omitted `_clerk_session_id`, and the activity-scoped rename ViewModel retained `Success`, causing later rename attempts to immediately navigate back.

Users can now rename a passkey repeatedly, and the requests are authenticated with the active session.


https://github.com/user-attachments/assets/3beaf05b-0597-446e-85c3-381af13e29ea





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix passkey rename flow so the Save button correctly tracks edited input
> - Fixes a bug ([MOBILE-600](https://linear.app/clerk/issue/MOBILE-600)) where the Save button checked `passkeyName` instead of `passkeyNameInput`, keeping it permanently disabled and submitting the wrong value if triggered.
> - Adds `updatedPasskeyNameOrNull` in [UserProfilePasskeyRenameView.kt](https://github.com/clerk/clerk-android/pull/829/files#diff-0745cfe6f6a88e481e0a00495268c2ab4cdda7c7fc3b9066bbba2e0b4103ccd8) to validate that the edited name is non-blank and differs from the original before enabling Save.
> - Adds `resetState()` to [UserProfilePasskeyRenameViewModel.kt](https://github.com/clerk/clerk-android/pull/829/files#diff-360c6ca9a163bf61ac10ca8b9b644ecc78a9edba3a1fd8c6078d0d8245ce420c) and calls it after a successful rename to return the VM to `Idle`.
> - Adds `_clerk_session_id` as an optional query parameter to `getPasskey`, `deletePasskey`, and `updatePasskey` endpoints in [UserApi.kt](https://github.com/clerk/clerk-android/pull/829/files#diff-5428451a116abbf8965fef435a878ccb40093df807a8e160627128c0b08da13a), defaulting to `Clerk.session?.id`.
>
> #### 🖇️ Linked Issues
> Resolves [MOBILE-600](https://linear.app/clerk/issue/MOBILE-600) — "Passkey rename can never save" — by fixing the button enablement and submission logic to use the live input field rather than the original name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08bec27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->