### PR TITLE
build: allow skipping publication signing for local publishing

### DIFF
--- a/source/api/build.gradle.kts
+++ b/source/api/build.gradle.kts
@@ -58,7 +58,11 @@ tasks
 mavenPublishing {
   coordinates("com.clerk", "clerk-android-api", property("CLERK_API_VERSION") as String)
   publishToMavenCentral()
-  signAllPublications()
+  // Skip signing for local publishing: ./gradlew publishToMavenLocal
+  // -PRELEASE_SIGNING_ENABLED=false
+  if (providers.gradleProperty("RELEASE_SIGNING_ENABLED").orNull != "false") {
+    signAllPublications()
+  }
   pom {
     name.set("Clerk Android UI")
     description.set("UI components for Clerk Android SDK")

--- a/source/telemetry/build.gradle.kts
+++ b/source/telemetry/build.gradle.kts
@@ -9,7 +9,11 @@ plugins {
 mavenPublishing {
   coordinates("com.clerk", "clerk-android-telemetry", property("CLERK_TELEMETRY_VERSION") as String)
   publishToMavenCentral()
-  signAllPublications()
+  // Skip signing for local publishing: ./gradlew publishToMavenLocal
+  // -PRELEASE_SIGNING_ENABLED=false
+  if (providers.gradleProperty("RELEASE_SIGNING_ENABLED").orNull != "false") {
+    signAllPublications()
+  }
   pom {
     name.set("Clerk Android Telemetry")
     description.set("Telemetry module for Clerk Android SDK")

--- a/source/ui/build.gradle.kts
+++ b/source/ui/build.gradle.kts
@@ -61,7 +61,11 @@ tasks
 mavenPublishing {
   coordinates("com.clerk", "clerk-android-ui", property("CLERK_UI_VERSION") as String)
   publishToMavenCentral()
-  signAllPublications()
+  // Skip signing for local publishing: ./gradlew publishToMavenLocal
+  // -PRELEASE_SIGNING_ENABLED=false
+  if (providers.gradleProperty("RELEASE_SIGNING_ENABLED").orNull != "false") {
+    signAllPublications()
+  }
   pom {
     name.set("Clerk Android UI")
     description.set("UI components for Clerk Android SDK")


### PR DESCRIPTION
## Problem

`./gradlew publishToMavenLocal` fails on `signMavenPublication` / `signAndroidPublication` unless Maven Central signing keys are configured, which no local dev machine has. That makes it needlessly hard to build consumers (like the Expo module) against a local clerk-android checkout — the workaround was commenting out `signAllPublications()` by hand.

## What this adds

All three publishing modules (`api`, `ui`, `telemetry`) skip `signAllPublications()` when `-PRELEASE_SIGNING_ENABLED=false` is passed:

```
./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false
```

The property name follows the vanniktech maven-publish convention. Without the property, publications are signed exactly as before, so Maven Central releases are unaffected.

## Modules

`source/api`, `source/ui`, `source/telemetry` — build scripts only, no source changes.

## Testing

- `publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false`: all modules publish with no signing keys configured
- `publishToMavenLocal` without the property: still fails with "no configured signatory" on this keyless machine, confirming default signing behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip publication signing for local publishing via `RELEASE_SIGNING_ENABLED` flag
> Wraps `signAllPublications()` in a conditional check for the `RELEASE_SIGNING_ENABLED` Gradle property in [api/build.gradle.kts](https://github.com/clerk/clerk-android/pull/833/files#diff-fb6a9216b8f6adbd92ee4e7091cda368bbc657246fd48a01518aa5878b2005dc), [telemetry/build.gradle.kts](https://github.com/clerk/clerk-android/pull/833/files#diff-a669d4f61cef78090ff2cc3109f9706cb227d051001473f039b8b7e1457b3d3f), and [ui/build.gradle.kts](https://github.com/clerk/clerk-android/pull/833/files#diff-8ff23c86e320e654c8ce73eb5638e51e6cbf62403b04e79b341af3231fe0f737). Setting `RELEASE_SIGNING_ENABLED=false` skips signing, which is useful for local Maven publishing without requiring signing credentials.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fa451a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Publishing**
  * Publication signing can now be disabled for local publishing by setting `RELEASE_SIGNING_ENABLED=false`.
  * Release publications continue to be signed by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->