### PR TITLE
fix(ui): label user avatars for accessibility

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt
@@ -76,7 +76,13 @@ internal fun AvatarView(
   Box(modifier = Modifier.wrapContentSize().then(modifier), contentAlignment = Alignment.Center) {
     SubcomposeAsyncImage(
       model = imageModel,
-      contentDescription = stringResource(R.string.logo),
+      contentDescription =
+        stringResource(
+          when (avatarType) {
+            AvatarType.USER -> R.string.user_avatar
+            AvatarType.ORGANIZATION -> R.string.logo
+          }
+        ),
       modifier = Modifier.size(size.toDp()).clip(shape),
       contentScale = ContentScale.FillBounds,
       loading = { CircularProgressIndicator(modifier = Modifier.size(dp24)) },


### PR DESCRIPTION
### Motivation
- Prevent TalkBack from announcing user profile images as “Logo” by using the correct localized content description for user avatars instead of always using the logo string.

### Description
- Update `AvatarView` (`source/ui/src/main/java/com/clerk/ui/core/avatar/AvatarView.kt`) to set the `contentDescription` via `stringResource` conditional on `avatarType`, using `R.string.user_avatar` for `AvatarType.USER` and preserving `R.string.logo` for `AvatarType.ORGANIZATION`.

### Testing
- Ran `git diff --check` which reported no whitespace/errors and committed the change as `fix(ui): label user avatars for accessibility`.
- Attempted `./gradlew spotlessApply spotlessCheck :source:ui:testDebug` but execution of the UI test task was blocked by the environment lacking the configured Java 21 toolchain, so unit/ui tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cd915dcf083228df913e2193d0a1e)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix TalkBack reading user avatars as "Logo" in `AvatarView`
> The `contentDescription` in [AvatarView.kt](https://github.com/clerk/clerk-android/pull/854/files#diff-cb85d80d2b49422f9764483d59a02e483c0394fa26263b65969103ab690f1dc1) was hardcoded to `R.string.logo` for all avatar types. It now uses `R.string.user_avatar` when `avatarType == AvatarType.USER` and `R.string.logo` for `AvatarType.ORGANIZATION`.
>
> #### 🖇️ Linked Issues
> Resolves [MOBILE-608](https://linear.app/clerk/issue/MOBILE-608), which tracked TalkBack announcing all user avatars as "Logo" due to the hardcoded string resource.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32db53c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Updated avatar image descriptions to distinguish between user avatars and organization logos, improving clarity for screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->