### PR TITLE
fix(ui): surface sign-in-only auth errors

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -8,7 +8,6 @@ import com.clerk.api.credentials.shouldFallbackToOAuthFromGoogleOneTap
 import com.clerk.api.credentials.shouldSuppressAutomaticCredentialFlowError
 import com.clerk.api.credentials.shouldSuppressCredentialFlowError
 import com.clerk.api.log.ClerkLog
-import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
@@ -180,14 +179,13 @@ internal class AuthStartViewModel(private val ioDispatcher: CoroutineDispatcher 
       SignIn.create(SignIn.CreateParams.Strategy.Identifier(identifier = resolvedIdentifier))
         .onSuccess { signIn -> handleSignInSuccess(signIn, transferable) }
         .onFailure {
-          if (withSignUp && it.error is ClerkErrorResponse) {
-            val matchingCodes = listOf(FORM_IDENTIFIER_NOT_FOUND, INVITATION_ACCOUNT_NOT_EXISTS)
-            val hasMatchingError = it.error?.errors?.any { it.code in matchingCodes } ?: false
-            if (hasMatchingError) {
-              signUp(isPhoneNumberFieldActive, identifier, phoneNumber, unsafeMetadata)
-            } else {
-              _state.value = AuthState.Error(it.errorMessage)
-            }
+          val matchingCodes = listOf(FORM_IDENTIFIER_NOT_FOUND, INVITATION_ACCOUNT_NOT_EXISTS)
+          val shouldSignUp =
+            withSignUp && it.error?.errors?.any { error -> error.code in matchingCodes } == true
+          if (shouldSignUp) {
+            signUp(isPhoneNumberFieldActive, identifier, phoneNumber, unsafeMetadata)
+          } else {
+            _state.value = AuthState.Error(it.errorMessage)
           }
         }
     }

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -84,6 +84,53 @@ class AuthViewModelTest {
   }
 
   @Test
+  fun startAuthWithSignInModeShouldSurfaceApiFailure() = runTest {
+    mockkObject(SignIn.Companion)
+    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
+      ClerkResult.apiFailure(
+        ClerkErrorResponse(errors = listOf(ClerkError(longMessage = "Couldn't find your account.")))
+      )
+
+    viewModel.state.test {
+      assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
+
+      viewModel.startAuth(
+        authMode = AuthMode.SignIn,
+        isPhoneNumberFieldActive = false,
+        phoneNumber = "",
+        identifier = "test@example.com",
+      )
+
+      assertEquals(AuthStartViewModel.AuthState.Loading, awaitItem())
+      assertEquals(AuthStartViewModel.AuthState.Error("Couldn't find your account."), awaitItem())
+    }
+  }
+
+  @Test
+  fun startAuthWithSignInModeShouldSurfaceUnknownFailure() = runTest {
+    mockkObject(SignIn.Companion)
+    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
+      ClerkResult.unknownFailure(IllegalStateException("Network unavailable"))
+
+    viewModel.state.test {
+      assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
+
+      viewModel.startAuth(
+        authMode = AuthMode.SignIn,
+        isPhoneNumberFieldActive = false,
+        phoneNumber = "",
+        identifier = "test@example.com",
+      )
+
+      assertEquals(AuthStartViewModel.AuthState.Loading, awaitItem())
+      assertEquals(
+        AuthStartViewModel.AuthState.Error("Error occurred with unknown message."),
+        awaitItem(),
+      )
+    }
+  }
+
+  @Test
   fun automaticPasskeySignInUsesPasskeyStrategy() = runTest {
     val signIn = SignIn(id = "sign_in_123")
     mockkObject(SignIn.Companion)


### PR DESCRIPTION
### What & why

- Fix `AuthMode.SignIn` failures remaining in `Loading` indefinitely.
- Preserve the sign-in-or-up fallback only for identifier-not-found and invitation-account-not-found errors.
- Surface all other API and unknown/network failures through `AuthState.Error`.
- Add regression coverage for API and unknown failures in sign-in-only mode.

The failure handler previously gated its entire body on `withSignUp`, so sign-in-only attempts never updated UI state after an error.

Linear: [MOBILE-602](https://linear.app/clerk/issue/MOBILE-602/spike-sign-in-only-mode-swallows-auth-errors)

### What to focus on

- The fallback condition in `AuthStartViewModel.signIn` and whether any additional errors should transfer into sign-up.

### Screenshots / video

Manually verified with the workbench configured in sign-in-only mode: an invalid identifier surfaces an error instead of leaving the Continue button loading.

<img height="700" alt="image" src="https://github.com/user-attachments/assets/499cbafa-2d21-48cb-a971-eabf3248d0a3" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AuthStartViewModel.startAuth` to surface errors in sign-in-only mode
> In sign-in-only mode (`withSignUp = false`), auth failures never updated state, leaving the UI stuck on `Loading` with no error shown. The `onFailure` branch in [`AuthStartViewModel.kt`](https://github.com/clerk/clerk-android/pull/834/files#diff-5e5866e21502f602457310559db6784dc3d21a023bdd31824b2f41021b4c3a12) was gated on a `ClerkErrorResponse` type check inside a `withSignUp` condition, so all failures in sign-in mode were silently dropped. The fix removes the type check and always emits `AuthState.Error` unless the error code warrants a sign-up fallback.
>
> #### 🖇️ Linked Issues
> Resolves [MOBILE-602](https://linear.app/clerk/issue/MOBILE-602), which identified that wrong identifier, throttle, and network errors in sign-in-only mode left the UI in a permanent loading state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b38636.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in error handling to correctly distinguish recoverable errors from unexpected failures.
  * Sign-in now displays the relevant backend error message when available, or a clear generic message when no details are provided.
* **Tests**
  * Added coverage for API and unknown sign-in failure scenarios, including expected loading and error state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->