### PR TITLE
fix(ui): localize remaining auth strings

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/input/ClerkPhoneNumberField.kt
@@ -467,7 +467,7 @@ private fun CountryDropdownContent(
     if (detectedCountry != null) {
       Text(
         modifier = Modifier.padding(start = dp12),
-        text = "Default",
+        text = stringResource(R.string.default_text),
         style = ClerkMaterialTheme.typography.labelSmall,
         color = ClerkMaterialTheme.colors.mutedForeground,
       )

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
@@ -186,7 +186,8 @@ private fun PasswordInputs(authState: AuthState, passwordsMatch: Boolean, onSubm
     visualTransformation = PasswordVisualTransformation(),
     inputContentType = ContentType.Password,
     isError = showPasswordMismatchError,
-    supportingText = if (showPasswordMismatchError) "Passwords don't match" else null,
+    supportingText =
+      if (showPasswordMismatchError) stringResource(R.string.passwords_dont_match) else null,
     keyboardOptions =
       KeyboardOptions(
         keyboardType = KeyboardType.Password,

--- a/source/ui/src/main/res/values/strings.xml
+++ b/source/ui/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="reset_password">Reset password</string>
     <string name="confirm_password">Confirm password</string>
     <string name="new_password">New password</string>
+    <string name="passwords_dont_match">Passwords don\'t match</string>
     <string name="account_requires_new_password_before_continue" tools:ignore="MissingTranslation">Your account requires a new password before you can continue</string>
     <string name="sign_out_of_all_other_devices">Sign out of all other devices</string>
     <string name="choose_an_organization">Choose an organization</string>


### PR DESCRIPTION
## Summary

- replace the hardcoded phone-country `Default` label with the existing `default_text` string resource
- add a `passwords_dont_match` resource and use it for the reset-password validation message

## Why

MOBILE-610 identified English literals in the Android auth UI that bypassed Android string resources and therefore could not participate in localization.

## Impact

The phone country selector and reset-password mismatch state now resolve their labels through Android resources. Authentication behavior is unchanged.

## Root cause

The affected Compose components passed English literals directly to `Text` and `supportingText` instead of resolving resource IDs.

## Validation

- `./gradlew spotlessCheck`
- `./gradlew :source:ui:testDebug detekt`
- parsed `source/ui/src/main/res/values/strings.xml` with Python's XML parser
- verified the hardcoded literals are absent from the Kotlin sources
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Localize hardcoded "Default" and "Passwords don't match" strings in Android auth UI
> Replaces two hardcoded English strings with `stringResource` lookups to support localization. Fixes `"Default"` in [`ClerkPhoneNumberField.kt`](https://github.com/clerk/clerk-android/pull/847/files#diff-f151351fd98f0e749d08f5fa2c42ae9c26638731c159cef1846cc5abeb3c5ea8) and `"Passwords don't match"` in [`SignInSetNewPasswordView.kt`](https://github.com/clerk/clerk-android/pull/847/files#diff-1547c83257dd8c1a1ddd71a73b45e8dbfd5b16a7e5587b83ec9de3150a0b802d), with corresponding entries added to [`strings.xml`](https://github.com/clerk/clerk-android/pull/847/files#diff-5cce6e7b65f7d6859f9bdfab6e0e2885d594eeb4bca3f02c74dfcc50b0b1e751).
>
> #### 🖇️ Linked Issues
> Resolves [MOBILE-610](https://linear.app/clerk/issue/MOBILE-610), which identified these two untranslated strings as the remaining hardcoded English text in the Android auth UI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a3895b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->