### PR TITLE
fix(ui): link Google accounts instead of signing in

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/network/api/UserApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/UserApi.kt
@@ -470,7 +470,8 @@ internal interface UserApi {
   @FormUrlEncoded
   @POST(ApiPaths.User.ExternalAccount.BASE)
   suspend fun createExternalAccount(
-    @FieldMap params: Map<String, String>
+    @FieldMap params: Map<String, String>,
+    @Query(ApiParams.CLERK_SESSION_ID) sessionId: String? = Clerk.session?.id,
   ): ClerkResult<ExternalAccount, ClerkErrorResponse>
 
   /**
@@ -486,6 +487,7 @@ internal interface UserApi {
   suspend fun reauthorizeExternalAccount(
     @Path(ApiParams.EXTERNAL_ACCOUNT_ID) externalAccountId: String,
     @Field("redirect_url") redirectUrl: String,
+    @Query(ApiParams.CLERK_SESSION_ID) sessionId: String? = Clerk.session?.id,
   ): ClerkResult<ExternalAccount, ClerkErrorResponse>
 
   /**

--- a/source/api/src/test/java/com/clerk/api/network/api/UserApiTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/api/UserApiTest.kt
@@ -26,6 +26,18 @@ class UserApiTest {
     }
   }
 
+  @Test
+  fun `external account linking endpoints include clerk session id query`() {
+    val linkingMethods = listOf("createExternalAccount", "reauthorizeExternalAccount")
+
+    linkingMethods.forEach { methodName ->
+      assertTrue(
+        method(methodName).hasQuery(ApiParams.CLERK_SESSION_ID),
+        "$methodName should include _clerk_session_id",
+      )
+    }
+  }
+
   private fun method(name: String): java.lang.reflect.Method {
     return UserApi::class.java.methods.single { it.name == name }
   }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/AddConnectedAccountViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/AddConnectedAccountViewModel.kt
@@ -2,26 +2,19 @@ package com.clerk.ui.userprofile.connectedaccount
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.clerk.api.Clerk
 import com.clerk.api.externalaccount.ExternalAccount
 import com.clerk.api.externalaccount.delete
-import com.clerk.api.externalaccount.reauthorize
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.serialization.errorMessage
-import com.clerk.api.network.serialization.flatMap
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
-import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
-import com.clerk.api.sso.ResultType
 import com.clerk.api.user.User
 import com.clerk.api.user.createExternalAccount
 import com.clerk.ui.core.common.guardUser
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 internal class AddConnectedAccountViewModel : ViewModel() {
 
@@ -32,32 +25,12 @@ internal class AddConnectedAccountViewModel : ViewModel() {
     _state.value = State.Loading
     guardUser(userDoesNotExist = { _state.value = State.Error("User does not exist") }) { user ->
       viewModelScope.launch {
-        if (provider == OAuthProvider.GOOGLE && Clerk.isGoogleOneTapEnabled) {
-          handleGoogleOneTap()
-        } else {
-
-          user
-            .createExternalAccount(User.CreateExternalAccountParams(provider = provider))
-            .flatMap { it.reauthorize() }
-            .onSuccess { _state.value = State.Success }
-            .onFailure { _state.value = State.Error(it.errorMessage) }
-        }
+        user
+          .createExternalAccount(User.CreateExternalAccountParams(provider = provider))
+          .onSuccess { _state.value = State.Success }
+          .onFailure { _state.value = State.Error(it.errorMessage) }
       }
     }
-  }
-
-  private suspend fun handleGoogleOneTap() {
-    SignIn.authenticateWithGoogleOneTap()
-      .onSuccess {
-        withContext(Dispatchers.Main) {
-          when (it.resultType) {
-            ResultType.SIGN_IN -> _state.value = State.Success
-            ResultType.SIGN_UP -> _state.value = State.Success
-            ResultType.UNKNOWN -> _state.value = State.Error("Unknown result type")
-          }
-        }
-      }
-      .onFailure { withContext(Dispatchers.Main) { _state.value = State.Error(it.errorMessage) } }
   }
 
   fun removeConnectedAccount(externalAccount: ExternalAccount) {

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileAddConnectedAccountView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileAddConnectedAccountView.kt
@@ -8,9 +8,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.clerk.api.Clerk
 import com.clerk.api.sso.OAuthProvider
@@ -44,6 +47,14 @@ private fun UserProfileAddConnectedAccountViewImpl(
   viewModel: AddConnectedAccountViewModel = viewModel(),
   onClosePressed: () -> Unit,
 ) {
+  val state by viewModel.state.collectAsStateWithLifecycle()
+  LaunchedEffect(state) {
+    handleAddConnectedAccountState(
+      state = state,
+      resetState = viewModel::resetState,
+      onClosePressed = onClosePressed,
+    )
+  }
   Column(modifier = Modifier.then(modifier)) {
     BottomSheetTopBar(
       title = stringResource(R.string.connect_account),
@@ -63,6 +74,17 @@ private fun UserProfileAddConnectedAccountViewImpl(
         onClick = { viewModel.connectExternalAccount(it) },
       )
     }
+  }
+}
+
+internal fun handleAddConnectedAccountState(
+  state: AddConnectedAccountViewModel.State,
+  resetState: () -> Unit,
+  onClosePressed: () -> Unit,
+) {
+  if (state == AddConnectedAccountViewModel.State.Success) {
+    resetState()
+    onClosePressed()
   }
 }
 

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/connectedaccount/AddConnectedAccountViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/connectedaccount/AddConnectedAccountViewModelTest.kt
@@ -14,6 +14,7 @@ import com.clerk.api.user.User
 import com.clerk.api.user.createExternalAccount
 import com.clerk.ui.userprofile.MainDispatcherRule
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -58,7 +59,6 @@ class AddConnectedAccountViewModelTest {
     val account = mockk<ExternalAccount>()
     every { Clerk.user } returns user
     coEvery { user.createExternalAccount(any()) } returns ClerkResult.success(account)
-    coEvery { account.reauthorize() } returns ClerkResult.success(account)
 
     val viewModel = AddConnectedAccountViewModel()
 
@@ -66,6 +66,7 @@ class AddConnectedAccountViewModelTest {
     advanceUntilIdle()
 
     assertEquals(AddConnectedAccountViewModel.State.Success, viewModel.state.value)
+    coVerify(exactly = 0) { account.reauthorize() }
   }
 
   @Test
@@ -99,11 +100,14 @@ class AddConnectedAccountViewModelTest {
   }
 
   @Test
-  fun googleOneTap_success_setsSuccessState() = runTest {
+  fun googleOneTapEnabled_connectsExternalAccountInsteadOfSigningIn() = runTest {
     val result = mockk<OAuthResult> { every { resultType } returns ResultType.SIGN_IN }
-    every { Clerk.user } returns mockk()
+    val user = mockk<User>()
+    val account = mockk<ExternalAccount>()
+    every { Clerk.user } returns user
     every { Clerk.isGoogleOneTapEnabled } returns true
     coEvery { SignIn.authenticateWithGoogleOneTap() } returns ClerkResult.success(result)
+    coEvery { user.createExternalAccount(any()) } returns ClerkResult.success(account)
 
     val viewModel = AddConnectedAccountViewModel()
 
@@ -111,38 +115,12 @@ class AddConnectedAccountViewModelTest {
     advanceUntilIdle()
 
     assertEquals(AddConnectedAccountViewModel.State.Success, viewModel.state.value)
-  }
-
-  @Test
-  fun googleOneTap_unknownResult_setsErrorState() = runTest {
-    val result = mockk<OAuthResult> { every { resultType } returns ResultType.UNKNOWN }
-    every { Clerk.user } returns mockk()
-    every { Clerk.isGoogleOneTapEnabled } returns true
-    coEvery { SignIn.authenticateWithGoogleOneTap() } returns ClerkResult.success(result)
-
-    val viewModel = AddConnectedAccountViewModel()
-
-    viewModel.connectExternalAccount(OAuthProvider.GOOGLE)
-    advanceUntilIdle()
-
-    assertEquals(
-      AddConnectedAccountViewModel.State.Error("Unknown result type"),
-      viewModel.state.value,
-    )
-  }
-
-  @Test
-  fun googleOneTap_failure_setsErrorState() = runTest {
-    val error = ClerkErrorResponse(errors = listOf(Error(longMessage = "nope")))
-    every { Clerk.user } returns mockk()
-    every { Clerk.isGoogleOneTapEnabled } returns true
-    coEvery { SignIn.authenticateWithGoogleOneTap() } returns ClerkResult.Failure(error)
-
-    val viewModel = AddConnectedAccountViewModel()
-
-    viewModel.connectExternalAccount(OAuthProvider.GOOGLE)
-    advanceUntilIdle()
-
-    assertEquals(AddConnectedAccountViewModel.State.Error("nope"), viewModel.state.value)
+    coVerify(exactly = 1) {
+      user.createExternalAccount(
+        match<User.CreateExternalAccountParams> { it.provider == OAuthProvider.GOOGLE }
+      )
+    }
+    coVerify(exactly = 0) { account.reauthorize() }
+    coVerify(exactly = 0) { SignIn.authenticateWithGoogleOneTap(any()) }
   }
 }

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/connectedaccount/UserProfileAddConnectedAccountViewTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/connectedaccount/UserProfileAddConnectedAccountViewTest.kt
@@ -1,0 +1,33 @@
+package com.clerk.ui.userprofile.connectedaccount
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UserProfileAddConnectedAccountViewTest {
+
+  @Test
+  fun successResetsStateAndClosesSheet() {
+    val events = mutableListOf<String>()
+
+    handleAddConnectedAccountState(
+      state = AddConnectedAccountViewModel.State.Success,
+      resetState = { events += "reset" },
+      onClosePressed = { events += "close" },
+    )
+
+    assertEquals(listOf("reset", "close"), events)
+  }
+
+  @Test
+  fun nonSuccessStateKeepsSheetOpen() {
+    val events = mutableListOf<String>()
+
+    handleAddConnectedAccountState(
+      state = AddConnectedAccountViewModel.State.Loading,
+      resetState = { events += "reset" },
+      onClosePressed = { events += "close" },
+    )
+
+    assertEquals(emptyList(), events)
+  }
+}


### PR DESCRIPTION
### What & why
- Fixes MOBILE-604 by routing Google account connections through the existing external-account linking flow instead of `SignIn.authenticateWithGoogleOneTap()`.
- Include the active Clerk session on external-account create and reauthorize requests so the backend can authenticate them.
- Treat successful `createExternalAccount()` completion as the completed OAuth link. Calling `reauthorize()` afterward used a now-null redirect URL and crashed the app.
- Reset the success state and dismiss the Connect account sheet when the OAuth callback completes.
- Add regression coverage for session-aware endpoints, avoiding One Tap sign-in and redundant reauthorization, and success-driven sheet dismissal.

### What to focus on
- The external-account flow now relies on `createExternalAccount()` to perform and complete the OAuth redirect before returning success.
- The success observer resets view-model state before dismissing so reopening the sheet does not immediately close it again.

### Screenshots / video

https://github.com/user-attachments/assets/3c6fafda-415e-43a2-885a-ef1c450702dc




### Testing
- `./gradlew :source:api:testDebugUnitTest --tests 'com.clerk.api.network.api.UserApiTest' :source:ui:testDebugUnitTest --tests 'com.clerk.ui.userprofile.connectedaccount.*' spotlessCheck`
- `./gradlew :workbench:installDebug`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Google account connection to link accounts instead of signing in
> - Removes the Google One Tap branch from `AddConnectedAccountViewModel.connectExternalAccount`, which previously called `SignIn.authenticateWithGoogleOneTap()` and could silently create a new account instead of linking.
> - The method now always calls `user.createExternalAccount()` regardless of provider, matching the correct non-One-Tap behavior.
> - Adds `_clerk_session_id` as a query parameter to `UserApi.createExternalAccount` and `UserApi.reauthorizeExternalAccount` so the session is included in the request.
> - The connected account bottom sheet now closes automatically on `State.Success` via a new `handleAddConnectedAccountState` handler.
> - Behavioral Change: Google One Tap is no longer used in the add-connected-account flow; all Google account connections go through `createExternalAccount`.
>
> #### 🖇️ Linked Issues
> Resolves [MOBILE-604](https://linear.app/clerk/issue/MOBILE-604), which identified that the One Tap path in `AddConnectedAccountViewModel` was signing users in rather than linking their Google account.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 641e405.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->