### PR TITLE
fix(api): delete only the targeted session

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
@@ -4,7 +4,6 @@ import com.clerk.api.Clerk
 import com.clerk.api.Constants.Strategy.PASSKEY
 import com.clerk.api.Constants.Strategy.PASSWORD
 import com.clerk.api.network.ClerkApi
-import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.token.TokenResource
 import com.clerk.api.network.model.userdata.PublicUserData
@@ -198,8 +197,8 @@ data class SessionActivity(
 )
 
 /** Deletes the current session. */
-suspend fun Session.delete(): ClerkResult<Client, ClerkErrorResponse> {
-  return ClerkApi.session.deleteSessions()
+suspend fun Session.delete(): ClerkResult<Session, ClerkErrorResponse> {
+  return ClerkApi.session.removeSession(id)
 }
 
 /**

--- a/source/api/src/test/java/com/clerk/api/session/SessionDeleteTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/SessionDeleteTest.kt
@@ -1,0 +1,52 @@
+package com.clerk.api.session
+
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.api.SessionApi
+import com.clerk.api.network.serialization.ClerkResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+
+class SessionDeleteTest {
+  private lateinit var sessionApi: SessionApi
+
+  @Before
+  fun setup() {
+    sessionApi = mockk()
+    mockkObject(ClerkApi)
+    every { ClerkApi.session } returns sessionApi
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `delete removes only the target session`() = runTest {
+    val session = session("sess_target")
+    val result = ClerkResult.success(session)
+    coEvery { sessionApi.removeSession("sess_target") } returns result
+
+    assertSame(result, session.delete())
+    coVerify(exactly = 1) { sessionApi.removeSession("sess_target") }
+    coVerify(exactly = 0) { sessionApi.deleteSessions() }
+  }
+
+  private fun session(id: String): Session =
+    Session(
+      id = id,
+      expireAt = 0L,
+      lastActiveAt = 0L,
+      createdAt = 0L,
+      updatedAt = 0L,
+    )
+}


### PR DESCRIPTION
### Motivation

- `Session.delete()` was documented to delete the receiver session but previously called the client-wide `DELETE /client/sessions` endpoint and never used the session `id`, risking removal of all client sessions.

### Description

- Route `Session.delete()` through the per-session endpoint by calling `ClerkApi.session.removeSession(id)` and change its return type to `ClerkResult<Session, ClerkErrorResponse>`.
- Remove the now-unused `Client` import from `Session.kt` that was associated with the bulk delete return type.
- Add `SessionDeleteTest` which verifies that `removeSession(id)` is invoked for the target session ID and that `deleteSessions()` is not called.

### Testing

- Ran `git diff --check` to validate changes and code hygiene which reported no issues.
- Added the unit test `com.clerk.api.session.SessionDeleteTest` to cover the regression scenario and verify the correct API call.
- Attempted to run `./gradlew spotlessApply :source:api:testDebugUnitTest --tests 'com.clerk.api.session.SessionDeleteTest'` but execution was blocked by the environment missing an Android SDK (`ANDROID_HOME`/`sdk.dir`), so the test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6aad0623c08322809cc15b5669d874)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Session.delete` to delete only the targeted session instead of all sessions
> [`Session.delete`](https://github.com/clerk/clerk-android/pull/832/files#diff-fcd0cfee8dbe6dbd3ca43a7dd00ba570ffc2df3b6f7154f4db93247df31164a1) was calling `deleteSessions()` (`DELETE /client/sessions`), removing all sessions instead of just the current one. It now calls `removeSession(id)` with the session's own `id` and returns a `ClerkResult<Session>` instead of `ClerkResult<Client>`. A new test class [`SessionDeleteTest`](https://github.com/clerk/clerk-android/pull/832/files#diff-9ca65e7dcd0d4cd3de729bc4517039ec9c6de1676639d15852d8bafd12e3f16e) verifies the correct endpoint is called and `deleteSessions()` is not invoked.
>
> #### 🖇️ Linked Issues
> Resolves [MOBILE-603](https://linear.app/clerk/issue/MOBILE-603), which identified that `Session.delete()` was documented to delete the current session but instead called the bulk-delete endpoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c9446f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected session deletion to remove only the selected session.
  * Updated the deletion result to return the affected session correctly.
* **Tests**
  * Added coverage confirming the targeted session is removed and broader session deletion is not triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->