### PR TITLE
feat(ui): host-owned back stack embedding for the user profile

### DIFF
--- a/samples/prebuilt-ui/build.gradle.kts
+++ b/samples/prebuilt-ui/build.gradle.kts
@@ -52,6 +52,8 @@ dependencies {
   implementation(libs.coil.okhttp)
   implementation(libs.core.ktx)
   implementation(libs.kotlinx.serialization)
+  implementation(libs.androidx.navigation3.runtime)
+  implementation(libs.androidx.navigation3.ui)
   implementation(libs.material3)
   implementation(libs.navigation.compose)
   implementation(projects.source.api)

--- a/samples/prebuilt-ui/src/main/java/com/clerk/prebuiltui/MainActivity.kt
+++ b/samples/prebuilt-ui/src/main/java/com/clerk/prebuiltui/MainActivity.kt
@@ -29,6 +29,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
 import com.clerk.api.Clerk
 import com.clerk.api.session.pendingTaskKey
 import com.clerk.prebuiltui.ui.theme.ClerkTheme
@@ -42,6 +46,9 @@ import com.clerk.ui.organizationprofile.custom.OrganizationProfileCustomRowPlace
 import com.clerk.ui.organizationprofile.custom.OrganizationProfileRow
 import com.clerk.ui.organizationprofile.custom.OrganizationProfileRowIcon
 import com.clerk.ui.organizationswitcher.OrganizationSwitcher
+import com.clerk.ui.userprofile.ClerkUserProfileRoute
+import com.clerk.ui.userprofile.clerkUserProfileEntries
+import kotlinx.serialization.Serializable
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -74,6 +81,7 @@ class MainActivity : ComponentActivity() {
 private fun SignedInPrebuiltHome(hasActiveOrganization: Boolean) {
   var showOrganizationList by rememberSaveable { androidx.compose.runtime.mutableStateOf(false) }
   var showOrganizationProfile by rememberSaveable { androidx.compose.runtime.mutableStateOf(false) }
+  var showHostStackProfile by rememberSaveable { androidx.compose.runtime.mutableStateOf(false) }
   val customRows = rememberOrganizationSampleCustomRows()
 
   OrganizationSampleLauncherContent(
@@ -81,6 +89,7 @@ private fun SignedInPrebuiltHome(hasActiveOrganization: Boolean) {
     customRows = customRows,
     onShowOrganizationList = { showOrganizationList = true },
     onShowOrganizationProfile = { showOrganizationProfile = true },
+    onShowHostStackProfile = { showHostStackProfile = true },
   )
 
   OrganizationSampleDialogs(
@@ -90,6 +99,12 @@ private fun SignedInPrebuiltHome(hasActiveOrganization: Boolean) {
     onDismissOrganizationList = { showOrganizationList = false },
     onDismissOrganizationProfile = { showOrganizationProfile = false },
   )
+
+  if (showHostStackProfile) {
+    FullScreenPrebuiltDialog(onDismissRequest = { showHostStackProfile = false }) {
+      HostStackProfileSample(onClose = { showHostStackProfile = false })
+    }
+  }
 }
 
 @Composable
@@ -121,6 +136,7 @@ private fun OrganizationSampleLauncherContent(
   customRows: List<OrganizationProfileCustomRow>,
   onShowOrganizationList: () -> Unit,
   onShowOrganizationProfile: () -> Unit,
+  onShowHostStackProfile: () -> Unit,
 ) {
   Column(
     modifier = Modifier.fillMaxSize().statusBarsPadding().padding(24.dp),
@@ -145,6 +161,9 @@ private fun OrganizationSampleLauncherContent(
       onClick = onShowOrganizationProfile,
     ) {
       Text(text = stringResource(R.string.open_organization_profile))
+    }
+    OutlinedButton(modifier = Modifier.fillMaxWidth(), onClick = onShowHostStackProfile) {
+      Text(text = stringResource(R.string.open_host_stack_profile))
     }
   }
 }
@@ -214,6 +233,44 @@ private fun SampleOrganizationProfileDestination(routeKey: String) {
     Button(onClick = navigator::navigateBack) { Text(text = stringResource(R.string.done)) }
   }
 }
+
+/**
+ * Demonstrates hosting Clerk's user profile inside the app's own NavDisplay: the app owns the back
+ * stack and transitions, and Clerk's screens are ordinary destinations on it.
+ */
+@Composable
+private fun HostStackProfileSample(onClose: () -> Unit) {
+  val backStack = rememberNavBackStack(HostHomeRoute)
+
+  NavDisplay(
+    modifier = Modifier.fillMaxSize(),
+    backStack = backStack,
+    onBack = { if (backStack.size > 1) backStack.removeLastOrNull() else onClose() },
+    entryProvider =
+      entryProvider {
+        entry<HostHomeRoute> {
+          Column(
+            modifier = Modifier.fillMaxSize().padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+            horizontalAlignment = Alignment.CenterHorizontally,
+          ) {
+            Text(
+              text = stringResource(R.string.host_stack_home_title),
+              style = MaterialTheme.typography.headlineSmall,
+            )
+            Button(onClick = { backStack.add(ClerkUserProfileRoute) }) {
+              Text(text = stringResource(R.string.open_clerk_profile))
+            }
+            OutlinedButton(onClick = onClose) { Text(text = stringResource(R.string.done)) }
+          }
+        }
+
+        clerkUserProfileEntries(backStack)
+      },
+  )
+}
+
+@Serializable private data object HostHomeRoute : NavKey
 
 private const val BILLING_ROUTE = "billing"
 private const val SUPPORT_ROUTE = "support"

--- a/samples/prebuilt-ui/src/main/res/values/strings.xml
+++ b/samples/prebuilt-ui/src/main/res/values/strings.xml
@@ -9,4 +9,7 @@
     <string name="support_destination_title">Support settings</string>
     <string name="custom_destination_body">This is an app-owned destination inside the Clerk organization profile flow.</string>
     <string name="done">Done</string>
+  <string name="open_host_stack_profile">Open profile in host back stack</string>
+  <string name="host_stack_home_title">Host app screen</string>
+  <string name="open_clerk_profile">Open Clerk profile</string>
 </resources>

--- a/source/api/src/main/kotlin/com/clerk/api/FrameworkIntegrationApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/FrameworkIntegrationApi.kt
@@ -1,0 +1,18 @@
+package com.clerk.api
+
+/**
+ * Marks APIs that exist for Clerk's own framework integrations (for example the Expo SDK).
+ *
+ * These APIs are supported for that purpose but are not part of the SDK's stable public surface:
+ * they can change shape or disappear in minor releases as integration needs evolve. This is the
+ * Android counterpart of the iOS SDK's `@_spi(FrameworkIntegration)` surface.
+ */
+@RequiresOptIn(
+  level = RequiresOptIn.Level.ERROR,
+  message =
+    "This API exists for Clerk's own framework integrations (e.g. the Expo SDK) and may " +
+      "change without notice in minor releases. Opt in only if you accept that contract.",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.CONSTRUCTOR, AnnotationTarget.FUNCTION)
+annotation class FrameworkIntegrationApi

--- a/source/ui/build.gradle.kts
+++ b/source/ui/build.gradle.kts
@@ -107,7 +107,7 @@ dependencies {
   implementation(libs.androidx.compose.runtime)
   implementation(libs.androidx.lifecycle)
   implementation(libs.androidx.lifecycle.viewmodel.compose)
-  implementation(libs.androidx.navigation3.runtime)
+  api(libs.androidx.navigation3.runtime)
   implementation(libs.androidx.navigation3.ui)
   implementation(libs.androidx.ui)
   implementation(libs.androidx.ui.tooling)

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -139,7 +139,16 @@ fun AuthView(
       ObservePendingSessionTaskRouting(backStack = backStack)
       ObserveInProgressAuthRouting(backStack = backStack, onAuthComplete = onAuthComplete)
       TrackScreenLoaded(LocalAuthState.current.mode.name)
-      EmbeddedNavigationEffects(embeddedNavigation = embeddedNavigation, backStack = backStack)
+      val authState = LocalAuthState.current
+      // Route embedded pops through AuthState so back navigation also suppresses the
+      // in-progress attempt resume; raw stack pops would bounce straight back to the
+      // factor screen the user just left.
+      EmbeddedNavigationEffects(
+        embeddedNavigation = embeddedNavigation,
+        backStack = backStack,
+        pop = { authState.navigateBack() },
+        popToRoot = { authState.navigateToAuthStartForIdentifierEdit() },
+      )
       CompositionLocalProvider(LocalClerkEmbeddedNavigation provides embeddedNavigation) {
         ClerkLogoProvider(logo) {
           DevelopmentModeWarningBox(

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -39,6 +40,9 @@ import com.clerk.ui.core.composition.LocalAuthState
 import com.clerk.ui.core.composition.LocalTelemetryCollector
 import com.clerk.ui.core.footer.DevelopmentModeWarningBackground
 import com.clerk.ui.core.footer.DevelopmentModeWarningBox
+import com.clerk.ui.navigation.ClerkEmbeddedNavigation
+import com.clerk.ui.navigation.EmbeddedNavigationEffects
+import com.clerk.ui.navigation.LocalClerkEmbeddedNavigation
 import com.clerk.ui.sessiontask.mfa.SessionTaskMfaView
 import com.clerk.ui.sessiontask.organization.SessionTaskChooseOrganizationView
 import com.clerk.ui.sessiontask.organization.SessionTaskCreateOrganizationView
@@ -86,6 +90,10 @@ import kotlinx.serialization.Serializable
  *   sizing or spacing, so you are responsible for its layout and accessibility. To only change the
  *   size of the dashboard-configured logo, set [com.clerk.api.ui.ClerkDesign.logoMaxHeight]
  *   instead.
+ * @param embeddedNavigation Optional embedded-navigation handle for embedding the auth flow inside
+ *   the host's own navigation chrome. When provided, Clerk's top app bars are hidden and the host
+ *   observes and drives the flow's internal back stack through the handle. See
+ *   [ClerkEmbeddedNavigation].
  */
 @Composable
 fun AuthView(
@@ -104,6 +112,7 @@ fun AuthView(
   onDismiss: (() -> Unit)? = null,
   onAuthComplete: () -> Unit = {},
   mode: AuthMode = AuthMode.SignInOrUp,
+  embeddedNavigation: ClerkEmbeddedNavigation? = null,
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
     val fullScreenModifier = Modifier.fillMaxSize().then(modifier)
@@ -130,23 +139,26 @@ fun AuthView(
       ObservePendingSessionTaskRouting(backStack = backStack)
       ObserveInProgressAuthRouting(backStack = backStack, onAuthComplete = onAuthComplete)
       TrackScreenLoaded(LocalAuthState.current.mode.name)
-      ClerkLogoProvider(logo) {
-        DevelopmentModeWarningBox(
-          modifier = fullScreenModifier,
-          background = DevelopmentModeWarningBackground.White,
-        ) {
-          AuthNavDisplay(
-            modifier = Modifier.fillMaxSize(),
-            backStack = backStack,
-            options =
-              AuthNavOptions(
-                preferGoogleOneTap = preferGoogleOneTap,
-                startSocialOAuthAsSignUp = startSocialOAuthAsSignUp,
-                isDismissible = isDismissible,
-                onDismiss = onDismiss,
-                onAuthComplete = onAuthComplete,
-              ),
-          )
+      EmbeddedNavigationEffects(embeddedNavigation = embeddedNavigation, backStack = backStack)
+      CompositionLocalProvider(LocalClerkEmbeddedNavigation provides embeddedNavigation) {
+        ClerkLogoProvider(logo) {
+          DevelopmentModeWarningBox(
+            modifier = fullScreenModifier,
+            background = DevelopmentModeWarningBackground.White,
+          ) {
+            AuthNavDisplay(
+              modifier = Modifier.fillMaxSize(),
+              backStack = backStack,
+              options =
+                AuthNavOptions(
+                  preferGoogleOneTap = preferGoogleOneTap,
+                  startSocialOAuthAsSignUp = startSocialOAuthAsSignUp,
+                  isDismissible = isDismissible,
+                  onDismiss = onDismiss,
+                  onAuthComplete = onAuthComplete,
+                ),
+            )
+          }
         }
       }
     }

--- a/source/ui/src/main/java/com/clerk/ui/core/appbar/ClerkTopAppbar.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/appbar/ClerkTopAppbar.kt
@@ -38,6 +38,7 @@ import com.clerk.ui.core.dimens.dp48
 import com.clerk.ui.core.dimens.dp68
 import com.clerk.ui.core.dimens.dp8
 import com.clerk.ui.core.extensions.withMediumWeight
+import com.clerk.ui.navigation.LocalClerkEmbeddedNavigation
 import com.clerk.ui.theme.ClerkMaterialTheme
 
 @Composable
@@ -53,6 +54,9 @@ internal fun ClerkTopAppBar(
   contentPadding: PaddingValues = PaddingValues(),
   trailingContent: (@Composable () -> Unit)? = null,
 ) {
+  // Embedded navigation means the host renders all header chrome, including back affordances.
+  if (LocalClerkEmbeddedNavigation.current != null) return
+
   ClerkMaterialTheme(clerkTheme = clerkTheme) {
     val resolvedBackgroundColor = backgroundColor ?: ClerkMaterialTheme.colors.muted
     Box(modifier = Modifier.fillMaxWidth().then(modifier).background(resolvedBackgroundColor)) {

--- a/source/ui/src/main/java/com/clerk/ui/navigation/ClerkEmbeddedNavigation.kt
+++ b/source/ui/src/main/java/com/clerk/ui/navigation/ClerkEmbeddedNavigation.kt
@@ -89,7 +89,7 @@ internal fun EmbeddedNavigationEffects(
   }
 
   DisposableEffect(embeddedNavigation, backStack) {
-    embeddedNavigation.popHandler = { toRoot ->
+    val handler: (toRoot: Boolean) -> Unit = { toRoot ->
       if (toRoot) {
         while (backStack.size > 1) {
           backStack.removeLastOrNull()
@@ -98,9 +98,14 @@ internal fun EmbeddedNavigationEffects(
         backStack.removeLastOrNull()
       }
     }
+    embeddedNavigation.popHandler = handler
     onDispose {
-      if (embeddedNavigation.popHandler != null) {
+      // Only tear down our own registration: a component leaving composition after
+      // a successor has registered must not clear the successor's handler. Reset
+      // depth so the handle doesn't advertise canGoBack with a no-op pop.
+      if (embeddedNavigation.popHandler === handler) {
         embeddedNavigation.popHandler = null
+        embeddedNavigation.depth = 0
       }
     }
   }

--- a/source/ui/src/main/java/com/clerk/ui/navigation/ClerkEmbeddedNavigation.kt
+++ b/source/ui/src/main/java/com/clerk/ui/navigation/ClerkEmbeddedNavigation.kt
@@ -1,0 +1,107 @@
+package com.clerk.ui.navigation
+
+import android.annotation.SuppressLint
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import com.clerk.api.FrameworkIntegrationApi
+
+/**
+ * Lets a host that embeds Clerk components inside its own navigation chrome (for example Clerk's
+ * Expo SDK, or an app with its own top app bar) hide Clerk's top app bars while observing and
+ * driving the component's internal navigation stack.
+ *
+ * Pass an instance to [UserProfileView][com.clerk.ui.userprofile.UserProfileView] or
+ * [AuthView][com.clerk.ui.auth.AuthView]. The component then hides its top app bars, keeps [depth]
+ * up to date as its internal back stack changes, and executes [pop] / [popToRoot] against that
+ * stack. The host owns all header chrome, including back affordances: render your own back button
+ * and call [pop] while [canGoBack] is `true`.
+ *
+ * When no instance is passed (the default), component behavior is unchanged.
+ *
+ * Only one component drives an instance at a time.
+ *
+ * Obtaining an instance requires opting in to [FrameworkIntegrationApi]: this surface exists for
+ * Clerk's own framework integrations and may change without notice in minor releases.
+ */
+@Stable
+class ClerkEmbeddedNavigation @FrameworkIntegrationApi constructor() {
+  /** The number of screens pushed above the embedded component's root screen. */
+  var depth: Int by mutableIntStateOf(0)
+    internal set
+
+  /** Whether the embedded component's internal stack has screens to pop. */
+  val canGoBack: Boolean
+    get() = depth > 0
+
+  internal var popHandler: ((toRoot: Boolean) -> Unit)? = null
+
+  /** Pops one screen off the embedded component's internal stack. No-op at the root. */
+  fun pop() {
+    popHandler?.invoke(false)
+  }
+
+  /** Pops the embedded component's internal stack back to its root screen. */
+  fun popToRoot() {
+    popHandler?.invoke(true)
+  }
+}
+
+/** Creates and remembers a [ClerkEmbeddedNavigation] for embedding Clerk components. */
+@FrameworkIntegrationApi
+@Composable
+fun rememberClerkEmbeddedNavigation(): ClerkEmbeddedNavigation {
+  return remember { ClerkEmbeddedNavigation() }
+}
+
+/**
+ * Embedded navigation for the enclosing Clerk component, or `null` when the component renders its
+ * own navigation chrome. [ClerkTopAppBar][com.clerk.ui.core.appbar.ClerkTopAppBar] renders nothing
+ * while this is non-null.
+ */
+@SuppressLint("ComposeCompositionLocalUsage")
+internal val LocalClerkEmbeddedNavigation =
+  staticCompositionLocalOf<ClerkEmbeddedNavigation?> { null }
+
+/**
+ * Connects [embeddedNavigation] to a component's [backStack]: publishes depth changes and executes
+ * pop commands. No-op when [embeddedNavigation] is `null`.
+ */
+@Composable
+internal fun EmbeddedNavigationEffects(
+  embeddedNavigation: ClerkEmbeddedNavigation?,
+  backStack: NavBackStack<NavKey>,
+) {
+  if (embeddedNavigation == null) return
+
+  LaunchedEffect(embeddedNavigation, backStack) {
+    snapshotFlow { backStack.size }
+      .collect { size -> embeddedNavigation.depth = (size - 1).coerceAtLeast(0) }
+  }
+
+  DisposableEffect(embeddedNavigation, backStack) {
+    embeddedNavigation.popHandler = { toRoot ->
+      if (toRoot) {
+        while (backStack.size > 1) {
+          backStack.removeLastOrNull()
+        }
+      } else if (backStack.size > 1) {
+        backStack.removeLastOrNull()
+      }
+    }
+    onDispose {
+      if (embeddedNavigation.popHandler != null) {
+        embeddedNavigation.popHandler = null
+      }
+    }
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/navigation/ClerkEmbeddedNavigation.kt
+++ b/source/ui/src/main/java/com/clerk/ui/navigation/ClerkEmbeddedNavigation.kt
@@ -75,11 +75,16 @@ internal val LocalClerkEmbeddedNavigation =
 /**
  * Connects [embeddedNavigation] to a component's [backStack]: publishes depth changes and executes
  * pop commands. No-op when [embeddedNavigation] is `null`.
+ *
+ * [pop] and [popToRoot] override how commands mutate the stack for components whose navigation
+ * state carries extra bookkeeping beyond the raw back stack.
  */
 @Composable
 internal fun EmbeddedNavigationEffects(
   embeddedNavigation: ClerkEmbeddedNavigation?,
   backStack: NavBackStack<NavKey>,
+  pop: (() -> Unit)? = null,
+  popToRoot: (() -> Unit)? = null,
 ) {
   if (embeddedNavigation == null) return
 
@@ -91,11 +96,14 @@ internal fun EmbeddedNavigationEffects(
   DisposableEffect(embeddedNavigation, backStack) {
     val handler: (toRoot: Boolean) -> Unit = { toRoot ->
       if (toRoot) {
-        while (backStack.size > 1) {
-          backStack.removeLastOrNull()
-        }
+        popToRoot?.invoke()
+          ?: run {
+            while (backStack.size > 1) {
+              backStack.removeLastOrNull()
+            }
+          }
       } else if (backStack.size > 1) {
-        backStack.removeLastOrNull()
+        pop?.invoke() ?: backStack.removeLastOrNull()
       }
     }
     embeddedNavigation.popHandler = handler

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/ClerkUserProfileEntries.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/ClerkUserProfileEntries.kt
@@ -1,0 +1,210 @@
+package com.clerk.ui.userprofile
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import com.clerk.api.Clerk
+import com.clerk.api.ui.ClerkTheme
+import com.clerk.telemetry.TelemetryEvents
+import com.clerk.ui.auth.AuthView
+import com.clerk.ui.core.composition.LocalTelemetryCollector
+import com.clerk.ui.core.footer.DevelopmentModeWarningBox
+import com.clerk.ui.theme.ClerkThemeOverrideProvider
+import com.clerk.ui.userprofile.account.UserProfileAccountSwitcherSheet
+import com.clerk.ui.userprofile.account.UserProfileAccountView
+import com.clerk.ui.userprofile.account.UserProfileAction
+import com.clerk.ui.userprofile.custom.CustomRouteNavKey
+import com.clerk.ui.userprofile.custom.UserProfileCustomRow
+import com.clerk.ui.userprofile.custom.effectiveCustomRows
+import kotlinx.collections.immutable.toImmutableList
+
+/**
+ * Registers Clerk's user profile screens in a host-owned
+ * [NavDisplay][androidx.navigation3.ui.NavDisplay], so the profile takes part in the host's own
+ * navigation: its transitions, predictive back, and back stack.
+ *
+ * Push [ClerkUserProfileRoute] onto [backStack] to open the profile. Clerk pushes its own internal
+ * keys above it as the user navigates, and removes its keys (never the host's) when the flow ends.
+ *
+ * ```kotlin
+ * val backStack = rememberNavBackStack(Home)
+ *
+ * NavDisplay(
+ *   backStack = backStack,
+ *   entryProvider =
+ *     entryProvider {
+ *       entry<Home> { HomeScreen(onOpenProfile = { backStack.add(ClerkUserProfileRoute) }) }
+ *       clerkUserProfileEntries(backStack)
+ *     },
+ * )
+ * ```
+ *
+ * This is the host-owned counterpart of [UserProfileView], which renders a self-contained profile
+ * with its own navigation container.
+ *
+ * @param backStack The host's back stack, which must be the one rendered by the `NavDisplay` these
+ *   entries are registered in.
+ * @param clerkTheme Optional theme customization for the user profile UI.
+ * @param customRows Custom rows to display on the profile account screen.
+ * @param customDestination Composable that renders the destination for a given route key. The route
+ *   key matches [UserProfileCustomRow.routeKey] of the tapped row.
+ * @param onAddAccount Optional callback for hosting the add-account auth flow outside the profile.
+ */
+@Suppress("LongParameterList")
+fun EntryProviderScope<NavKey>.clerkUserProfileEntries(
+  backStack: NavBackStack<NavKey>,
+  clerkTheme: ClerkTheme? = null,
+  customRows: List<UserProfileCustomRow> = emptyList(),
+  customDestination: (@Composable (String) -> Unit)? = null,
+  onAddAccount: (() -> Unit)? = null,
+) {
+  val exitProfile = { backStack.exitClerkUserProfile() }
+  val decorate: @Composable (@Composable () -> Unit) -> Unit = { content ->
+    HostEntryChrome(
+      clerkTheme = clerkTheme,
+      backStack = backStack,
+      onClearBackStack = exitProfile,
+      content = content,
+    )
+  }
+
+  entry<ClerkUserProfileRoute> {
+    decorate {
+      UserProfileRootEntry(
+        backStack = backStack,
+        customRows = customRows,
+        customDestination = customDestination,
+        onAddAccount = onAddAccount,
+        onExit = exitProfile,
+      )
+    }
+  }
+
+  userProfileChildEntries(
+    backStack = backStack,
+    customDestination = customDestination,
+    popToRoot = { backStack.popToClerkUserProfileRoot() },
+    navigateBack = {
+      if (backStack.lastOrNull() != ClerkUserProfileRoute) backStack.removeLastOrNull()
+    },
+    decorate = decorate,
+  )
+}
+
+/** Applies per-entry the providers the self-contained profile applies around its NavDisplay. */
+@Composable
+private fun HostEntryChrome(
+  clerkTheme: ClerkTheme?,
+  backStack: NavBackStack<NavKey>,
+  onClearBackStack: () -> Unit,
+  content: @Composable () -> Unit,
+) {
+  ClerkThemeOverrideProvider(clerkTheme) {
+    UserProfileStateProvider(backStack, onClearBackStack = onClearBackStack) {
+      DevelopmentModeWarningBox(modifier = Modifier.fillMaxSize()) { content() }
+    }
+  }
+}
+
+@Suppress("LongMethod")
+@Composable
+private fun UserProfileRootEntry(
+  backStack: NavBackStack<NavKey>,
+  customRows: List<UserProfileCustomRow>,
+  customDestination: (@Composable (String) -> Unit)?,
+  onAddAccount: (() -> Unit)?,
+  onExit: () -> Unit,
+) {
+  val telemetry = LocalTelemetryCollector.current
+  val user by Clerk.userFlow.collectAsStateWithLifecycle()
+  var showAccountSwitcher by rememberSaveable { mutableStateOf(false) }
+  var showAuth by rememberSaveable { mutableStateOf(false) }
+  val showAddAccountAuth = {
+    showAccountSwitcher = false
+    onAddAccount?.invoke() ?: run { showAuth = true }
+  }
+
+  LaunchedEffect(Unit) {
+    telemetry.record(TelemetryEvents.viewDidAppear("UserProfileView"))
+    Clerk.refreshClient()
+  }
+  LaunchedEffect(user?.id, showAuth) {
+    if (user == null && !showAuth) {
+      onExit()
+    }
+  }
+
+  if (showAuth) {
+    // The add-account flow replaces the profile entry entirely, so it keeps Clerk's own
+    // navigation chrome. Hosts that want to own this flow can pass onAddAccount instead.
+    AuthView(
+      modifier = Modifier.fillMaxSize(),
+      preferGoogleOneTap = false,
+      onDismiss = { showAuth = false },
+      onAuthComplete = { showAuth = false },
+    )
+  } else {
+    UserProfileAccountView(
+      onClick = {
+        when (it) {
+          UserProfileAction.Profile -> backStack.add(UserProfileDestination.UserProfileDetail)
+
+          UserProfileAction.Security -> backStack.add(UserProfileDestination.UserProfileSecurity)
+
+          UserProfileAction.SwitchAccount -> showAccountSwitcher = true
+
+          UserProfileAction.AddAccount -> showAddAccountAuth()
+
+          UserProfileAction.SignOut -> Unit
+        }
+      },
+      onBackPressed = onExit,
+      isDismissible = false,
+      showsBackButton = true,
+      onClickEdit = { backStack.add(UserProfileDestination.UserProfileUpdate) },
+      customRows =
+        effectiveCustomRows(customRows, hasDestination = customDestination != null)
+          .toImmutableList(),
+      onCustomRowClick =
+        if (customDestination != null) {
+          { routeKey -> backStack.add(CustomRouteNavKey(routeKey)) }
+        } else {
+          {}
+        },
+    )
+
+    if (showAccountSwitcher) {
+      UserProfileAccountSwitcherSheet(
+        onDismissRequest = { showAccountSwitcher = false },
+        onAddAccount = showAddAccountAuth,
+      )
+    }
+  }
+}
+
+/** Removes the profile's keys from the host stack, including [ClerkUserProfileRoute]. */
+private fun NavBackStack<NavKey>.exitClerkUserProfile() {
+  val rootIndex = indexOfLast { it == ClerkUserProfileRoute }
+  if (rootIndex == -1) return
+  while (size > rootIndex) {
+    removeLastOrNull()
+  }
+}
+
+/** Pops the profile's pushed keys so [ClerkUserProfileRoute] is back on top. */
+private fun NavBackStack<NavKey>.popToClerkUserProfileRoot() {
+  val rootIndex = indexOfLast { it == ClerkUserProfileRoute }
+  if (rootIndex == -1) return
+  while (size - 1 > rootIndex) {
+    removeLastOrNull()
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/ClerkUserProfileRoute.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/ClerkUserProfileRoute.kt
@@ -1,0 +1,13 @@
+package com.clerk.ui.userprofile
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+
+/**
+ * Marks the root of Clerk's user profile inside a host-owned navigation back stack.
+ *
+ * Push this key to open the profile; register the profile's screens with [clerkUserProfileEntries].
+ * The profile removes its own keys from the stack when the flow ends (root back navigation,
+ * sign-out, account deletion).
+ */
+@Serializable object ClerkUserProfileRoute : NavKey

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileState.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileState.kt
@@ -9,8 +9,10 @@ import com.clerk.ui.core.common.NavigableState
 import com.clerk.ui.core.navigation.pop
 
 @Stable
-internal class UserProfileState(val backStack: NavBackStack<NavKey>) :
-  NavigableState<UserProfileDestination> {
+internal class UserProfileState(
+  val backStack: NavBackStack<NavKey>,
+  private val onClearBackStack: (() -> Unit)? = null,
+) : NavigableState<UserProfileDestination> {
   override fun navigateTo(destination: NavKey) {
     backStack.add(destination)
   }
@@ -20,7 +22,8 @@ internal class UserProfileState(val backStack: NavBackStack<NavKey>) :
   }
 
   override fun clearBackStack() {
-    backStack.clear()
+    // In a host-owned back stack only the profile's own segment may be cleared.
+    onClearBackStack?.invoke() ?: backStack.clear()
   }
 
   override fun pop(numberOfScreens: Int) {

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
@@ -63,10 +63,12 @@ internal val LocalUserProfileState =
 @Composable
 internal fun UserProfileStateProvider(
   backStack: NavBackStack<NavKey>,
+  onClearBackStack: (() -> Unit)? = null,
   content: @Composable () -> Unit,
 ) {
   TelemetryProvider {
-    val userProfileState = UserProfileState(backStack = backStack)
+    val userProfileState =
+      UserProfileState(backStack = backStack, onClearBackStack = onClearBackStack)
     CompositionLocalProvider(LocalUserProfileState provides userProfileState) { content() }
   }
 }
@@ -241,39 +243,67 @@ private fun EntryProviderScope<NavKey>.userProfileEntries(
         },
     )
   }
-  entry<UserProfileDestination.UserProfileSecurity> { UserProfileSecurityView() }
+  userProfileChildEntries(
+    backStack = backStack,
+    customDestination = customDestination,
+    popToRoot = {
+      while (backStack.size > 1) {
+        backStack.removeLastOrNull()
+      }
+    },
+    navigateBack = { if (backStack.size > 1) backStack.removeLastOrNull() },
+    decorate = { content -> content() },
+  )
+}
 
-  entry<UserProfileDestination.UserProfileUpdate> { UserProfileUpdateProfileView() }
+/**
+ * Registers the destinations pushed above the profile root. Shared between the self-contained
+ * [UserProfileView] and host-owned back stacks ([clerkUserProfileEntries]); [decorate] lets the
+ * host-owned variant wrap each entry with the providers that the self-contained variant applies
+ * once around its own NavDisplay.
+ */
+internal fun EntryProviderScope<NavKey>.userProfileChildEntries(
+  backStack: NavBackStack<NavKey>,
+  customDestination: (@Composable (String) -> Unit)?,
+  popToRoot: () -> Unit,
+  navigateBack: () -> Unit,
+  decorate: @Composable (@Composable () -> Unit) -> Unit,
+) {
+  entry<UserProfileDestination.UserProfileSecurity> { decorate { UserProfileSecurityView() } }
+
+  entry<UserProfileDestination.UserProfileUpdate> { decorate { UserProfileUpdateProfileView() } }
 
   entry<UserProfileDestination.RenamePasskeyView> { key ->
-    UserProfilePasskeyRenameView(passkeyId = key.passkeyId, passkeyName = key.passkeyName)
+    decorate {
+      UserProfilePasskeyRenameView(passkeyId = key.passkeyId, passkeyName = key.passkeyName)
+    }
   }
 
-  entry<UserProfileDestination.VerifyView> { key -> UserProfileVerifyView(mode = key.mode) }
+  entry<UserProfileDestination.VerifyView> { key ->
+    decorate { UserProfileVerifyView(mode = key.mode) }
+  }
 
-  entry<UserProfileDestination.UserProfileDetail> { UserProfileDetailView() }
+  entry<UserProfileDestination.UserProfileDetail> { decorate { UserProfileDetailView() } }
 
   // Always register the entry so that a restored CustomRouteNavKey does not crash the graph.
   // If no destination is provided, pop back to the profile root.
   entry<CustomRouteNavKey> { key ->
-    if (customDestination != null) {
-      val navigator =
-        remember(backStack) {
-          UserProfileCustomNavigator(
-            pushAction = { routeKey -> backStack.add(CustomRouteNavKey(routeKey)) },
-            popToRootAction = {
-              while (backStack.size > 1) {
-                backStack.removeLastOrNull()
-              }
-            },
-            navigateBackAction = { if (backStack.size > 1) backStack.removeLastOrNull() },
-          )
+    decorate {
+      if (customDestination != null) {
+        val navigator =
+          remember(backStack) {
+            UserProfileCustomNavigator(
+              pushAction = { routeKey -> backStack.add(CustomRouteNavKey(routeKey)) },
+              popToRootAction = popToRoot,
+              navigateBackAction = navigateBack,
+            )
+          }
+        CompositionLocalProvider(LocalUserProfileCustomNavigator provides navigator) {
+          customDestination(key.routeKey)
         }
-      CompositionLocalProvider(LocalUserProfileCustomNavigator provides navigator) {
-        customDestination(key.routeKey)
+      } else {
+        LaunchedEffect(Unit) { backStack.removeLastOrNull() }
       }
-    } else {
-      LaunchedEffect(Unit) { backStack.removeLastOrNull() }
     }
   }
 }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
@@ -33,6 +33,9 @@ import com.clerk.ui.core.composition.LocalTelemetryCollector
 import com.clerk.ui.core.composition.TelemetryProvider
 import com.clerk.ui.core.footer.DevelopmentModeWarningBox
 import com.clerk.ui.core.navigation.rememberDismissHandler
+import com.clerk.ui.navigation.ClerkEmbeddedNavigation
+import com.clerk.ui.navigation.EmbeddedNavigationEffects
+import com.clerk.ui.navigation.LocalClerkEmbeddedNavigation
 import com.clerk.ui.theme.ClerkThemeOverrideProvider
 import com.clerk.ui.userprofile.account.UserProfileAccountSwitcherSheet
 import com.clerk.ui.userprofile.account.UserProfileAccountView
@@ -84,6 +87,10 @@ internal fun UserProfileStateProvider(
  * @param onDismiss Callback when the user profile view is dismissed. When omitted, top-level
  *   dismissal falls back to the system back dispatcher.
  * @param isDismissible Whether to show a top-right close affordance that dismisses the profile.
+ * @param embeddedNavigation Optional embedded-navigation handle for embedding the profile inside
+ *   the host's own navigation chrome. When provided, Clerk's top app bars are hidden and the host
+ *   observes and drives the profile's internal back stack through the handle. See
+ *   [ClerkEmbeddedNavigation].
  */
 @OptIn(ExperimentalAnimationApi::class)
 @SuppressLint("ComposeModifierMissing", "ComposeUnstableReceiver")
@@ -96,6 +103,7 @@ fun UserProfileView(
   onAddAccount: (() -> Unit)? = null,
   onDismiss: (() -> Unit)? = null,
   isDismissible: Boolean = true,
+  embeddedNavigation: ClerkEmbeddedNavigation? = null,
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
     val backStack = rememberNavBackStack(UserProfileDestination.UserProfileAccount)
@@ -121,6 +129,9 @@ fun UserProfileView(
       }
 
       if (showAuth) {
+        // The add-account flow replaces the profile entirely, so it keeps Clerk's own
+        // navigation chrome even when the profile itself is embedded. Hosts that want to own
+        // this flow can pass onAddAccount instead.
         AuthView(
           modifier = Modifier.fillMaxSize(),
           preferGoogleOneTap = false,
@@ -128,52 +139,55 @@ fun UserProfileView(
           onAuthComplete = { showAuth = false },
         )
       } else {
-        DevelopmentModeWarningBox(modifier = Modifier.fillMaxSize()) {
-          NavDisplay(
-            modifier = Modifier.fillMaxSize(),
-            backStack = backStack,
-            onBack = {
-              handleUserProfileBack(
-                isAtRoot = backStack.size == 1,
-                isDismissible = isDismissible,
-                onDismiss = dismissHandler,
-                onNavigateBack = { backStack.removeLastOrNull() },
-              )
-            },
-            transitionSpec = {
-              val spec = tween<IntOffset>(durationMillis = 300)
-              slideInHorizontally(animationSpec = spec, initialOffsetX = { it }) togetherWith
-                slideOutHorizontally(animationSpec = spec, targetOffsetX = { -it })
-            },
-            popTransitionSpec = {
-              val spec = tween<IntOffset>(durationMillis = 300)
-              slideInHorizontally(animationSpec = spec, initialOffsetX = { -it }) togetherWith
-                slideOutHorizontally(animationSpec = spec, targetOffsetX = { it })
-            },
-            predictivePopTransitionSpec = { distance ->
-              // Use the provided distance to align with the system back gesture
-              slideInHorizontally(initialOffsetX = { -distance }) togetherWith
-                slideOutHorizontally(targetOffsetX = { distance })
-            },
-            entryProvider =
-              entryProvider {
-                userProfileEntries(
-                  backStack = backStack,
+        EmbeddedNavigationEffects(embeddedNavigation = embeddedNavigation, backStack = backStack)
+        CompositionLocalProvider(LocalClerkEmbeddedNavigation provides embeddedNavigation) {
+          DevelopmentModeWarningBox(modifier = Modifier.fillMaxSize()) {
+            NavDisplay(
+              modifier = Modifier.fillMaxSize(),
+              backStack = backStack,
+              onBack = {
+                handleUserProfileBack(
+                  isAtRoot = backStack.size == 1,
                   isDismissible = isDismissible,
                   onDismiss = dismissHandler,
-                  customRows = customRows,
-                  customDestination = customDestination,
-                  onSwitchAccount = { showAccountSwitcher = true },
-                  onAddAccount = showAddAccountAuth,
+                  onNavigateBack = { backStack.removeLastOrNull() },
                 )
               },
-          )
-
-          if (showAccountSwitcher) {
-            UserProfileAccountSwitcherSheet(
-              onDismissRequest = { showAccountSwitcher = false },
-              onAddAccount = showAddAccountAuth,
+              transitionSpec = {
+                val spec = tween<IntOffset>(durationMillis = 300)
+                slideInHorizontally(animationSpec = spec, initialOffsetX = { it }) togetherWith
+                  slideOutHorizontally(animationSpec = spec, targetOffsetX = { -it })
+              },
+              popTransitionSpec = {
+                val spec = tween<IntOffset>(durationMillis = 300)
+                slideInHorizontally(animationSpec = spec, initialOffsetX = { -it }) togetherWith
+                  slideOutHorizontally(animationSpec = spec, targetOffsetX = { it })
+              },
+              predictivePopTransitionSpec = { distance ->
+                // Use the provided distance to align with the system back gesture
+                slideInHorizontally(initialOffsetX = { -distance }) togetherWith
+                  slideOutHorizontally(targetOffsetX = { distance })
+              },
+              entryProvider =
+                entryProvider {
+                  userProfileEntries(
+                    backStack = backStack,
+                    isDismissible = isDismissible,
+                    onDismiss = dismissHandler,
+                    customRows = customRows,
+                    customDestination = customDestination,
+                    onSwitchAccount = { showAccountSwitcher = true },
+                    onAddAccount = showAddAccountAuth,
+                  )
+                },
             )
+
+            if (showAccountSwitcher) {
+              UserProfileAccountSwitcherSheet(
+                onDismissRequest = { showAccountSwitcher = false },
+                onAddAccount = showAddAccountAuth,
+              )
+            }
           }
         }
       }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/account/UserProfileAccountView.kt
@@ -46,6 +46,7 @@ internal fun UserProfileAccountView(
   onClickEdit: () -> Unit,
   modifier: Modifier = Modifier,
   isDismissible: Boolean = true,
+  showsBackButton: Boolean = false,
   customRows: ImmutableList<UserProfileCustomRow> = persistentListOf(),
   onCustomRowClick: (routeKey: String) -> Unit = {},
 ) {
@@ -63,6 +64,7 @@ internal fun UserProfileAccountView(
     onBackPressed = onBackPressed,
     onEditAvatarClick = onClickEdit,
     isDismissible = isDismissible,
+    showsBackButton = showsBackButton,
     customRows = customRows,
     onCustomRowClick = onCustomRowClick,
   )
@@ -80,6 +82,7 @@ private fun UserProfileAccountViewImpl(
   onEditAvatarClick: () -> Unit,
   modifier: Modifier = Modifier,
   isDismissible: Boolean = true,
+  showsBackButton: Boolean = false,
   imageUrl: String? = null,
   viewModel: UserProfileAccountViewModel = viewModel(),
   customRows: ImmutableList<UserProfileCustomRow> = persistentListOf(),
@@ -97,7 +100,7 @@ private fun UserProfileAccountViewImpl(
       modifier = modifier,
       title = stringResource(R.string.account),
       backgroundColor = ClerkMaterialTheme.colors.muted,
-      hasBackButton = false,
+      hasBackButton = showsBackButton,
       horizontalPadding = dp0,
       onBackPressed = onBackPressed,
       trailingContent = userProfileDismissTrailingContent(isDismissible, onDismiss = onBackPressed),

--- a/source/ui/src/test/java/com/clerk/ui/navigation/ClerkEmbeddedNavigationTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/navigation/ClerkEmbeddedNavigationTest.kt
@@ -1,0 +1,55 @@
+package com.clerk.ui.navigation
+
+import com.clerk.api.FrameworkIntegrationApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(FrameworkIntegrationApi::class)
+class ClerkEmbeddedNavigationTest {
+
+  @Test
+  fun `canGoBack reflects depth`() {
+    val embeddedNavigation = ClerkEmbeddedNavigation()
+
+    assertFalse(embeddedNavigation.canGoBack)
+
+    embeddedNavigation.depth = 2
+
+    assertEquals(2, embeddedNavigation.depth)
+    assertTrue(embeddedNavigation.canGoBack)
+  }
+
+  @Test
+  fun `pop routes to registered handler`() {
+    val embeddedNavigation = ClerkEmbeddedNavigation()
+    val pops = mutableListOf<Boolean>()
+    embeddedNavigation.popHandler = { toRoot -> pops.add(toRoot) }
+
+    embeddedNavigation.pop()
+    embeddedNavigation.popToRoot()
+
+    assertEquals(listOf(false, true), pops)
+  }
+
+  @Test
+  fun `pop is a no-op without a registered handler`() {
+    val embeddedNavigation = ClerkEmbeddedNavigation()
+
+    embeddedNavigation.pop()
+    embeddedNavigation.popToRoot()
+  }
+
+  @Test
+  fun `clearing the handler stops routing pops`() {
+    val embeddedNavigation = ClerkEmbeddedNavigation()
+    val pops = mutableListOf<Boolean>()
+    embeddedNavigation.popHandler = { toRoot -> pops.add(toRoot) }
+    embeddedNavigation.popHandler = null
+
+    embeddedNavigation.pop()
+
+    assertTrue(pops.isEmpty())
+  }
+}


### PR DESCRIPTION
## Problem

The embedded-navigation handle ([#798](https://github.com/clerk/clerk-android/pull/798)) lets a host hide Clerk's top bars and drive the profile's internal stack, but the profile still renders its own navigation container. Native Compose apps should be able to put Clerk's screens *inside their own* `NavDisplay` — the Android counterpart of the iOS SDK's public `UserProfileView(navigationPath:)` embedding — so the host owns transitions, predictive back, and the stack itself.

## What this adds

A public `ClerkUserProfileRoute` key and `EntryProviderScope.clerkUserProfileEntries(backStack)`:

```kotlin
val backStack = rememberNavBackStack(Home)

NavDisplay(
  backStack = backStack,
  entryProvider =
    entryProvider {
      entry<Home> { HomeScreen(onOpenProfile = { backStack.add(ClerkUserProfileRoute) }) }
      clerkUserProfileEntries(backStack)
    },
)
```

- Clerk's internal destination keys stay internal; hosts interact only with the root key. Internal keys restore in the host's `rememberNavBackStack` via nav3's reflection-based NavKey serialization.
- The profile removes only its own segment of the stack on exit: root back navigation, sign-out, and account deletion pop through `ClerkUserProfileRoute` and never touch host entries (`UserProfileState.clearBackStack` gains a scoped strategy for this).
- The profile root shows a back arrow instead of the dismiss X in this mode.
- `navigation3-runtime` moves from `implementation` to `api` since the new surface exposes its types.
- The existing self-contained `UserProfileView` shares the same entry registrations (extracted `userProfileChildEntries`) and is unchanged in behavior.

Verified end to end on an emulator via the new demo in the prebuilt-ui sample: host home → profile root → Security inside one host-owned `NavDisplay`, with hardware back unwinding one screen at a time and landing on the intact host screen.

Follow-up (intentionally not in this PR): the same treatment for `AuthView`. Its `AuthState` carries cross-screen form state, so per-entry providers would break it — the shared-scope design for that is coming separately.

## Modules

`source/ui` and the `prebuilt-ui` sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add host-owned back stack embedding for the Clerk user profile in NavDisplay
> - Adds `clerkUserProfileEntries` extension on `EntryProviderScope` so apps can register Clerk's user profile destinations inside their own `NavDisplay` and back stack, with Clerk only removing its own keys on exit.
> - Introduces `ClerkUserProfileRoute` as a serializable `NavKey` that hosts push onto their `NavBackStack` to open the profile.
> - Adds `exitClerkUserProfile` and `popToClerkUserProfileRoot` back stack helpers and a `HostEntryChrome` wrapper that applies Clerk's theme and providers to hosted entries.
> - Refactors `userProfileChildEntries` out of `userProfileEntries` so child destinations are shared between self-contained and host-owned setups without changing existing behavior.
> - Adds a sample `HostStackProfileSample` composable in the prebuilt-ui sample app demonstrating the host-owned flow via a full-screen dialog.
> - Behavioral Change: `libs.androidx.navigation3.runtime` is now exposed as `api` from the `source/ui` module, making it transitive for library consumers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a7f419.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->