### PR TITLE
fix(sso): prevent OAuth network failures from crashing

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/sso/SSOExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/SSOExtensions.kt
@@ -3,7 +3,6 @@ package com.clerk.api.sso
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
-import com.clerk.api.network.serialization.shortErrorMessageOrNull
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
 
@@ -24,8 +23,7 @@ internal fun ClerkResult<SignIn, ClerkErrorResponse>.signInToOAuthResult():
         ClerkResult.Failure.ErrorType.API -> ClerkResult.apiFailure(this.error)
         ClerkResult.Failure.ErrorType.HTTP ->
           ClerkResult.httpFailure(error = this.error, code = this.code!!)
-        ClerkResult.Failure.ErrorType.UNKNOWN ->
-          ClerkResult.unknownFailure(error("${this.shortErrorMessageOrNull()}"))
+        ClerkResult.Failure.ErrorType.UNKNOWN -> this
       }
     }
   }
@@ -50,8 +48,7 @@ internal fun ClerkResult<SignUp, ClerkErrorResponse>.signUpToOAuthResult():
         ClerkResult.Failure.ErrorType.HTTP ->
           ClerkResult.httpFailure(error = this.error, code = this.code!!)
 
-        ClerkResult.Failure.ErrorType.UNKNOWN ->
-          ClerkResult.unknownFailure(error("${this.shortErrorMessageOrNull()}"))
+        ClerkResult.Failure.ErrorType.UNKNOWN -> this
       }
     }
   }

--- a/source/api/src/test/java/com/clerk/api/sso/SSOExtensionsTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/SSOExtensionsTest.kt
@@ -1,0 +1,41 @@
+package com.clerk.api.sso
+
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signup.SignUp
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class SSOExtensionsTest {
+
+  @Test
+  fun `signInToOAuthResult preserves unknown transport failure`() {
+    val cause = IOException("Unable to resolve host api.clerk.com")
+    val failure = ClerkResult.unknownFailure(cause)
+    val result: ClerkResult<SignIn, ClerkErrorResponse> = failure
+
+    val converted = result.signInToOAuthResult()
+
+    assertSame(failure, converted)
+    val convertedFailure = converted as ClerkResult.Failure
+    assertEquals(ClerkResult.Failure.ErrorType.UNKNOWN, convertedFailure.errorType)
+    assertSame(cause, convertedFailure.throwable)
+  }
+
+  @Test
+  fun `signUpToOAuthResult preserves unknown transport failure`() {
+    val cause = IOException("Unable to resolve host api.clerk.com")
+    val failure = ClerkResult.unknownFailure(cause)
+    val result: ClerkResult<SignUp, ClerkErrorResponse> = failure
+
+    val converted = result.signUpToOAuthResult()
+
+    assertSame(failure, converted)
+    val convertedFailure = converted as ClerkResult.Failure
+    assertEquals(ClerkResult.Failure.ErrorType.UNKNOWN, convertedFailure.errorType)
+    assertSame(cause, convertedFailure.throwable)
+  }
+}


### PR DESCRIPTION
## Summary

- return existing `UNKNOWN` failures from the OAuth result converters instead of invoking `kotlin.error`
- preserve the original network throwable and failure metadata
- add regression coverage for both sign-in and sign-up conversions

## Why

Starting OAuth or SSO without network connectivity currently throws an `IllegalStateException` inside the SDK coroutine and crashes the prebuilt `AuthView`. Returning the failure allows the existing OAuth error state and snackbar handling to surface the problem normally.

Fixes #857

## Testing

- `./gradlew :source:api:testDebugUnitTest --tests 'com.clerk.api.sso.SSOExtensionsTest'`
- `./gradlew :source:api:spotlessCheck :source:api:detekt :source:api:testDebugUnitTest`
- `./gradlew :source:api:lintDebug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved original unknown sign-in and sign-up transport failures during OAuth conversion.
  * Retained the failure type and underlying cause for more accurate error handling.

* **Tests**
  * Added coverage verifying that unknown transport failures remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->