### PR TITLE
fix(ci): check out pull request head for detekt

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v7
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
       - name: detekt


### PR DESCRIPTION
### What & why
- Restore Detekt analysis against the pull request head commit. After `3cb3f53f`, `actions/checkout` defaulted to GitHub's synthetic merge ref, which broke the expected Detekt/Reviewdog behavior.
- Explicitly check out the contributor repository and immutable head SHA so same-repository and fork pull requests both analyze the submitted commit.
- Fall back to the current repository and SHA for manual workflow runs.

### What to focus on
- Confirm the pull request head repository/SHA expressions behave as expected for fork PRs and `workflow_dispatch` fallbacks.

### Screenshots / video
Not applicable.

### Validation
- `git diff --check`
- Parsed `.github/workflows/detekt.yml` successfully with Ruby's YAML parser.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix detekt CI workflow to check out pull request head commit
> Updates [detekt.yml](.github/workflows/detekt.yml) to pass `repository` and `ref` inputs to `actions/checkout`, using the PR head repo and SHA when running on pull requests, falling back to `github.repository` and `github.sha` otherwise. Without this fix, the workflow checked out the base branch instead of the PR head, so detekt ran against the wrong code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 653f53f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->