### PR TITLE
fix(android): preserve custom OAuth provider strategy keys

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -1111,7 +1111,7 @@ data class ClerkConfigurationOptions(
  *
  * This is useful for easily iterating over available OAuth providers for UI display or other logic.
  *
- * @return A list of [OAuthProvider] enums corresponding to the enabled social providers.
+ * @return A list of [OAuthProvider] values corresponding to the enabled social providers.
  * @receiver A map where keys are strategy identifiers (e.g., `oauth_google`) and values are
  *   [UserSettings.SocialConfig].
  */

--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -304,7 +304,7 @@ class Auth internal constructor() {
   ): ClerkResult<OAuthResult, ClerkErrorResponse> {
     val result =
       SSOService.authenticateWithRedirect(
-        strategy = provider.providerData.strategy,
+        strategy = provider.strategy,
         redirectUrl = RedirectConfiguration.DEFAULT_REDIRECT_URL,
       )
     result.onFailure { emitAuthError(it) }
@@ -499,7 +499,7 @@ class Auth internal constructor() {
   ): ClerkResult<OAuthResult, ClerkErrorResponse> {
     val result =
       SSOService.authenticateSignUpWithRedirect(
-        strategy = provider.providerData.strategy,
+        strategy = provider.strategy,
         redirectUrl = RedirectConfiguration.DEFAULT_REDIRECT_URL,
       )
     result.onFailure { emitAuthError(it) }

--- a/source/api/src/main/kotlin/com/clerk/api/externalaccount/ExternalAccount.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/externalaccount/ExternalAccount.kt
@@ -115,4 +115,7 @@ suspend fun ExternalAccount.revokeTokens(): ClerkResult<User, ClerkErrorResponse
 }
 
 val ExternalAccount.oauthProviderType: OAuthProvider
-  get() = OAuthProvider.fromStrategy(this.provider)
+  get() {
+    val strategy = provider.takeIf { it.startsWith("oauth_") } ?: "oauth_$provider"
+    return OAuthProvider.fromStrategy(strategy)
+  }

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
@@ -348,7 +348,7 @@ data class SignIn(
     @Serializable
     @AutoMap
     data class OAuth(
-      @MapProperty("providerData?.strategy") val provider: OAuthProvider,
+      @MapProperty("strategy") val provider: OAuthProvider,
       @SerialName("redirect_url")
       override val redirectUrl: String = RedirectConfiguration.DEFAULT_REDIRECT_URL,
       @SerialName("email_address") override val emailAddress: String? = null,
@@ -728,7 +728,7 @@ data class SignIn(
       val strategy =
         when (params) {
           is AuthenticateWithRedirectParams.EnterpriseSSO -> params.strategy
-          is AuthenticateWithRedirectParams.OAuth -> params.provider.providerData.strategy
+          is AuthenticateWithRedirectParams.OAuth -> params.provider.strategy
         }
       return SSOService.authenticateWithRedirect(
         strategy = strategy,

--- a/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
@@ -296,7 +296,7 @@ data class SignUp(
     @AutoMap
     @Serializable
     data class OAuth(
-      @MapProperty("providerData?.strategy") @SerialName("strategy") val provider: OAuthProvider,
+      @MapProperty("strategy") @SerialName("strategy") val provider: OAuthProvider,
       @SerialName("redirect_url")
       override val redirectUrl: String = RedirectConfiguration.DEFAULT_REDIRECT_URL,
       override val identifier: String? = null,
@@ -542,7 +542,7 @@ data class SignUp(
       val strategy =
         when (params) {
           is AuthenticateWithRedirectParams.EnterpriseSSO -> params.strategy
-          is AuthenticateWithRedirectParams.OAuth -> params.provider.providerData.strategy
+          is AuthenticateWithRedirectParams.OAuth -> params.provider.strategy
         }
       return SSOService.authenticateSignUpWithRedirect(
         strategy = strategy,

--- a/source/api/src/main/kotlin/com/clerk/api/sso/OAuthProvider.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/OAuthProvider.kt
@@ -46,7 +46,8 @@ import kotlinx.serialization.encoding.Encoder
  * @see [OAuthProviderData]
  */
 @kotlinx.serialization.Serializable(with = OAuthProviderSerializer::class)
-class OAuthProvider private constructor(val strategy: String) {
+@ConsistentCopyVisibility
+data class OAuthProvider private constructor(val strategy: String) {
   companion object {
     /** Facebook OAuth authentication provider. */
     @JvmField val FACEBOOK = OAuthProvider("oauth_facebook")
@@ -318,10 +319,6 @@ class OAuthProvider private constructor(val strategy: String) {
         strategy.startsWith("oauth_") -> "CUSTOM"
         else -> "UNKNOWN"
       }
-
-  override fun equals(other: Any?): Boolean = other is OAuthProvider && strategy == other.strategy
-
-  override fun hashCode(): Int = strategy.hashCode()
 
   override fun toString(): String = name
 }

--- a/source/api/src/main/kotlin/com/clerk/api/sso/OAuthProvider.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/OAuthProvider.kt
@@ -2,16 +2,23 @@ package com.clerk.api.sso
 
 import androidx.annotation.VisibleForTesting
 import com.clerk.api.Clerk
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 /**
- * Enum class representing supported OAuth providers for authentication.
+ * Value representing an OAuth provider strategy for authentication.
  *
  * Each OAuth provider corresponds to a third-party authentication service that users can use to
- * sign in to your application. The enum provides a type-safe way to reference OAuth providers and
- * automatically handles the mapping to the appropriate strategy strings used in Clerk API requests.
+ * sign in to your application. Built-in providers are available as constants, while custom
+ * providers retain their complete strategy string so it can be sent to Clerk without losing the
+ * provider key.
  *
  * ## Supported Providers
- * The enum includes support for major OAuth providers such as:
+ * The type includes support for major OAuth providers such as:
  * - **Social platforms**: Facebook, Google, Twitter, Instagram, TikTok, Discord
  * - **Professional platforms**: LinkedIn, Microsoft, Slack
  * - **Developer platforms**: GitHub, GitLab, Bitbucket, Atlassian, Vercel
@@ -33,114 +40,218 @@ import com.clerk.api.Clerk
  *
  * // Convert from strategy string
  * val provider = OAuthProvider.fromStrategy("oauth_github")
+ * val customProvider = OAuthProvider.custom("oauth_custom_patreon")
  * ```
  *
  * @see [OAuthProviderData]
  */
-@kotlinx.serialization.Serializable
-enum class OAuthProvider {
-  /** Facebook OAuth authentication provider. */
-  FACEBOOK,
-
-  /** Google OAuth authentication provider. */
-  GOOGLE,
-
-  /** HubSpot OAuth authentication provider. */
-  HUBSPOT,
-
-  /** GitHub OAuth authentication provider. */
-  GITHUB,
-
-  /** TikTok OAuth authentication provider. */
-  TIKTOK,
-
-  /** GitLab OAuth authentication provider. */
-  GITLAB,
-
-  /** Discord OAuth authentication provider. */
-  DISCORD,
-
-  /** Twitter OAuth authentication provider. */
-  TWITTER,
-
-  /** Twitch OAuth authentication provider. */
-  TWITCH,
-
-  /** LinkedIn OAuth authentication provider (legacy). */
-  LINKEDIN,
-
-  /** LinkedIn OpenID Connect authentication provider. */
-  LINKEDIN_OIDC,
-
-  /** Dropbox OAuth authentication provider. */
-  DROPBOX,
-
-  /** Atlassian OAuth authentication provider. */
-  ATLASSIAN,
-
-  /** Bitbucket OAuth authentication provider. */
-  BITBUCKET,
-
-  /** Microsoft OAuth authentication provider. */
-  MICROSOFT,
-
-  /** Notion OAuth authentication provider. */
-  NOTION,
-
-  /** Apple OAuth authentication provider. */
-  APPLE,
-
-  /** LINE OAuth authentication provider. */
-  LINE,
-
-  /** Instagram OAuth authentication provider. */
-  INSTAGRAM,
-
-  /** Coinbase OAuth authentication provider. */
-  COINBASE,
-
-  /** Spotify OAuth authentication provider. */
-  SPOTIFY,
-
-  /** Xero OAuth authentication provider. */
-  XERO,
-
-  /** Box OAuth authentication provider. */
-  BOX,
-
-  /** Slack OAuth authentication provider. */
-  SLACK,
-
-  /** Linear OAuth authentication provider. */
-  LINEAR,
-
-  /** Hugging Face OAuth authentication provider. */
-  HUGGING_FACE,
-
-  /** Vercel OAuth authentication provider. */
-  VERCEL,
-
-  /** Custom OAuth authentication provider for enterprise or specialized implementations. */
-  CUSTOM,
-
-  /** Unknown OAuth provider - used as fallback for unrecognized providers. */
-  UNKNOWN;
-
+@kotlinx.serialization.Serializable(with = OAuthProviderSerializer::class)
+class OAuthProvider private constructor(val strategy: String) {
   companion object {
+    /** Facebook OAuth authentication provider. */
+    @JvmField val FACEBOOK = OAuthProvider("oauth_facebook")
+
+    /** Google OAuth authentication provider. */
+    @JvmField val GOOGLE = OAuthProvider("oauth_google")
+
+    /** HubSpot OAuth authentication provider. */
+    @JvmField val HUBSPOT = OAuthProvider("oauth_hubspot")
+
+    /** GitHub OAuth authentication provider. */
+    @JvmField val GITHUB = OAuthProvider("oauth_github")
+
+    /** TikTok OAuth authentication provider. */
+    @JvmField val TIKTOK = OAuthProvider("oauth_tiktok")
+
+    /** GitLab OAuth authentication provider. */
+    @JvmField val GITLAB = OAuthProvider("oauth_gitlab")
+
+    /** Discord OAuth authentication provider. */
+    @JvmField val DISCORD = OAuthProvider("oauth_discord")
+
+    /** Twitter OAuth authentication provider. */
+    @JvmField val TWITTER = OAuthProvider("oauth_twitter")
+
+    /** Twitch OAuth authentication provider. */
+    @JvmField val TWITCH = OAuthProvider("oauth_twitch")
+
+    /** LinkedIn OAuth authentication provider (legacy). */
+    @JvmField val LINKEDIN = OAuthProvider("oauth_linkedin")
+
+    /** LinkedIn OpenID Connect authentication provider. */
+    @JvmField val LINKEDIN_OIDC = OAuthProvider("oauth_linkedin_oidc")
+
+    /** Dropbox OAuth authentication provider. */
+    @JvmField val DROPBOX = OAuthProvider("oauth_dropbox")
+
+    /** Atlassian OAuth authentication provider. */
+    @JvmField val ATLASSIAN = OAuthProvider("oauth_atlassian")
+
+    /** Bitbucket OAuth authentication provider. */
+    @JvmField val BITBUCKET = OAuthProvider("oauth_bitbucket")
+
+    /** Microsoft OAuth authentication provider. */
+    @JvmField val MICROSOFT = OAuthProvider("oauth_microsoft")
+
+    /** Notion OAuth authentication provider. */
+    @JvmField val NOTION = OAuthProvider("oauth_notion")
+
+    /** Apple OAuth authentication provider. */
+    @JvmField val APPLE = OAuthProvider("oauth_apple")
+
+    /** LINE OAuth authentication provider. */
+    @JvmField val LINE = OAuthProvider("oauth_line")
+
+    /** Instagram OAuth authentication provider. */
+    @JvmField val INSTAGRAM = OAuthProvider("oauth_instagram")
+
+    /** Coinbase OAuth authentication provider. */
+    @JvmField val COINBASE = OAuthProvider("oauth_coinbase")
+
+    /** Spotify OAuth authentication provider. */
+    @JvmField val SPOTIFY = OAuthProvider("oauth_spotify")
+
+    /** Xero OAuth authentication provider. */
+    @JvmField val XERO = OAuthProvider("oauth_xero")
+
+    /** Box OAuth authentication provider. */
+    @JvmField val BOX = OAuthProvider("oauth_box")
+
+    /** Slack OAuth authentication provider. */
+    @JvmField val SLACK = OAuthProvider("oauth_slack")
+
+    /** Linear OAuth authentication provider. */
+    @JvmField val LINEAR = OAuthProvider("oauth_linear")
+
+    /** Hugging Face OAuth authentication provider. */
+    @JvmField val HUGGING_FACE = OAuthProvider("oauth_huggingface")
+
+    /** Vercel OAuth authentication provider. */
+    @JvmField val VERCEL = OAuthProvider("oauth_vercel")
+
+    /** Generic custom OAuth strategy retained for source compatibility. */
+    @JvmField val CUSTOM = OAuthProvider("oauth_custom")
+
+    /** Unknown OAuth provider - used as fallback for non-OAuth strategies. */
+    @JvmField val UNKNOWN = OAuthProvider("oauth_unknown")
+
+    /** Built-in provider values, matching the former enum entry order. */
+    @JvmField
+    val entries: List<OAuthProvider> =
+      listOf(
+        FACEBOOK,
+        GOOGLE,
+        HUBSPOT,
+        GITHUB,
+        TIKTOK,
+        GITLAB,
+        DISCORD,
+        TWITTER,
+        TWITCH,
+        LINKEDIN,
+        LINKEDIN_OIDC,
+        DROPBOX,
+        ATLASSIAN,
+        BITBUCKET,
+        MICROSOFT,
+        NOTION,
+        APPLE,
+        LINE,
+        INSTAGRAM,
+        COINBASE,
+        SPOTIFY,
+        XERO,
+        BOX,
+        SLACK,
+        LINEAR,
+        HUGGING_FACE,
+        VERCEL,
+        CUSTOM,
+        UNKNOWN,
+      )
+
+    private val entryNameByStrategy: Map<String, String> =
+      listOf(
+          "FACEBOOK",
+          "GOOGLE",
+          "HUBSPOT",
+          "GITHUB",
+          "TIKTOK",
+          "GITLAB",
+          "DISCORD",
+          "TWITTER",
+          "TWITCH",
+          "LINKEDIN",
+          "LINKEDIN_OIDC",
+          "DROPBOX",
+          "ATLASSIAN",
+          "BITBUCKET",
+          "MICROSOFT",
+          "NOTION",
+          "APPLE",
+          "LINE",
+          "INSTAGRAM",
+          "COINBASE",
+          "SPOTIFY",
+          "XERO",
+          "BOX",
+          "SLACK",
+          "LINEAR",
+          "HUGGING_FACE",
+          "VERCEL",
+          "CUSTOM",
+          "UNKNOWN",
+        )
+        .zip(entries)
+        .associate { (name, provider) -> provider.strategy to name }
+
+    private val providerDataByStrategy: Map<String, OAuthProviderData> =
+      listOf(
+          OAuthProviderData("facebook", FACEBOOK.strategy, "Facebook"),
+          OAuthProviderData("google", GOOGLE.strategy, "Google"),
+          OAuthProviderData("hubspot", HUBSPOT.strategy, "HubSpot"),
+          OAuthProviderData("github", GITHUB.strategy, "GitHub"),
+          OAuthProviderData("tiktok", TIKTOK.strategy, "TikTok"),
+          OAuthProviderData("gitlab", GITLAB.strategy, "GitLab"),
+          OAuthProviderData("discord", DISCORD.strategy, "Discord"),
+          OAuthProviderData("twitter", TWITTER.strategy, "Twitter"),
+          OAuthProviderData("twitch", TWITCH.strategy, "Twitch"),
+          OAuthProviderData("linkedin", LINKEDIN.strategy, "LinkedIn"),
+          OAuthProviderData("linkedin_oidc", LINKEDIN_OIDC.strategy, "LinkedIn"),
+          OAuthProviderData("dropbox", DROPBOX.strategy, "Dropbox"),
+          OAuthProviderData("atlassian", ATLASSIAN.strategy, "Atlassian"),
+          OAuthProviderData("bitbucket", BITBUCKET.strategy, "Bitbucket"),
+          OAuthProviderData("microsoft", MICROSOFT.strategy, "Microsoft"),
+          OAuthProviderData("notion", NOTION.strategy, "Notion"),
+          OAuthProviderData("apple", APPLE.strategy, "Apple"),
+          OAuthProviderData("line", LINE.strategy, "LINE"),
+          OAuthProviderData("instagram", INSTAGRAM.strategy, "Instagram"),
+          OAuthProviderData("coinbase", COINBASE.strategy, "Coinbase"),
+          OAuthProviderData("spotify", SPOTIFY.strategy, "Spotify"),
+          OAuthProviderData("xero", XERO.strategy, "Xero"),
+          OAuthProviderData("box", BOX.strategy, "Box"),
+          OAuthProviderData("slack", SLACK.strategy, "Slack"),
+          OAuthProviderData("linear", LINEAR.strategy, "Linear"),
+          OAuthProviderData("huggingface", HUGGING_FACE.strategy, "Hugging Face"),
+          OAuthProviderData("vercel", VERCEL.strategy, "Vercel"),
+          OAuthProviderData("custom", CUSTOM.strategy, "Custom"),
+          OAuthProviderData("unknown", UNKNOWN.strategy, "Unknown"),
+        )
+        .associateBy { it.strategy }
+
     /**
      * Converts a strategy string to the corresponding [OAuthProvider].
      *
      * This convenience function is primarily used to convert strategy strings from
      * [com.clerk.network.model.environment.UserSettings.SocialConfig.strategy] into type-safe
-     * [OAuthProvider] enum values. This is useful when processing configuration data or API
-     * responses that contain strategy strings.
+     * [OAuthProvider] values. This is useful when processing configuration data or API responses
+     * that contain strategy strings.
      *
      * @param strategy The OAuth strategy string to convert (e.g., "oauth_google", "oauth_github").
-     *   The strategy string should match one of the supported provider strategies. For custom OAuth
-     *   providers, any strategy string starting with "oauth_" will return [CUSTOM]. Non-OAuth
-     *   strategies will return [UNKNOWN].
-     * @return The corresponding [OAuthProvider] enum value. Returns [CUSTOM] for unrecognized OAuth
-     *   strategies and [UNKNOWN] for non-OAuth strategies.
+     *   The strategy string should match one of the supported provider strategies. Custom and
+     *   otherwise unrecognized OAuth strategies retain the complete string. Non-OAuth strategies
+     *   return [UNKNOWN].
+     * @return The corresponding [OAuthProvider] value, preserving custom OAuth strategy keys.
      *
      * ### Example usage:
      * ```kotlin
@@ -149,12 +260,27 @@ enum class OAuthProvider {
      * ```
      */
     fun fromStrategy(strategy: String): OAuthProvider {
-      return OAuthProvider.entries.find { it.providerData.strategy == strategy }
-        ?: when {
-          strategy.startsWith("oauth_") -> CUSTOM
-          else -> UNKNOWN
-        }
+      return entries.find { it.strategy == strategy }
+        ?: if (strategy.startsWith("oauth_")) OAuthProvider(strategy) else UNKNOWN
     }
+
+    /** Creates a custom OAuth provider while preserving its complete strategy key. */
+    @JvmStatic
+    fun custom(strategy: String): OAuthProvider {
+      require(strategy == CUSTOM.strategy || strategy.startsWith("oauth_custom_")) {
+        "Custom OAuth strategy must be oauth_custom or start with oauth_custom_"
+      }
+      return OAuthProvider(strategy)
+    }
+
+    /** Returns the built-in provider values, matching the former enum API. */
+    @JvmStatic fun values(): Array<OAuthProvider> = entries.toTypedArray()
+
+    /** Returns a built-in provider by its former enum constant name. */
+    @JvmStatic
+    fun valueOf(name: String): OAuthProvider =
+      entries.firstOrNull { it.name == name }
+        ?: throw IllegalArgumentException("No OAuthProvider with name $name")
   }
 
   /**
@@ -172,77 +298,51 @@ enum class OAuthProvider {
    * @see [OAuthProviderData]
    */
   internal val providerData: OAuthProviderData
-    get() =
-      when (this) {
-        FACEBOOK ->
-          OAuthProviderData(provider = "facebook", strategy = "oauth_facebook", name = "Facebook")
-        GOOGLE -> OAuthProviderData(provider = "google", strategy = "oauth_google", name = "Google")
-        HUBSPOT ->
-          OAuthProviderData(provider = "hubspot", strategy = "oauth_hubspot", name = "HubSpot")
-        GITHUB -> OAuthProviderData(provider = "github", strategy = "oauth_github", name = "GitHub")
-        TIKTOK -> OAuthProviderData(provider = "tiktok", strategy = "oauth_tiktok", name = "TikTok")
-        GITLAB -> OAuthProviderData(provider = "gitlab", strategy = "oauth_gitlab", name = "GitLab")
-        DISCORD ->
-          OAuthProviderData(provider = "discord", strategy = "oauth_discord", name = "Discord")
-        TWITTER ->
-          OAuthProviderData(provider = "twitter", strategy = "oauth_twitter", name = "Twitter")
-        TWITCH -> OAuthProviderData(provider = "twitch", strategy = "oauth_twitch", name = "Twitch")
-        LINKEDIN ->
-          OAuthProviderData(provider = "linkedin", strategy = "oauth_linkedin", name = "LinkedIn")
-        LINKEDIN_OIDC ->
-          OAuthProviderData(
-            provider = "linkedin_oidc",
-            strategy = "oauth_linkedin_oidc",
-            name = "LinkedIn",
-          )
-        DROPBOX ->
-          OAuthProviderData(provider = "dropbox", strategy = "oauth_dropbox", name = "Dropbox")
-        ATLASSIAN ->
-          OAuthProviderData(
-            provider = "atlassian",
-            strategy = "oauth_atlassian",
-            name = "Atlassian",
-          )
-        BITBUCKET ->
-          OAuthProviderData(
-            provider = "bitbucket",
-            strategy = "oauth_bitbucket",
-            name = "Bitbucket",
-          )
-        MICROSOFT ->
-          OAuthProviderData(
-            provider = "microsoft",
-            strategy = "oauth_microsoft",
-            name = "Microsoft",
-          )
-        NOTION -> OAuthProviderData(provider = "notion", strategy = "oauth_notion", name = "Notion")
-        APPLE -> OAuthProviderData(provider = "apple", strategy = "oauth_apple", name = "Apple")
-        LINE -> OAuthProviderData(provider = "line", strategy = "oauth_line", name = "LINE")
-        INSTAGRAM ->
-          OAuthProviderData(
-            provider = "instagram",
-            strategy = "oauth_instagram",
-            name = "Instagram",
-          )
-        COINBASE ->
-          OAuthProviderData(provider = "coinbase", strategy = "oauth_coinbase", name = "Coinbase")
-        SPOTIFY ->
-          OAuthProviderData(provider = "spotify", strategy = "oauth_spotify", name = "Spotify")
-        XERO -> OAuthProviderData(provider = "xero", strategy = "oauth_xero", name = "Xero")
-        BOX -> OAuthProviderData(provider = "box", strategy = "oauth_box", name = "Box")
-        SLACK -> OAuthProviderData(provider = "slack", strategy = "oauth_slack", name = "Slack")
-        LINEAR -> OAuthProviderData(provider = "linear", strategy = "oauth_linear", name = "Linear")
-        HUGGING_FACE ->
-          OAuthProviderData(
-            provider = "huggingface",
-            strategy = "oauth_huggingface",
-            name = "Hugging Face",
-          )
-        VERCEL -> OAuthProviderData(provider = "vercel", strategy = "oauth_vercel", name = "Vercel")
-        CUSTOM -> OAuthProviderData(provider = "custom", strategy = "oauth_custom", name = "Custom")
-        UNKNOWN ->
-          OAuthProviderData(provider = "unknown", strategy = "oauth_unknown", name = "Unknown")
+    get() {
+      providerDataByStrategy[strategy]?.let {
+        return it
       }
+      val configuredProvider = Clerk.socialProviders.values.find { it.strategy == strategy }
+      return OAuthProviderData(
+        provider = strategy.removePrefix("oauth_"),
+        strategy = strategy,
+        name = configuredProvider?.name?.takeIf { it.isNotBlank() } ?: "Custom",
+      )
+    }
+
+  /** Enum-style constant name retained for source compatibility. */
+  val name: String
+    get() =
+      when {
+        strategy in entryNameByStrategy -> entryNameByStrategy.getValue(strategy)
+        strategy.startsWith("oauth_") -> "CUSTOM"
+        else -> "UNKNOWN"
+      }
+
+  override fun equals(other: Any?): Boolean = other is OAuthProvider && strategy == other.strategy
+
+  override fun hashCode(): Int = strategy.hashCode()
+
+  override fun toString(): String = name
+}
+
+internal object OAuthProviderSerializer : KSerializer<OAuthProvider> {
+  override val descriptor: SerialDescriptor =
+    PrimitiveSerialDescriptor("OAuthProvider", PrimitiveKind.STRING)
+
+  override fun serialize(encoder: Encoder, value: OAuthProvider) {
+    val builtInProvider = OAuthProvider.entries.firstOrNull { it == value }
+    encoder.encodeString(builtInProvider?.name ?: value.strategy)
+  }
+
+  override fun deserialize(decoder: Decoder): OAuthProvider {
+    val serializedValue = decoder.decodeString()
+    return if (serializedValue.startsWith("oauth_")) {
+      OAuthProvider.fromStrategy(serializedValue)
+    } else {
+      OAuthProvider.valueOf(serializedValue)
+    }
+  }
 }
 
 /**
@@ -306,7 +406,7 @@ val OAuthProvider.logoUrl: String?
     // Test override takes precedence when present
     logoUrlOverrides[this]?.let { it.trim().takeIf { trimmed -> trimmed.isNotEmpty() } }
       ?: Clerk.socialProviders.values
-        .find { it.strategy == this.providerData.strategy }
+        .find { it.strategy == strategy }
         ?.logoUrl
         ?.trim()
         ?.takeIf { it.isNotEmpty() }

--- a/source/api/src/main/kotlin/com/clerk/api/user/User.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/user/User.kt
@@ -284,7 +284,7 @@ data class User(
   @Serializable
   data class CreateExternalAccountParams(
     /** The strategy corresponding to the OAuth provider. For example: `oauth_google` */
-    @MapProperty("providerData?.strategy") @SerialName("strategy") val provider: OAuthProvider,
+    @MapProperty("strategy") @SerialName("strategy") val provider: OAuthProvider,
     /**
      * The full URL or path that the OAuth provider should redirect to, on successful authorization
      * on their part.
@@ -475,9 +475,9 @@ suspend fun User.reload(): ClerkResult<User, ClerkErrorResponse> {
  * [updateMetadata] separately and handle partial failures themselves.
  *
  * The pre-metadata `/v1/me` call also serves as a freshness anchor: the merge-patch diff is
- * computed against the server's current state, not the locally cached value on `this`. Without
- * that step, server-side mutations made by another tab, client, or backend job would silently
- * survive the "replace" call.
+ * computed against the server's current state, not the locally cached value on `this`. Without that
+ * step, server-side mutations made by another tab, client, or backend job would silently survive
+ * the "replace" call.
  *
  * @param params The parameters to update the user with. **See**: [UpdateParams].
  * @return A [ClerkResult] containing the updated [User] if the operation was successful, or a
@@ -514,11 +514,11 @@ private fun parseUnsafeMetadata(rawMetadata: String): ClerkResult<JsonObject, Cl
 
 /**
  * Returns `true` when the caller supplied any field other than `unsafeMetadata`. Used by the
- * routing logic to decide whether the `/v1/me` step is a `PATCH` (to apply non-metadata
- * changes) or a `GET` (to refresh the merge-patch baseline without other mutations).
+ * routing logic to decide whether the `/v1/me` step is a `PATCH` (to apply non-metadata changes) or
+ * a `GET` (to refresh the merge-patch baseline without other mutations).
  *
- * Note: [UpdateParams.publicMetadata] and [UpdateParams.privateMetadata] are deprecated.
- * They are only settable from the Backend API; on the Frontend API they are no-ops
+ * Note: [UpdateParams.publicMetadata] and [UpdateParams.privateMetadata] are deprecated. They are
+ * only settable from the Backend API; on the Frontend API they are no-ops
  */
 @Suppress("DEPRECATION") // params.{public,private,unsafe}Metadata are themselves deprecated.
 private fun UpdateParams.hasNonMetadataFields(): Boolean =
@@ -929,12 +929,11 @@ private fun User.hasAlternativeFirstFactorIdentification(excludingPhoneId: Strin
     emailAddresses.orEmpty().any { email ->
       email.verification?.status == Verification.Status.VERIFIED
     }
-  val hasAnotherVerifiedNonReservedPhone =
-    phoneNumbers.any { phone ->
-      phone.id != excludingPhoneId &&
-        !phone.reservedForSecondFactor &&
-        phone.verification?.status == Verification.Status.VERIFIED
-    }
+  val hasAnotherVerifiedNonReservedPhone = phoneNumbers.any { phone ->
+    phone.id != excludingPhoneId &&
+      !phone.reservedForSecondFactor &&
+      phone.verification?.status == Verification.Status.VERIFIED
+  }
   return hasUsername || hasVerifiedEmail || hasAnotherVerifiedNonReservedPhone
 }
 

--- a/source/api/src/test/java/com/clerk/api/sdk/ToOAuthProvidersListTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ToOAuthProvidersListTest.kt
@@ -76,4 +76,23 @@ class ToOAuthProvidersListTest {
     assertTrue(result.contains(OAuthProvider.GOOGLE))
     assertTrue(result.contains(OAuthProvider.APPLE))
   }
+
+  @Test
+  fun `preserves distinct custom provider strategies`() {
+    val providers =
+      mapOf(
+        "oauth_custom_patreon" to socialConfig("oauth_custom_patreon"),
+        "oauth_custom_line" to socialConfig("oauth_custom_line"),
+      )
+
+    val result = providers.toOAuthProvidersList()
+
+    assertEquals(
+      listOf(
+        OAuthProvider.custom("oauth_custom_patreon"),
+        OAuthProvider.custom("oauth_custom_line"),
+      ),
+      result,
+    )
+  }
 }

--- a/source/api/src/test/java/com/clerk/api/signin/SignInAuthenticateWithRedirectTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signin/SignInAuthenticateWithRedirectTest.kt
@@ -61,6 +61,43 @@ class SignInAuthenticateWithRedirectTest {
   }
 
   @Test
+  fun `authenticateWithRedirect preserves custom OAuth provider strategy`() = runTest {
+    mockkObject(SSOService)
+    val redirectUrl = "clerk://example.callback"
+    val oauthResult = OAuthResult(signIn = null)
+    coEvery {
+      SSOService.authenticateWithRedirect(
+        strategy = "oauth_custom_patreon",
+        redirectUrl = redirectUrl,
+        identifier = null,
+        emailAddress = null,
+        legalAccepted = null,
+        transferable = true,
+      )
+    } returns ClerkResult.success(oauthResult)
+
+    val result =
+      SignIn.authenticateWithRedirect(
+        SignIn.AuthenticateWithRedirectParams.OAuth(
+          provider = OAuthProvider.custom("oauth_custom_patreon"),
+          redirectUrl = redirectUrl,
+        )
+      )
+
+    assertTrue(result is ClerkResult.Success)
+    coVerify(exactly = 1) {
+      SSOService.authenticateWithRedirect(
+        strategy = "oauth_custom_patreon",
+        redirectUrl = redirectUrl,
+        identifier = null,
+        emailAddress = null,
+        legalAccepted = null,
+        transferable = true,
+      )
+    }
+  }
+
+  @Test
   fun `authenticateWithRedirect uses Enterprise SSO strategy`() = runTest {
     mockkObject(SSOService)
     val redirectUrl = "https://sso.example.com/start"

--- a/source/api/src/test/java/com/clerk/api/signup/SignUpAuthenticateWithRedirectTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signup/SignUpAuthenticateWithRedirectTest.kt
@@ -61,6 +61,41 @@ class SignUpAuthenticateWithRedirectTest {
   }
 
   @Test
+  fun `authenticateWithRedirect preserves custom OAuth provider strategy`() = runTest {
+    mockkObject(SSOService)
+    val redirectUrl = "clerk://example.callback"
+    val oauthResult = OAuthResult(signUp = mockk(relaxed = true))
+    coEvery {
+      SSOService.authenticateSignUpWithRedirect(
+        strategy = "oauth_custom_patreon",
+        redirectUrl = redirectUrl,
+        identifier = null,
+        emailAddress = null,
+        legalAccepted = null,
+      )
+    } returns ClerkResult.success(oauthResult)
+
+    val result =
+      SignUp.authenticateWithRedirect(
+        SignUp.AuthenticateWithRedirectParams.OAuth(
+          provider = OAuthProvider.custom("oauth_custom_patreon"),
+          redirectUrl = redirectUrl,
+        )
+      )
+
+    assertTrue(result is ClerkResult.Success)
+    coVerify(exactly = 1) {
+      SSOService.authenticateSignUpWithRedirect(
+        strategy = "oauth_custom_patreon",
+        redirectUrl = redirectUrl,
+        identifier = null,
+        emailAddress = null,
+        legalAccepted = null,
+      )
+    }
+  }
+
+  @Test
   fun `authenticateWithRedirect forwards unsafe metadata`() = runTest {
     mockkObject(SSOService)
     val unsafeMetadata = mapOf("test" to "test")
@@ -111,5 +146,15 @@ class SignUpAuthenticateWithRedirectTest {
 
     assertEquals("oauth_google", paramsMap["strategy"])
     assertEquals("""{"test":"test"}""", paramsMap["unsafe_metadata"])
+  }
+
+  @Test
+  fun `redirect params map preserves custom OAuth provider strategy`() {
+    val params =
+      SignUp.AuthenticateWithRedirectParams.OAuth(
+        provider = OAuthProvider.custom("oauth_custom_patreon")
+      )
+
+    assertEquals("oauth_custom_patreon", params.toMap()["strategy"])
   }
 }

--- a/source/api/src/test/java/com/clerk/api/sso/OAuthProviderTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/OAuthProviderTest.kt
@@ -1,0 +1,88 @@
+package com.clerk.api.sso
+
+import com.clerk.api.Clerk
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.environment.Environment
+import com.clerk.api.network.model.environment.UserSettings
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class OAuthProviderTest {
+
+  private val previousEnvironment = Clerk.environment
+
+  @After
+  fun tearDown() {
+    Clerk.environment = previousEnvironment
+  }
+
+  @Test
+  fun `fromStrategy preserves a custom OAuth strategy`() {
+    val provider = OAuthProvider.fromStrategy("oauth_custom_patreon")
+
+    assertEquals("oauth_custom_patreon", provider.strategy)
+    assertEquals("CUSTOM", provider.name)
+    assertNotEquals(OAuthProvider.CUSTOM, provider)
+  }
+
+  @Test
+  fun `custom providers with different keys remain distinct`() {
+    val patreon = OAuthProvider.custom("oauth_custom_patreon")
+    val line = OAuthProvider.custom("oauth_custom_line")
+
+    assertNotEquals(patreon, line)
+  }
+
+  @Test
+  fun `custom provider reads configured name and logo by exact strategy`() {
+    Clerk.environment = environmentWith(patreonConfig())
+    val provider = OAuthProvider.fromStrategy("oauth_custom_patreon")
+
+    assertEquals("Patreon", provider.providerName)
+    assertEquals("https://cdn.example.com/patreon.png", provider.logoUrl)
+  }
+
+  @Test
+  fun `serialization preserves built-in format and custom strategy`() {
+    val builtIn = ClerkApi.json.encodeToString(OAuthProvider.serializer(), OAuthProvider.GOOGLE)
+    val custom =
+      ClerkApi.json.encodeToString(
+        OAuthProvider.serializer(),
+        OAuthProvider.custom("oauth_custom_patreon"),
+      )
+
+    assertEquals("\"GOOGLE\"", builtIn)
+    assertEquals("\"oauth_custom_patreon\"", custom)
+    assertEquals(
+      OAuthProvider.GOOGLE,
+      ClerkApi.json.decodeFromString(OAuthProvider.serializer(), builtIn),
+    )
+    assertEquals(
+      OAuthProvider.custom("oauth_custom_patreon"),
+      ClerkApi.json.decodeFromString(OAuthProvider.serializer(), custom),
+    )
+  }
+
+  private fun environmentWith(vararg socialConfigs: UserSettings.SocialConfig): Environment {
+    val environment = mockk<Environment>()
+    val userSettings = mockk<UserSettings>()
+    every { environment.userSettings } returns userSettings
+    every { userSettings.social } returns socialConfigs.associateBy { it.strategy }
+    return environment
+  }
+
+  private fun patreonConfig() =
+    UserSettings.SocialConfig(
+      enabled = true,
+      required = false,
+      authenticatable = true,
+      strategy = "oauth_custom_patreon",
+      notSelectable = false,
+      name = "Patreon",
+      logoUrl = "https://cdn.example.com/patreon.png",
+    )
+}

--- a/source/api/src/test/java/com/clerk/api/user/UserOAuthProviderTest.kt
+++ b/source/api/src/test/java/com/clerk/api/user/UserOAuthProviderTest.kt
@@ -1,0 +1,62 @@
+package com.clerk.api.user
+
+import com.clerk.api.Clerk
+import com.clerk.api.externalaccount.ExternalAccount
+import com.clerk.api.network.model.environment.Environment
+import com.clerk.api.network.model.environment.UserSettings
+import com.clerk.api.sso.OAuthProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UserOAuthProviderTest {
+
+  private val previousEnvironment = Clerk.environment
+
+  @After
+  fun tearDown() {
+    Clerk.environment = previousEnvironment
+  }
+
+  @Test
+  fun `create external account params preserve custom strategy`() {
+    val params =
+      User.CreateExternalAccountParams(provider = OAuthProvider.custom("oauth_custom_patreon"))
+
+    assertEquals("oauth_custom_patreon", params.toMap()["strategy"])
+  }
+
+  @Test
+  fun `connecting one custom provider does not hide another`() {
+    val patreon = socialConfig("oauth_custom_patreon", "Patreon")
+    val line = socialConfig("oauth_custom_line", "LINE")
+    Clerk.environment = environmentWith(patreon, line)
+
+    val connectedAccount = mockk<ExternalAccount>()
+    every { connectedAccount.provider } returns patreon.strategy
+    val user = mockk<User>()
+    every { user.verifiedExternalAccounts } returns listOf(connectedAccount)
+
+    assertEquals(listOf(OAuthProvider.custom(line.strategy)), user.unconnectedProviders)
+  }
+
+  private fun environmentWith(vararg socialConfigs: UserSettings.SocialConfig): Environment {
+    val environment = mockk<Environment>()
+    val userSettings = mockk<UserSettings>()
+    every { environment.userSettings } returns userSettings
+    every { userSettings.social } returns socialConfigs.associateBy { it.strategy }
+    return environment
+  }
+
+  private fun socialConfig(strategy: String, name: String) =
+    UserSettings.SocialConfig(
+      enabled = true,
+      required = false,
+      authenticatable = true,
+      strategy = strategy,
+      notSelectable = false,
+      name = name,
+    )
+}

--- a/source/api/src/test/java/com/clerk/api/user/UserOAuthProviderTest.kt
+++ b/source/api/src/test/java/com/clerk/api/user/UserOAuthProviderTest.kt
@@ -35,7 +35,7 @@ class UserOAuthProviderTest {
     Clerk.environment = environmentWith(patreon, line)
 
     val connectedAccount = mockk<ExternalAccount>()
-    every { connectedAccount.provider } returns patreon.strategy
+    every { connectedAccount.provider } returns patreon.strategy.removePrefix("oauth_")
     val user = mockk<User>()
     every { user.verifiedExternalAccounts } returns listOf(connectedAccount)
 

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountRow.kt
@@ -33,6 +33,7 @@ import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.logoUrl
+import com.clerk.api.sso.providerName
 import com.clerk.ui.R
 import com.clerk.ui.core.dimens.dp16
 import com.clerk.ui.core.dimens.dp2
@@ -121,8 +122,7 @@ private fun EmailWithAccountBadge(externalAccount: ExternalAccount) {
         fallback = fallbackPainter,
       )
       Text(
-        text =
-          externalAccount.oauthProviderType.name.lowercase().replaceFirstChar { it.titlecase() },
+        text = externalAccount.oauthProviderType.providerName,
         color = ClerkMaterialTheme.colors.mutedForeground,
         style = ClerkMaterialTheme.typography.bodyMedium,
       )

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthStartViewHelperTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthStartViewHelperTest.kt
@@ -1,12 +1,44 @@
 package com.clerk.ui.auth
 
 import androidx.compose.ui.autofill.ContentType
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.environment.UserSettings
+import com.clerk.api.sso.OAuthProvider
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AuthStartViewHelperTest {
+
+  @Test
+  fun authenticatableSocialProvidersPreserveCustomStrategy() {
+    mockkObject(Clerk)
+    try {
+      every { Clerk.socialProviders } returns
+        mapOf(
+          "oauth_custom_patreon" to
+            UserSettings.SocialConfig(
+              enabled = true,
+              required = false,
+              authenticatable = true,
+              strategy = "oauth_custom_patreon",
+              notSelectable = false,
+              name = "Patreon",
+            )
+        )
+
+      assertEquals(
+        listOf(OAuthProvider.custom("oauth_custom_patreon")),
+        AuthStartViewHelper().authenticatableSocialProviders,
+      )
+    } finally {
+      unmockkObject(Clerk)
+    }
+  }
 
   @Test
   fun shouldStartOnPhoneNumberReturnsFalseWhenIdentifierMethodsAreEnabled() {

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -515,7 +515,7 @@ class AuthViewModelTest {
   }
 
   @Test
-  fun oauthProviderEnumShouldHaveExpectedValues() {
+  fun oauthProviderShouldHaveExpectedValues() {
     // Test that OAuth providers work correctly with our ViewModel
     val google = OAuthProvider.GOOGLE
     val facebook = OAuthProvider.FACEBOOK
@@ -548,6 +548,24 @@ class AuthViewModelTest {
 
     coVerify(exactly = 0) { SignIn.authenticateWithGoogleOneTap(any()) }
     coVerify(exactly = 1) { SignIn.authenticateWithRedirect(any(), true) }
+  }
+
+  @Test
+  fun customSocialAuthPreservesProviderStrategy() = runTest {
+    val paramsSlot = slot<SignIn.AuthenticateWithRedirectParams>()
+    mockkObject(SignIn.Companion)
+    coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
+      ClerkResult.success(OAuthResult(signIn = mockk(relaxed = true)))
+
+    viewModel.authenticateWithSocialProvider(
+      provider = OAuthProvider.custom("oauth_custom_patreon"),
+      preferGoogleOneTap = false,
+    )
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    coVerify(exactly = 1) { SignIn.authenticateWithRedirect(capture(paramsSlot), true) }
+    val params = paramsSlot.captured as SignIn.AuthenticateWithRedirectParams.OAuth
+    assertEquals("oauth_custom_patreon", params.provider.strategy)
   }
 
   @Test

--- a/source/ui/src/test/java/com/clerk/ui/auth/LastUsedAuthTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/LastUsedAuthTest.kt
@@ -44,6 +44,21 @@ class LastUsedAuthTest {
   }
 
   @Test
+  fun fromPreservesCustomSocialProviderStrategy() {
+    val customProvider = OAuthProvider.custom("oauth_custom_patreon")
+
+    val result =
+      LastUsedAuth.from(
+        lastAuthenticationStrategy = customProvider.strategy,
+        enabledFirstFactorAttributes = listOf("email_address"),
+        authenticatableSocialProviders = listOf(customProvider),
+        storedIdentifierType = null,
+      )
+
+    assertEquals(customProvider, (result as LastUsedAuth.Social).provider)
+  }
+
+  @Test
   fun fromReturnsNullWhenOAuthStrategyNotAuthenticatable() {
     val result =
       LastUsedAuth.from(

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/connectedaccount/AddConnectedAccountViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/connectedaccount/AddConnectedAccountViewModelTest.kt
@@ -70,6 +70,29 @@ class AddConnectedAccountViewModelTest {
   }
 
   @Test
+  fun connectExternalAccount_preservesCustomProviderStrategy() = runTest {
+    val customProvider = OAuthProvider.custom("oauth_custom_patreon")
+    val user = mockk<User>()
+    val account = mockk<ExternalAccount>()
+    every { Clerk.user } returns user
+    coEvery { user.createExternalAccount(any()) } returns ClerkResult.success(account)
+
+    val viewModel = AddConnectedAccountViewModel()
+
+    viewModel.connectExternalAccount(customProvider)
+    advanceUntilIdle()
+
+    assertEquals(AddConnectedAccountViewModel.State.Success, viewModel.state.value)
+    coVerify(exactly = 1) {
+      user.createExternalAccount(
+        match<User.CreateExternalAccountParams> {
+          it.provider.strategy == "oauth_custom_patreon"
+        }
+      )
+    }
+  }
+
+  @Test
   fun connectExternalAccount_failure_setsErrorState() = runTest {
     val user = mockk<User>()
     every { Clerk.user } returns user


### PR DESCRIPTION
## Summary

- preserve complete custom OAuth strategies such as `oauth_custom_patreon` instead of collapsing them to `oauth_custom`
- resolve custom provider names and logos from the exact matching environment social configuration
- propagate the exact strategy through sign-in, sign-up, AuthView, last-used auth, and connected-account flows
- keep built-in provider constants and their serialized format compatible
- add regression coverage for multiple custom providers and native UI/API request paths

## Why

`OAuthProvider.fromStrategy()` previously mapped every unknown OAuth strategy to the singleton `OAuthProvider.CUSTOM`. Request paths then read its hard-coded `oauth_custom` strategy, dropping the configured provider key. Native components consequently displayed generic labels and Clerk rejected connected-account requests before opening the browser.

This restores custom OIDC/OAuth connections such as Patreon in Expo's native `UserProfileView`, including the configured name, logo, and exact outbound strategy.

Linear: [MOBILE-620](https://linear.app/clerk/issue/MOBILE-620/android-preserve-custom-oauth-provider-strategy-keys)

## Verification

- `./gradlew :source:api:testDebugUnitTest :source:ui:testDebugUnitTest`
- API and UI Spotless checks
- API and UI Detekt
- API lint
- `./gradlew :source:api:assemble :source:ui:assemble`

`:source:ui:lintDebug` continues to report four unrelated pre-existing violations in untouched snapshot, resource, and organization-switcher files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom OAuth provider strategies across sign-in, sign-up, redirects, and external account connections.
  - Custom providers now preserve distinct strategies, configured names, and logos.
  - OAuth provider serialization supports built-in and custom providers.

- **UI Improvements**
  - Connected account labels now display provider names consistently.

- **Bug Fixes**
  - Prevented custom providers from being merged or replaced during authentication and account management.

- **Tests**
  - Added coverage for custom provider authentication, metadata, serialization, and account flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->