### PR TITLE
Rename "Client Trust" to "Device Trust" in KDoc

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
@@ -189,7 +189,7 @@ data class SignIn(
     /** The user needs to create a new password. */
     @SerialName("needs_new_password") NEEDS_NEW_PASSWORD,
 
-    /** Client trust verification is required. */
+    /** Device trust verification is required. */
     @SerialName("needs_client_trust") NEEDS_CLIENT_TRUST,
 
     /** The sign-in process is in an unknown state. */

--- a/source/ui/src/main/java/com/clerk/ui/signin/clienttrust/SignInClientTrustView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/clienttrust/SignInClientTrustView.kt
@@ -19,7 +19,7 @@ import com.clerk.ui.theme.ClerkMaterialTheme
 import com.clerk.ui.theme.ClerkThemeOverrideProvider
 
 /**
- * A composable that displays the client trust verification view.
+ * A composable that displays the device trust verification view.
  *
  * This view is shown when the user is signing in from a new or untrusted device and needs to
  * complete an additional verification step. It displays a warning message explaining why
@@ -29,7 +29,7 @@ import com.clerk.ui.theme.ClerkThemeOverrideProvider
  * [SignInFactorCodeView] for phone code or email code verification, or [SignInGetHelpView] for
  * unsupported strategies.
  *
- * @param factor The factor to be verified for client trust.
+ * @param factor The factor to be verified for device trust.
  * @param modifier The [Modifier] to be applied to the view.
  * @param clerkTheme Optional theme override for customization.
  * @param onAuthComplete Callback invoked when authentication is complete.
@@ -58,7 +58,7 @@ fun SignInClientTrustView(
 }
 
 /**
- * A composable that displays a warning message for client trust verification.
+ * A composable that displays a warning message for device trust verification.
  *
  * This message informs the user that they are signing in from a new device and explains why
  * additional verification is being requested.


### PR DESCRIPTION
Part of [PROT-875](https://linear.app/clerk/issue/PROT-875/fully-rename-client-trust-to-device-trust).

## What

Renames the customer-facing feature name "Client Trust" → "Device Trust" in the four places it appears as prose in this SDK:

| File | What |
| --- | --- |
| `SignIn.kt` | `NEEDS_CLIENT_TRUST` status KDoc |
| `SignInClientTrustView.kt` | composable KDoc, its `@param factor` line, and the `ClientTrustWarningMessage` KDoc |

These surface in IDE quick documentation and generated API docs. "Client" is jargon to less technical readers, and "Device Trust" aligns with Protect's "Device Intelligence" naming. This SDK was flagged as still carrying the old name during review of the docs PR.

## API values and identifiers are deliberately unchanged

Per Kyle in the naming thread: _"we don't have to change APIs but the way we discuss clients externally should flip to devices."_

So the `com.clerk.ui.signin.clienttrust` package, `SignInClientTrustView`, `ClientTrustWarningMessage`, `isClientTrust`, `NEEDS_CLIENT_TRUST`, and the `needs_client_trust` wire value all keep their names — renaming them would break existing custom sign-in flows. **The diff is 4 lines and touches no identifier**, so `detekt-baseline.xml` needs no regeneration.

## No user-facing string changes

`R.string.signing_in_from_new_device` already reads "You're signing in from a new device. We're asking for verification to keep your account secure." — it was device-worded from the start, so nothing an end user sees changes here.

## Related

- clerk/clerk#3051 — docs + marketing (approved; landing as part of a combined typedoc sync PR)
- clerk/javascript#9266 — JSDoc (merged)
- clerk/dashboard#9839 — dashboard UI labels
- clerk/clerk_go#20787, clerk/skills#59
- Companion PRs: clerk-ios#540, clerk-expo-quickstart

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename 'Client Trust' to 'Device Trust' in KDoc comments
> Updates KDoc comments in `SignIn` and `SignInClientTrustView` to replace 'client trust' with 'device trust', aligning in-code documentation with the product terminology change described in [PROT-875](https://linear.app/clerk/issue/PROT-875). No runtime behavior is affected.
>
> #### 🖇️ Linked Issues
> Partially completes [PROT-875](https://linear.app/clerk/issue/PROT-875), which tracks the full rename of 'Client Trust' to 'Device Trust' across docs and product to better align with 'Device Intelligence' feature naming.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a9bcd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sign-in terminology from “client trust” to “device trust” for clearer device verification messaging.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->