### PR TITLE
Report email row errors only once across recomposition

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileEmailRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileEmailRow.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,9 +47,8 @@ internal fun UserProfileEmailRow(
 
   val isPreview = LocalInspectionMode.current
   val state by viewModel.state.collectAsStateWithLifecycle()
-  if (state is EmailViewModel.State.Failure) {
-    onError((state as EmailViewModel.State.Failure).message)
-  }
+  ReportEmailRowError(state, onError)
+
   ClerkMaterialTheme {
     Row(
       modifier =
@@ -97,6 +97,16 @@ internal fun UserProfileEmailRow(
           },
         )
       }
+    }
+  }
+}
+
+@Composable
+internal fun ReportEmailRowError(state: EmailViewModel.State, onError: (String) -> Unit) {
+  val errorMessage = (state as? EmailViewModel.State.Failure)?.message
+  LaunchedEffect(errorMessage) {
+    if (errorMessage != null) {
+      onError(errorMessage)
     }
   }
 }

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/email/UserProfileEmailRowTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/email/UserProfileEmailRowTest.kt
@@ -1,0 +1,33 @@
+package com.clerk.ui.userprofile.email
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import com.clerk.base.BaseSnapshotTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UserProfileEmailRowTest : BaseSnapshotTest() {
+
+  @Test
+  fun failureState_reportsErrorOnceAcrossRecomposition() {
+    val reportedErrors = mutableListOf<String>()
+    val callbackVersions = mutableListOf<Int>()
+    var recompositionTrigger by mutableIntStateOf(0)
+
+    paparazzi.snapshot {
+      val callbackVersion = recompositionTrigger
+      ReportEmailRowError(EmailViewModel.State.Failure("Unable to update email")) {
+        reportedErrors += it
+        callbackVersions += callbackVersion
+      }
+      Text(recompositionTrigger.toString())
+      LaunchedEffect(Unit) { recompositionTrigger++ }
+    }
+
+    assertEquals(listOf("Unable to update email"), reportedErrors)
+    assertEquals(listOf(0), callbackVersions)
+  }
+}


### PR DESCRIPTION
## Summary

- Move the email row error callback into a `LaunchedEffect` so recomposition does not re-fire the callback.
- Add a Paparazzi Compose test covering a failure state across recomposition.

## Testing

- Added and ran a Paparazzi UI test verifying the error is reported once.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `UserProfileEmailRow` error callback firing on every recomposition
> Inline `onError` invocation during composition in `UserProfileEmailRow` caused repeated callbacks (e.g. duplicate snackbars) on recomposition. A new `ReportEmailRowError` composable wraps the callback in a `LaunchedEffect` keyed by the error message, so `onError` fires only once per distinct error. A Compose test verifies the callback is invoked exactly once despite multiple recompositions.
>
> #### 🖇️ Linked Issues
> Resolves [MOBILE-612](https://linear.app/clerk/issue/MOBILE-612), which identified that `UserProfileEmailRow.kt` invoked `onError` inline during composition rather than as a side effect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c20b57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->