### PR TITLE
fix: smooth manage account transitions and email creation

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/network/api/UserApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/UserApi.kt
@@ -202,7 +202,7 @@ internal interface UserApi {
    * Creates a new email address for the current user.
    *
    * @param emailAddress The email address to add
-   * @param sessionId Optional session ID. Defaults to current user ID from [Clerk.session]
+   * @param sessionId Optional session ID. Defaults to current session ID from [Clerk.session]
    * @return [ClerkResult] containing the created [EmailAddress] on success or [ClerkErrorResponse]
    *   on failure
    */
@@ -210,7 +210,7 @@ internal interface UserApi {
   @POST(ApiPaths.User.EmailAddress.BASE)
   suspend fun createEmailAddress(
     @Field("email_address") emailAddress: String,
-    @Query(ApiParams.CLERK_SESSION_ID) sessionId: String? = Clerk.session?.user?.id,
+    @Query(ApiParams.CLERK_SESSION_ID) sessionId: String? = Clerk.session?.id,
   ): ClerkResult<EmailAddress, ClerkErrorResponse>
 
   /**

--- a/source/api/src/test/java/com/clerk/api/network/api/UserApiTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/api/UserApiTest.kt
@@ -1,11 +1,64 @@
 package com.clerk.api.network.api
 
+import com.clerk.api.Clerk
+import com.clerk.api.emailaddress.EmailAddress
 import com.clerk.api.network.ApiParams
+import com.clerk.api.network.model.client.Client
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.session.Session
+import com.clerk.api.user.User
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
 import retrofit2.http.Query
 
 class UserApiTest {
+
+  @Test
+  fun `create email address defaults to active session id`() = runTest {
+    val user =
+      User(
+        id = "user_123",
+        imageUrl = "",
+        hasImage = false,
+        passkeys = emptyList(),
+        passwordEnabled = false,
+        phoneNumbers = emptyList(),
+        totpEnabled = false,
+        twoFactorEnabled = false,
+        updatedAt = 0L,
+      )
+    val session =
+      Session(
+        id = "sess_123",
+        status = Session.SessionStatus.ACTIVE,
+        expireAt = 0L,
+        lastActiveAt = 0L,
+        user = user,
+        createdAt = 0L,
+        updatedAt = 0L,
+      )
+    Clerk.updateClient(Client(sessions = listOf(session), lastActiveSessionId = session.id))
+    val api = mockk<UserApi>()
+    val result =
+      ClerkResult.success(EmailAddress(id = "email_123", emailAddress = "new@example.com"))
+    coEvery {
+      api.createEmailAddress(emailAddress = "new@example.com", sessionId = session.id)
+    } returns result
+
+    try {
+      api.createEmailAddress(emailAddress = "new@example.com")
+
+      coVerify(exactly = 1) {
+        api.createEmailAddress(emailAddress = "new@example.com", sessionId = session.id)
+      }
+    } finally {
+      Clerk.updateClient(Client())
+    }
+  }
 
   @Test
   fun `passkey endpoints include clerk session id query`() {

--- a/source/ui/src/main/java/com/clerk/ui/theme/ClerkComposeTheme.kt
+++ b/source/ui/src/main/java/com/clerk/ui/theme/ClerkComposeTheme.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import com.clerk.api.Clerk
 import com.clerk.api.ui.ClerkColors
@@ -116,11 +117,12 @@ internal fun ClerkMaterialTheme(clerkTheme: ClerkTheme? = null, content: @Compos
   ClerkThemeProvider(theme = resolvedTheme) {
     val colors = ClerkThemeProviderAccess.colors
     val design = ClerkThemeProviderAccess.design
+    val isDarkMode = isSystemInDarkTheme()
 
-    val materialColors = computeColorScheme(colors)
-    val computedColors = generateComputedColors(colors)
+    val materialColors = remember(colors, isDarkMode) { computeColorScheme(colors, isDarkMode) }
+    val computedColors = remember(colors) { generateComputedColors(colors) }
 
-    val themeColors = ClerkThemeColors(colors)
+    val themeColors = remember(colors) { ClerkThemeColors(colors) }
 
     CompositionLocalProvider(
       LocalComposeColors provides themeColors,
@@ -289,7 +291,7 @@ internal class ClerkThemeColors internal constructor(private val colors: ClerkCo
  * @param colors The base ClerkColors to derive variants from.
  * @return A [ComputedColors] object containing all the derived color variants.
  */
-@Composable
+@Suppress("CyclomaticComplexMethod")
 private fun generateComputedColors(colors: ClerkColors): ComputedColors {
 
   val computed =
@@ -332,10 +334,9 @@ private fun generateComputedColors(colors: ClerkColors): ComputedColors {
  * @param colors The ClerkColors to map to Material3 color roles.
  * @return A [ColorScheme] configured for the current theme (light/dark).
  */
-@Composable
-private fun computeColorScheme(colors: ClerkColors): ColorScheme {
+private fun computeColorScheme(colors: ClerkColors, isDarkMode: Boolean): ColorScheme {
 
-  return if (isSystemInDarkTheme()) {
+  return if (isDarkMode) {
     darkColorScheme(
       primary = colors.primary!!,
       background = colors.background!!,

--- a/source/ui/src/main/java/com/clerk/ui/theme/ClerkThemeProvider.kt
+++ b/source/ui/src/main/java/com/clerk/ui/theme/ClerkThemeProvider.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import com.clerk.api.ui.ClerkColors
 import com.clerk.api.ui.ClerkDesign
@@ -90,14 +91,15 @@ internal val LocalClerkTypography =
  */
 @Composable
 internal fun ClerkThemeProvider(theme: ClerkTheme? = null, content: @Composable () -> Unit) {
+  val isDarkMode = isSystemInDarkTheme()
 
   // Resolve colors - use provided values or system defaults
-  val colors = generateColors(theme)
+  val colors = remember(theme, isDarkMode) { resolveColors(theme = theme, isDarkMode = isDarkMode) }
 
   // Resolve typography - use provided values or defaults
-  val typography = generateTypography(theme)
+  val typography = remember(theme) { generateTypography(theme) }
 
-  val design = theme?.design ?: ClerkDesign()
+  val design = remember(theme?.design) { theme?.design ?: ClerkDesign() }
 
   CompositionLocalProvider(
     LocalClerkColors provides colors,
@@ -107,7 +109,6 @@ internal fun ClerkThemeProvider(theme: ClerkTheme? = null, content: @Composable 
   )
 }
 
-@Composable
 private fun generateTypography(theme: ClerkTheme?): Typography {
   return Typography(
     displaySmall = theme?.typography?.displaySmall ?: ClerkTypographyDefaults.displaySmall,
@@ -122,11 +123,6 @@ private fun generateTypography(theme: ClerkTheme?): Typography {
     labelMedium = theme?.typography?.labelMedium ?: ClerkTypographyDefaults.labelMedium,
     labelSmall = theme?.typography?.labelSmall ?: ClerkTypographyDefaults.labelSmall,
   )
-}
-
-@Composable
-private fun generateColors(theme: ClerkTheme?): ClerkColors {
-  return resolveColors(theme = theme, isDarkMode = isSystemInDarkTheme())
 }
 
 internal fun resolveColors(theme: ClerkTheme?, isDarkMode: Boolean): ClerkColors {

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
@@ -1,11 +1,14 @@
 package com.clerk.ui.userprofile
 
 import android.annotation.SuppressLint
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -17,7 +20,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavBackStack
@@ -46,6 +52,7 @@ import com.clerk.ui.userprofile.custom.UserProfileCustomNavigator
 import com.clerk.ui.userprofile.custom.UserProfileCustomRow
 import com.clerk.ui.userprofile.custom.effectiveCustomRows
 import com.clerk.ui.userprofile.detail.UserProfileDetailView
+import com.clerk.ui.userprofile.detail.UserProfileDetailViewWithBackHandler
 import com.clerk.ui.userprofile.security.BackupCodesView
 import com.clerk.ui.userprofile.security.MfaType
 import com.clerk.ui.userprofile.security.Origin
@@ -101,6 +108,7 @@ fun UserProfileView(
 ) {
   ClerkThemeOverrideProvider(clerkTheme) {
     val backStack = rememberNavBackStack(UserProfileDestination.UserProfileAccount)
+    var showDetail by rememberSaveable { mutableStateOf(false) }
     val user by Clerk.userFlow.collectAsStateWithLifecycle()
     var showAccountSwitcher by rememberSaveable { mutableStateOf(false) }
     var showAuth by rememberSaveable { mutableStateOf(false) }
@@ -136,45 +144,66 @@ fun UserProfileView(
         }
       } else {
         DevelopmentModeWarningBox(modifier = Modifier.fillMaxSize()) {
-          NavDisplay(
-            modifier = Modifier.fillMaxSize(),
-            backStack = backStack,
-            onBack = {
-              handleUserProfileBack(
-                isAtRoot = backStack.size == 1,
-                isDismissible = isDismissible,
-                onDismiss = dismissHandler,
-                onNavigateBack = { backStack.removeLastOrNull() },
-              )
-            },
-            transitionSpec = {
-              val spec = tween<IntOffset>(durationMillis = 300)
-              slideInHorizontally(animationSpec = spec, initialOffsetX = { it }) togetherWith
-                slideOutHorizontally(animationSpec = spec, targetOffsetX = { -it })
-            },
-            popTransitionSpec = {
-              val spec = tween<IntOffset>(durationMillis = 300)
-              slideInHorizontally(animationSpec = spec, initialOffsetX = { -it }) togetherWith
-                slideOutHorizontally(animationSpec = spec, targetOffsetX = { it })
-            },
-            predictivePopTransitionSpec = { distance ->
-              // Use the provided distance to align with the system back gesture
-              slideInHorizontally(initialOffsetX = { -distance }) togetherWith
-                slideOutHorizontally(targetOffsetX = { distance })
-            },
-            entryProvider =
-              entryProvider {
-                userProfileEntries(
-                  backStack = backStack,
+          val detailProgress by
+            animateFloatAsState(
+              targetValue = if (showDetail) 1f else 0f,
+              animationSpec = tween(durationMillis = 300),
+              label = "user profile detail slide",
+            )
+          Box(modifier = Modifier.fillMaxSize().clipToBounds()) {
+            NavDisplay(
+              modifier =
+                Modifier.fillMaxSize().graphicsLayer {
+                  translationX = -size.width * detailProgress
+                },
+              backStack = backStack,
+              onBack = {
+                handleUserProfileBack(
+                  isAtRoot = backStack.size == 1,
                   isDismissible = isDismissible,
                   onDismiss = dismissHandler,
-                  customRows = customRows,
-                  customDestination = customDestination,
-                  onSwitchAccount = { showAccountSwitcher = true },
-                  onAddAccount = showAddAccountAuth,
+                  onNavigateBack = { backStack.removeLastOrNull() },
                 )
               },
-          )
+              transitionSpec = {
+                val spec = tween<IntOffset>(durationMillis = 300)
+                slideInHorizontally(animationSpec = spec, initialOffsetX = { it }) togetherWith
+                  slideOutHorizontally(animationSpec = spec, targetOffsetX = { -it })
+              },
+              popTransitionSpec = {
+                val spec = tween<IntOffset>(durationMillis = 300)
+                slideInHorizontally(animationSpec = spec, initialOffsetX = { -it }) togetherWith
+                  slideOutHorizontally(animationSpec = spec, targetOffsetX = { it })
+              },
+              predictivePopTransitionSpec = { distance ->
+                // Use the provided distance to align with the system back gesture
+                slideInHorizontally(initialOffsetX = { -distance }) togetherWith
+                  slideOutHorizontally(targetOffsetX = { distance })
+              },
+              entryProvider =
+                entryProvider {
+                  userProfileEntries(
+                    backStack = backStack,
+                    isDismissible = isDismissible,
+                    onDismiss = dismissHandler,
+                    customRows = customRows,
+                    customDestination = customDestination,
+                    onSwitchAccount = { showAccountSwitcher = true },
+                    onAddAccount = showAddAccountAuth,
+                    onShowDetail = { showDetail = true },
+                  )
+                },
+            )
+            Box(
+              modifier =
+                Modifier.fillMaxSize().zIndex(1f).graphicsLayer {
+                  translationX = size.width * (1f - detailProgress)
+                }
+            ) {
+              UserProfileDetailViewWithBackHandler(onBackPressed = { showDetail = false })
+            }
+          }
+          BackHandler(enabled = showDetail) { showDetail = false }
 
           if (showAccountSwitcher) {
             UserProfileAccountSwitcherSheet(
@@ -197,12 +226,13 @@ internal fun EntryProviderScope<NavKey>.userProfileEntries(
   customDestination: (@Composable (String) -> Unit)?,
   onSwitchAccount: () -> Unit,
   onAddAccount: () -> Unit,
+  onShowDetail: () -> Unit = { backStack.add(UserProfileDestination.UserProfileDetail) },
 ) {
   entry<UserProfileDestination.UserProfileAccount> {
     UserProfileAccountView(
       onClick = {
         when (it) {
-          UserProfileAction.Profile -> backStack.add(UserProfileDestination.UserProfileDetail)
+          UserProfileAction.Profile -> onShowDetail()
 
           UserProfileAction.Security -> backStack.add(UserProfileDestination.UserProfileSecurity)
 

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/common/UserProfileButtonRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/common/UserProfileButtonRow.kt
@@ -32,23 +32,21 @@ internal fun UserProfileButtonRow(
 ) {
   val interactionSource = remember { MutableInteractionSource() }
 
-  ClerkMaterialTheme {
-    Box(
-      modifier =
-        Modifier.fillMaxWidth()
-          .background(ClerkMaterialTheme.colors.background)
-          .clickable(
-            interactionSource = interactionSource,
-            indication = ripple(color = ClerkMaterialTheme.colors.mutedForeground.copy(alpha = 0.1f)),
-            role = Role.Button,
-            onClick = onClick,
-          )
-          .padding(vertical = dp16)
-          .padding(horizontal = dp24)
-          .then(modifier)
-    ) {
-      Text(text = text, color = textColor, style = textStyle)
-    }
+  Box(
+    modifier =
+      Modifier.fillMaxWidth()
+        .background(ClerkMaterialTheme.colors.background)
+        .clickable(
+          interactionSource = interactionSource,
+          indication = ripple(color = ClerkMaterialTheme.colors.mutedForeground.copy(alpha = 0.1f)),
+          role = Role.Button,
+          onClick = onClick,
+        )
+        .padding(vertical = dp16)
+        .padding(horizontal = dp24)
+        .then(modifier)
+  ) {
+    Text(text = text, color = textColor, style = textStyle)
   }
 }
 

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountRow.kt
@@ -1,6 +1,7 @@
 package com.clerk.ui.userprofile.connectedaccount
 
 import android.annotation.SuppressLint
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -38,6 +39,7 @@ import com.clerk.ui.core.dimens.dp16
 import com.clerk.ui.core.dimens.dp2
 import com.clerk.ui.core.dimens.dp20
 import com.clerk.ui.core.dimens.dp24
+import com.clerk.ui.core.dimens.dp48
 import com.clerk.ui.core.dimens.dp8
 import com.clerk.ui.core.extensions.withDarkVariant
 import com.clerk.ui.core.menu.DropDownItem
@@ -51,34 +53,38 @@ import kotlinx.collections.immutable.persistentListOf
 internal fun UserProfileExternalAccountRow(
   externalAccount: ExternalAccount,
   modifier: Modifier = Modifier,
-  viewModel: AddConnectedAccountViewModel = viewModel(),
+  isInteractive: Boolean = true,
+  viewModel: AddConnectedAccountViewModel? = if (isInteractive) viewModel() else null,
+  loadRemoteLogo: Boolean = true,
   onError: (String) -> Unit,
 ) {
-  val state by viewModel.state.collectAsStateWithLifecycle()
-  val context = LocalContext.current
-  LaunchedEffect(state) {
-    if (state is AddConnectedAccountViewModel.State.Error) {
-      onError(
-        (state as AddConnectedAccountViewModel.State.Error).message
-          ?: context.getString(R.string.something_went_wrong_please_try_again)
-      )
-      viewModel.resetState()
+  if (isInteractive && viewModel != null) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    LaunchedEffect(state) {
+      if (state is AddConnectedAccountViewModel.State.Error) {
+        onError(
+          (state as AddConnectedAccountViewModel.State.Error).message
+            ?: context.getString(R.string.something_went_wrong_please_try_again)
+        )
+        viewModel.resetState()
+      }
     }
   }
   val isPreview = LocalInspectionMode.current
-  ClerkMaterialTheme {
-    Row(
-      modifier =
-        Modifier.fillMaxWidth()
-          .background(ClerkMaterialTheme.colors.background)
-          .padding(start = dp24)
-          .padding(vertical = dp16)
-          .then(modifier),
-      verticalAlignment = Alignment.CenterVertically,
-    ) {
-      EmailWithAccountBadge(externalAccount)
-      Spacer(modifier = Modifier.weight(1f))
-      if (!isPreview) {
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .background(ClerkMaterialTheme.colors.background)
+        .padding(start = dp24)
+        .padding(vertical = dp16)
+        .then(modifier),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    EmailWithAccountBadge(externalAccount, loadRemoteLogo = loadRemoteLogo)
+    Spacer(modifier = Modifier.weight(1f))
+    if (!isPreview) {
+      if (isInteractive && viewModel != null) {
         ItemMoreMenu(
           dropDownItems =
             persistentListOf(
@@ -101,24 +107,25 @@ internal fun UserProfileExternalAccountRow(
             }
           },
         )
+      } else {
+        Spacer(modifier = Modifier.size(dp48))
       }
     }
   }
 }
 
 @Composable
-private fun EmailWithAccountBadge(externalAccount: ExternalAccount) {
+private fun EmailWithAccountBadge(externalAccount: ExternalAccount, loadRemoteLogo: Boolean) {
   val fallbackPainter =
     if (externalAccount.oauthProviderType == OAuthProvider.GOOGLE)
       painterResource(R.drawable.ic_google)
     else painterResource(R.drawable.ic_globe)
   Column {
     Row(horizontalArrangement = Arrangement.spacedBy(dp8)) {
-      AsyncImage(
-        modifier = Modifier.size(dp20),
-        model = externalAccount.oauthProviderType.logoUrl?.withDarkVariant(isSystemInDarkTheme()),
-        contentDescription = null,
-        fallback = fallbackPainter,
+      ExternalAccountLogo(
+        externalAccount = externalAccount,
+        loadRemoteLogo = loadRemoteLogo,
+        fallbackPainter = fallbackPainter,
       )
       Text(
         text =
@@ -163,6 +170,28 @@ private fun EmailWithAccountBadge(externalAccount: ExternalAccount) {
     }
   }
 }
+
+@Composable
+private fun ExternalAccountLogo(
+  externalAccount: ExternalAccount,
+  loadRemoteLogo: Boolean,
+  fallbackPainter: androidx.compose.ui.graphics.painter.Painter,
+) {
+  if (loadRemoteLogo) {
+    AsyncImage(
+      modifier = Modifier.size(dp20),
+      model = externalAccountLogoModel(externalAccount),
+      contentDescription = null,
+      fallback = fallbackPainter,
+    )
+  } else {
+    Image(modifier = Modifier.size(dp20), painter = fallbackPainter, contentDescription = null)
+  }
+}
+
+@Composable
+private fun externalAccountLogoModel(externalAccount: ExternalAccount): String? =
+  externalAccount.oauthProviderType.logoUrl?.withDarkVariant(isSystemInDarkTheme())
 
 internal enum class ExternalAccountAction {
   Reconnect,

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountSection.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountSection.kt
@@ -2,9 +2,11 @@ package com.clerk.ui.userprofile.connectedaccount
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -20,28 +22,35 @@ import com.clerk.ui.userprofile.common.UserProfileButtonRow
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
-@Composable
-internal fun UserProfileExternalAccountSection(
+internal fun LazyListScope.userProfileExternalAccountSection(
   externalAccounts: ImmutableList<ExternalAccount>,
   onError: (String) -> Unit,
-  modifier: Modifier = Modifier,
   onClickAddAccount: () -> Unit,
+  externalAccountRow: @Composable (ExternalAccount) -> Unit = {
+    UserProfileExternalAccountRow(it, onError = onError)
+  },
 ) {
-  ClerkMaterialTheme {
-    Column(modifier = Modifier.fillMaxWidth().then(modifier)) {
-      Text(
-        modifier = Modifier.padding(horizontal = dp24),
-        text = stringResource(R.string.connected_accounts).uppercase(),
-        style = ClerkMaterialTheme.typography.bodySmall.withMediumWeight(),
-        color = ClerkMaterialTheme.colors.mutedForeground,
-      )
-      Spacers.Vertical.Spacer16()
-      externalAccounts.forEach { UserProfileExternalAccountRow(it, onError = onError) }
-      UserProfileButtonRow(
-        text = stringResource(R.string.connect_account),
-        onClick = onClickAddAccount,
-      )
-    }
+  item(key = "user_profile_external_account_header") {
+    Text(
+      modifier = Modifier.padding(horizontal = dp24),
+      text = stringResource(R.string.connected_accounts).uppercase(),
+      style = ClerkMaterialTheme.typography.bodySmall.withMediumWeight(),
+      color = ClerkMaterialTheme.colors.mutedForeground,
+    )
+  }
+  item(key = "user_profile_external_account_header_spacing") { Spacers.Vertical.Spacer16() }
+  items(
+    items = externalAccounts,
+    key = { externalAccount -> "user_profile_external_account_${externalAccount.id}" },
+    contentType = { "user_profile_external_account" },
+  ) { externalAccount ->
+    externalAccountRow(externalAccount)
+  }
+  item(key = "user_profile_external_account_add") {
+    UserProfileButtonRow(
+      text = stringResource(R.string.connect_account),
+      onClick = onClickAddAccount,
+    )
   }
 }
 
@@ -50,35 +59,37 @@ internal fun UserProfileExternalAccountSection(
 private fun Preview() {
   ClerkMaterialTheme {
     Box(modifier = Modifier.background(ClerkMaterialTheme.colors.background)) {
-      UserProfileExternalAccountSection(
-        onError = {},
-        onClickAddAccount = {},
-        externalAccounts =
-          persistentListOf(
-            ExternalAccount(
-              id = "eac_34o5pCBEhohJtr1Ni14YiX8aQ0K",
-              identificationId = "idn_34o5pAvdtMtjAAdeFBfTkRfs77e",
-              provider = "oauth_google",
-              providerUserId = "102662613248529322762",
-              emailAddress = "sam@clerk.dev",
-              approvedScopes =
-                "email https://www.googleapis.com/auth/userinfo.email" +
-                  " https://www.googleapis.com/auth/userinfo.profile openid profile",
-              createdAt = 1L,
+      LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        userProfileExternalAccountSection(
+          onError = {},
+          onClickAddAccount = {},
+          externalAccounts =
+            persistentListOf(
+              ExternalAccount(
+                id = "eac_34o5pCBEhohJtr1Ni14YiX8aQ0K",
+                identificationId = "idn_34o5pAvdtMtjAAdeFBfTkRfs77e",
+                provider = "oauth_google",
+                providerUserId = "102662613248529322762",
+                emailAddress = "sam@clerk.dev",
+                approvedScopes =
+                  "email https://www.googleapis.com/auth/userinfo.email" +
+                    " https://www.googleapis.com/auth/userinfo.profile openid profile",
+                createdAt = 1L,
+              ),
+              ExternalAccount(
+                id = "eac_34o5pCBEhohJtr1Ni14YiX8aQ0L",
+                identificationId = "idn_34o5pAvdtMtjAAdeFBfTkRfs77f",
+                provider = "oauth_linear",
+                providerUserId = "102662613248529322762",
+                emailAddress = "sam@clerk.dev",
+                approvedScopes =
+                  "email https://www.googleapis.com/auth/userinfo.email" +
+                    " https://www.googleapis.com/auth/userinfo.profile openid profile",
+                createdAt = 1L,
+              ),
             ),
-            ExternalAccount(
-              id = "eac_34o5pCBEhohJtr1Ni14YiX8aQ0K",
-              identificationId = "idn_34o5pAvdtMtjAAdeFBfTkRfs77e",
-              provider = "oauth_linear",
-              providerUserId = "102662613248529322762",
-              emailAddress = "sam@clerk.dev",
-              approvedScopes =
-                "email https://www.googleapis.com/auth/userinfo.email" +
-                  " https://www.googleapis.com/auth/userinfo.profile openid profile",
-              createdAt = 1L,
-            ),
-          ),
-      )
+        )
+      }
     }
   }
 }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountSection.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountSection.kt
@@ -26,8 +26,15 @@ internal fun LazyListScope.userProfileExternalAccountSection(
   externalAccounts: ImmutableList<ExternalAccount>,
   onError: (String) -> Unit,
   onClickAddAccount: () -> Unit,
+  isInteractive: Boolean = true,
+  loadRemoteLogos: Boolean = true,
   externalAccountRow: @Composable (ExternalAccount) -> Unit = {
-    UserProfileExternalAccountRow(it, onError = onError)
+    UserProfileExternalAccountRow(
+      externalAccount = it,
+      isInteractive = isInteractive,
+      loadRemoteLogo = loadRemoteLogos,
+      onError = onError,
+    )
   },
 ) {
   item(key = "user_profile_external_account_header") {

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/detail/UserProfileDetailView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/detail/UserProfileDetailView.kt
@@ -1,13 +1,12 @@
 package com.clerk.ui.userprofile.detail
 
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
@@ -37,9 +36,9 @@ import com.clerk.ui.core.spacers.Spacers
 import com.clerk.ui.theme.ClerkMaterialTheme
 import com.clerk.ui.userprofile.LocalUserProfileState
 import com.clerk.ui.userprofile.PreviewUserProfileStateProvider
-import com.clerk.ui.userprofile.connectedaccount.UserProfileExternalAccountSection
-import com.clerk.ui.userprofile.email.UserProfileEmailSection
-import com.clerk.ui.userprofile.phone.UserProfilePhoneSection
+import com.clerk.ui.userprofile.connectedaccount.userProfileExternalAccountSection
+import com.clerk.ui.userprofile.email.userProfileEmailSection
+import com.clerk.ui.userprofile.phone.userProfilePhoneSection
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -70,7 +69,7 @@ private fun UserProfileDetailViewImpl(
 ) {
   val snackbarHostState = remember { SnackbarHostState() }
   val userProfileState = LocalUserProfileState.current
-  val scrollState = rememberScrollState()
+  val listState = rememberLazyListState()
   val scope = rememberCoroutineScope()
   var showBottomSheet by remember { mutableStateOf(false) }
   var bottomSheetType by remember { mutableStateOf<BottomSheetMode>(BottomSheetMode.EmailAddress) }
@@ -89,19 +88,22 @@ private fun UserProfileDetailViewImpl(
     ) { innerPadding ->
       ProfileContent(
         innerPadding = innerPadding,
-        scrollState = scrollState,
-        emailAddresses = emailAddresses,
-        phoneNumbers = phoneNumbers,
-        externalAccounts = externalAccounts,
-        onShowBottomSheet = { type ->
-          if (type == BottomSheetMode.EmailAddress && Clerk.isEmailImmutable) {
-            scope.launch { snackbarHostState.showSnackbar(EMAIL_IMMUTABLE_SNACKBAR_MESSAGE) }
-          } else {
-            bottomSheetType = type
-            showBottomSheet = true
-          }
-        },
-        onError = { errorMessage -> scope.launch { snackbarHostState.showSnackbar(errorMessage) } },
+        listState = listState,
+        data = ProfileContentData(emailAddresses, phoneNumbers, externalAccounts),
+        actions =
+          ProfileContentActions(
+            onShowBottomSheet = { type ->
+              if (type == BottomSheetMode.EmailAddress && Clerk.isEmailImmutable) {
+                scope.launch { snackbarHostState.showSnackbar(EMAIL_IMMUTABLE_SNACKBAR_MESSAGE) }
+              } else {
+                bottomSheetType = type
+                showBottomSheet = true
+              }
+            },
+            onError = { errorMessage ->
+              scope.launch { snackbarHostState.showSnackbar(errorMessage) }
+            },
+          ),
       )
 
       if (showBottomSheet) {
@@ -125,54 +127,66 @@ private fun UserProfileDetailViewImpl(
 @Composable
 private fun ProfileContent(
   innerPadding: PaddingValues,
-  scrollState: ScrollState,
-  emailAddresses: ImmutableList<EmailAddress>,
-  phoneNumbers: ImmutableList<PhoneNumber>,
-  externalAccounts: ImmutableList<ExternalAccount>,
-  onShowBottomSheet: (BottomSheetMode) -> Unit,
-  onError: (String) -> Unit,
+  listState: LazyListState,
+  data: ProfileContentData,
+  actions: ProfileContentActions,
 ) {
-  Column(
+  LazyColumn(
+    state = listState,
     modifier =
-      Modifier.fillMaxSize()
-        .background(ClerkMaterialTheme.colors.background)
-        .padding(innerPadding)
-        .verticalScroll(scrollState)
+      Modifier.fillMaxSize().background(ClerkMaterialTheme.colors.background).padding(innerPadding),
   ) {
     val showEmailSection =
-      Clerk.isEmailEnabled && !(Clerk.isEmailImmutable && emailAddresses.isEmpty())
+      Clerk.isEmailEnabled && !(Clerk.isEmailImmutable && data.emailAddresses.isEmpty())
     val showPhoneSection =
-      Clerk.isPhoneNumberEnabled && !(Clerk.isPhoneNumberImmutable && phoneNumbers.isEmpty())
+      Clerk.isPhoneNumberEnabled && !(Clerk.isPhoneNumberImmutable && data.phoneNumbers.isEmpty())
 
-    HorizontalDivider(thickness = dp1, color = ClerkMaterialTheme.computedColors.border)
-    if (showEmailSection) {
-      Spacers.Vertical.Spacer32()
-      UserProfileEmailSection(
-        emailAddresses = emailAddresses,
-        onError = onError,
-        onAddEmailClick = { onShowBottomSheet(BottomSheetMode.EmailAddress) },
-        onVerify = { onShowBottomSheet(BottomSheetMode.VerifyEmailAddress(it)) },
-      )
+    item(key = "user_profile_detail_top_divider") {
       HorizontalDivider(thickness = dp1, color = ClerkMaterialTheme.computedColors.border)
+    }
+    if (showEmailSection) {
+      item(key = "user_profile_detail_email_spacing") { Spacers.Vertical.Spacer32() }
+      userProfileEmailSection(
+        emailAddresses = data.emailAddresses,
+        onError = actions.onError,
+        onAddEmailClick = { actions.onShowBottomSheet(BottomSheetMode.EmailAddress) },
+        onVerify = { actions.onShowBottomSheet(BottomSheetMode.VerifyEmailAddress(it)) },
+      )
+      item(key = "user_profile_detail_email_divider") {
+        HorizontalDivider(thickness = dp1, color = ClerkMaterialTheme.computedColors.border)
+      }
     }
     if (showPhoneSection) {
-      Spacers.Vertical.Spacer16()
-      UserProfilePhoneSection(
-        phoneNumbers = phoneNumbers,
-        onError = onError,
-        onAddPhoneNumberClick = { onShowBottomSheet(BottomSheetMode.PhoneNumber) },
-        onVerify = { onShowBottomSheet(BottomSheetMode.VerifyPhoneNumber(it)) },
+      item(key = "user_profile_detail_phone_spacing") { Spacers.Vertical.Spacer16() }
+      userProfilePhoneSection(
+        phoneNumbers = data.phoneNumbers,
+        onError = actions.onError,
+        onAddPhoneNumberClick = { actions.onShowBottomSheet(BottomSheetMode.PhoneNumber) },
+        onVerify = { actions.onShowBottomSheet(BottomSheetMode.VerifyPhoneNumber(it)) },
       )
-      HorizontalDivider(thickness = dp1, color = ClerkMaterialTheme.computedColors.border)
+      item(key = "user_profile_detail_phone_divider") {
+        HorizontalDivider(thickness = dp1, color = ClerkMaterialTheme.computedColors.border)
+      }
     }
-    Spacers.Vertical.Spacer16()
-    UserProfileExternalAccountSection(
-      externalAccounts,
-      onError = onError,
-      onClickAddAccount = { onShowBottomSheet(BottomSheetMode.ExternalAccount) },
+    item(key = "user_profile_detail_external_account_spacing") { Spacers.Vertical.Spacer16() }
+    userProfileExternalAccountSection(
+      externalAccounts = data.externalAccounts,
+      onError = actions.onError,
+      onClickAddAccount = { actions.onShowBottomSheet(BottomSheetMode.ExternalAccount) },
     )
   }
 }
+
+private data class ProfileContentData(
+  val emailAddresses: ImmutableList<EmailAddress>,
+  val phoneNumbers: ImmutableList<PhoneNumber>,
+  val externalAccounts: ImmutableList<ExternalAccount>,
+)
+
+private data class ProfileContentActions(
+  val onShowBottomSheet: (BottomSheetMode) -> Unit,
+  val onError: (String) -> Unit,
+)
 
 internal sealed interface BottomSheetMode {
   data object ExternalAccount : BottomSheetMode
@@ -216,8 +230,8 @@ private fun Preview() {
         ),
         persistentListOf(
           ExternalAccount(
-            id = "eac_34o5pCBEhohJtr1Ni14YiX8aQ0K",
-            identificationId = "idn_34o5pAvdtMtjAAdeFBfTkRfs77e",
+            id = "eac_34o5pCBEhohJtr1Ni14YiX8aQ0L",
+            identificationId = "idn_34o5pAvdtMtjAAdeFBfTkRfs77f",
             provider = "oauth_google",
             providerUserId = "102662613248529322762",
             emailAddress = "sam@clerk.dev",

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/detail/UserProfileDetailView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/detail/UserProfileDetailView.kt
@@ -21,7 +21,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.currentStateAsState
 import com.clerk.api.Clerk
 import com.clerk.api.emailaddress.EmailAddress
 import com.clerk.api.externalaccount.ExternalAccount
@@ -50,11 +53,18 @@ private const val EMAIL_IMMUTABLE_SNACKBAR_MESSAGE =
 @Composable
 fun UserProfileDetailView(modifier: Modifier = Modifier) {
   val user by Clerk.userFlow.collectAsStateWithLifecycle()
-  LaunchedEffect(Unit) { Clerk.refreshClient() }
+  val destinationLifecycleState by LocalLifecycleOwner.current.lifecycle.currentStateAsState()
+  val isNavigationSettled = destinationLifecycleState == Lifecycle.State.RESUMED
+  LaunchedEffect(isNavigationSettled) {
+    if (isNavigationSettled) {
+      Clerk.refreshClient()
+    }
+  }
   UserProfileDetailViewImpl(
     emailAddresses = user.sortedEmailAddresses(),
     phoneNumbers = user.sortedPhoneNumbers(),
     externalAccounts = user.sortedExternalAccounts(),
+    isNavigationSettled = isNavigationSettled,
     modifier = modifier,
   )
 }
@@ -65,6 +75,7 @@ private fun UserProfileDetailViewImpl(
   emailAddresses: ImmutableList<EmailAddress>,
   phoneNumbers: ImmutableList<PhoneNumber>,
   externalAccounts: ImmutableList<ExternalAccount>,
+  isNavigationSettled: Boolean = true,
   modifier: Modifier = Modifier,
 ) {
   val snackbarHostState = remember { SnackbarHostState() }
@@ -90,6 +101,7 @@ private fun UserProfileDetailViewImpl(
         innerPadding = innerPadding,
         listState = listState,
         data = ProfileContentData(emailAddresses, phoneNumbers, externalAccounts),
+        isNavigationSettled = isNavigationSettled,
         actions =
           ProfileContentActions(
             onShowBottomSheet = { type ->
@@ -129,6 +141,7 @@ private fun ProfileContent(
   innerPadding: PaddingValues,
   listState: LazyListState,
   data: ProfileContentData,
+  isNavigationSettled: Boolean,
   actions: ProfileContentActions,
 ) {
   LazyColumn(
@@ -148,6 +161,7 @@ private fun ProfileContent(
       item(key = "user_profile_detail_email_spacing") { Spacers.Vertical.Spacer32() }
       userProfileEmailSection(
         emailAddresses = data.emailAddresses,
+        isInteractive = isNavigationSettled,
         onError = actions.onError,
         onAddEmailClick = { actions.onShowBottomSheet(BottomSheetMode.EmailAddress) },
         onVerify = { actions.onShowBottomSheet(BottomSheetMode.VerifyEmailAddress(it)) },
@@ -160,6 +174,7 @@ private fun ProfileContent(
       item(key = "user_profile_detail_phone_spacing") { Spacers.Vertical.Spacer16() }
       userProfilePhoneSection(
         phoneNumbers = data.phoneNumbers,
+        isInteractive = isNavigationSettled,
         onError = actions.onError,
         onAddPhoneNumberClick = { actions.onShowBottomSheet(BottomSheetMode.PhoneNumber) },
         onVerify = { actions.onShowBottomSheet(BottomSheetMode.VerifyPhoneNumber(it)) },
@@ -171,6 +186,8 @@ private fun ProfileContent(
     item(key = "user_profile_detail_external_account_spacing") { Spacers.Vertical.Spacer16() }
     userProfileExternalAccountSection(
       externalAccounts = data.externalAccounts,
+      isInteractive = isNavigationSettled,
+      loadRemoteLogos = isNavigationSettled,
       onError = actions.onError,
       onClickAddAccount = { actions.onShowBottomSheet(BottomSheetMode.ExternalAccount) },
     )

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/detail/UserProfileDetailView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/detail/UserProfileDetailView.kt
@@ -52,6 +52,19 @@ private const val EMAIL_IMMUTABLE_SNACKBAR_MESSAGE =
 
 @Composable
 fun UserProfileDetailView(modifier: Modifier = Modifier) {
+  UserProfileDetailViewContent(modifier = modifier)
+}
+
+@Composable
+internal fun UserProfileDetailViewWithBackHandler(
+  modifier: Modifier = Modifier,
+  onBackPressed: () -> Unit,
+) {
+  UserProfileDetailViewContent(modifier = modifier, onBackPressed = onBackPressed)
+}
+
+@Composable
+private fun UserProfileDetailViewContent(modifier: Modifier, onBackPressed: (() -> Unit)? = null) {
   val user by Clerk.userFlow.collectAsStateWithLifecycle()
   val destinationLifecycleState by LocalLifecycleOwner.current.lifecycle.currentStateAsState()
   val isNavigationSettled = destinationLifecycleState == Lifecycle.State.RESUMED
@@ -65,6 +78,7 @@ fun UserProfileDetailView(modifier: Modifier = Modifier) {
     phoneNumbers = user.sortedPhoneNumbers(),
     externalAccounts = user.sortedExternalAccounts(),
     isNavigationSettled = isNavigationSettled,
+    onBackPressed = onBackPressed,
     modifier = modifier,
   )
 }
@@ -76,6 +90,7 @@ private fun UserProfileDetailViewImpl(
   phoneNumbers: ImmutableList<PhoneNumber>,
   externalAccounts: ImmutableList<ExternalAccount>,
   isNavigationSettled: Boolean = true,
+  onBackPressed: (() -> Unit)? = null,
   modifier: Modifier = Modifier,
 ) {
   val snackbarHostState = remember { SnackbarHostState() }
@@ -90,7 +105,7 @@ private fun UserProfileDetailViewImpl(
       modifier = modifier,
       topBar = {
         ClerkTopAppBar(
-          onBackPressed = { userProfileState.navigateBack() },
+          onBackPressed = onBackPressed ?: { userProfileState.navigateBack() },
           title = stringResource(R.string.manage_account),
           hasLogo = false,
         )

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileEmailRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileEmailRow.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,6 +30,7 @@ import com.clerk.ui.core.badge.ClerkBadgeType
 import com.clerk.ui.core.dimens.dp16
 import com.clerk.ui.core.dimens.dp24
 import com.clerk.ui.core.dimens.dp4
+import com.clerk.ui.core.dimens.dp48
 import com.clerk.ui.core.menu.DropDownItem
 import com.clerk.ui.core.menu.ItemMoreMenu
 import com.clerk.ui.core.spacers.Spacers
@@ -42,63 +44,83 @@ internal fun UserProfileEmailRow(
   onError: (String) -> Unit,
   onVerify: (EmailAddress) -> Unit,
   modifier: Modifier = Modifier,
-  viewModel: EmailViewModel = viewModel(),
+  isInteractive: Boolean = true,
+  viewModel: EmailViewModel? = if (isInteractive) viewModel() else null,
 ) {
 
-  val isPreview = LocalInspectionMode.current
-  val state by viewModel.state.collectAsStateWithLifecycle()
-  ReportEmailRowError(state, onError)
-
-  ClerkMaterialTheme {
-    Row(
-      modifier =
-        Modifier.fillMaxWidth()
-          .background(ClerkMaterialTheme.colors.background)
-          .padding(start = dp24)
-          .padding(vertical = dp16)
-          .then(modifier),
-      verticalAlignment = Alignment.CenterVertically,
-    ) {
-      val canRemove = !Clerk.isEmailImmutable
-      val canSetAsPrimary = !Clerk.isEmailImmutable
-      val isPrimary = emailAddress.isPrimary
-      val isVerified = emailAddress.verification?.status == Verification.Status.VERIFIED
-      val shouldShowMenu = canRemove || (canSetAsPrimary && !isPrimary && isVerified) || !isVerified
-
-      EmailWithBadge(isPrimary, emailAddress)
-      Spacer(modifier = Modifier.weight(1f))
-      if (!isPreview && shouldShowMenu) {
-        ItemMoreMenu(
-          dropDownItems =
-            persistentListOf(
-              DropDownItem(
-                id = EmailAction.SetAsPrimary,
-                text = stringResource(R.string.set_as_primary),
-                isHidden = !canSetAsPrimary || isPrimary || !isVerified,
-              ),
-              DropDownItem(
-                id = EmailAction.Verify,
-                text = stringResource(R.string.verify),
-                isHidden = isVerified,
-              ),
-              DropDownItem(
-                id = EmailAction.Remove,
-                text = stringResource(R.string.remove_email),
-                danger = true,
-                isHidden = !canRemove,
-              ),
-            ),
-          onClick = {
-            when (it) {
-              EmailAction.SetAsPrimary -> viewModel.setAsPrimary(emailAddress)
-              EmailAction.Verify -> onVerify(emailAddress)
-              EmailAction.Remove -> viewModel.remove(emailAddress)
-            }
-          },
-        )
-      }
-    }
+  if (isInteractive && viewModel != null) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    ReportEmailRowError(state, onError)
   }
+
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .background(ClerkMaterialTheme.colors.background)
+        .padding(start = dp24)
+        .padding(vertical = dp16)
+        .then(modifier),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    val isPrimary = emailAddress.isPrimary
+
+    EmailWithBadge(isPrimary, emailAddress)
+    Spacer(modifier = Modifier.weight(1f))
+    EmailRowActions(
+      emailAddress = emailAddress,
+      isInteractive = isInteractive,
+      viewModel = viewModel,
+      onVerify = onVerify,
+    )
+  }
+}
+
+@Composable
+private fun EmailRowActions(
+  emailAddress: EmailAddress,
+  isInteractive: Boolean,
+  viewModel: EmailViewModel?,
+  onVerify: (EmailAddress) -> Unit,
+) {
+  val canRemove = !Clerk.isEmailImmutable
+  val canSetAsPrimary = !Clerk.isEmailImmutable
+  val isPrimary = emailAddress.isPrimary
+  val isVerified = emailAddress.verification?.status == Verification.Status.VERIFIED
+  val shouldShowMenu = canRemove || (canSetAsPrimary && !isPrimary && isVerified) || !isVerified
+
+  if (LocalInspectionMode.current || !shouldShowMenu) return
+  if (!isInteractive || viewModel == null) {
+    Spacer(modifier = Modifier.size(dp48))
+    return
+  }
+  ItemMoreMenu(
+    dropDownItems =
+      persistentListOf(
+        DropDownItem(
+          id = EmailAction.SetAsPrimary,
+          text = stringResource(R.string.set_as_primary),
+          isHidden = !canSetAsPrimary || isPrimary || !isVerified,
+        ),
+        DropDownItem(
+          id = EmailAction.Verify,
+          text = stringResource(R.string.verify),
+          isHidden = isVerified,
+        ),
+        DropDownItem(
+          id = EmailAction.Remove,
+          text = stringResource(R.string.remove_email),
+          danger = true,
+          isHidden = !canRemove,
+        ),
+      ),
+    onClick = {
+      when (it) {
+        EmailAction.SetAsPrimary -> viewModel.setAsPrimary(emailAddress)
+        EmailAction.Verify -> onVerify(emailAddress)
+        EmailAction.Remove -> viewModel.remove(emailAddress)
+      }
+    },
+  )
 }
 
 @Composable

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileEmailSection.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileEmailSection.kt
@@ -28,6 +28,7 @@ internal fun LazyListScope.userProfileEmailSection(
   onError: (String) -> Unit,
   onAddEmailClick: () -> Unit,
   onVerify: (EmailAddress) -> Unit,
+  isInteractive: Boolean = true,
 ) {
   item(key = "user_profile_email_header") {
     Text(
@@ -43,7 +44,12 @@ internal fun LazyListScope.userProfileEmailSection(
     key = { emailAddress -> "user_profile_email_${emailAddress.id}" },
     contentType = { "user_profile_email" },
   ) { emailAddress ->
-    UserProfileEmailRow(emailAddress = emailAddress, onError = onError, onVerify)
+    UserProfileEmailRow(
+      emailAddress = emailAddress,
+      onError = onError,
+      onVerify = onVerify,
+      isInteractive = isInteractive,
+    )
   }
   if (!Clerk.isEmailImmutable) {
     item(key = "user_profile_email_add") {

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileEmailSection.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileEmailSection.kt
@@ -1,9 +1,11 @@
 package com.clerk.ui.userprofile.email
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -21,36 +23,34 @@ import com.clerk.ui.userprofile.common.UserProfileButtonRow
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
-@Composable
-internal fun UserProfileEmailSection(
+internal fun LazyListScope.userProfileEmailSection(
   emailAddresses: ImmutableList<EmailAddress>,
   onError: (String) -> Unit,
   onAddEmailClick: () -> Unit,
-  modifier: Modifier = Modifier,
   onVerify: (EmailAddress) -> Unit,
 ) {
-
-  ClerkMaterialTheme {
-    Column(
-      modifier =
-        Modifier.fillMaxWidth()
-          .background(color = ClerkMaterialTheme.colors.background)
-          .then(modifier)
-    ) {
-      Text(
-        modifier = Modifier.padding(horizontal = dp24),
-        text = stringResource(R.string.email_addresses).uppercase(),
-        style = ClerkMaterialTheme.typography.bodySmall.withMediumWeight(),
-        color = ClerkMaterialTheme.colors.mutedForeground,
+  item(key = "user_profile_email_header") {
+    Text(
+      modifier = Modifier.padding(horizontal = dp24),
+      text = stringResource(R.string.email_addresses).uppercase(),
+      style = ClerkMaterialTheme.typography.bodySmall.withMediumWeight(),
+      color = ClerkMaterialTheme.colors.mutedForeground,
+    )
+  }
+  item(key = "user_profile_email_header_spacing") { Spacers.Vertical.Spacer16() }
+  items(
+    items = emailAddresses,
+    key = { emailAddress -> "user_profile_email_${emailAddress.id}" },
+    contentType = { "user_profile_email" },
+  ) { emailAddress ->
+    UserProfileEmailRow(emailAddress = emailAddress, onError = onError, onVerify)
+  }
+  if (!Clerk.isEmailImmutable) {
+    item(key = "user_profile_email_add") {
+      UserProfileButtonRow(
+        text = stringResource(R.string.add_email_address),
+        onClick = onAddEmailClick,
       )
-      Spacers.Vertical.Spacer16()
-      emailAddresses.forEach { UserProfileEmailRow(emailAddress = it, onError = onError, onVerify) }
-      if (!Clerk.isEmailImmutable) {
-        UserProfileButtonRow(
-          text = stringResource(R.string.add_email_address),
-          onClick = onAddEmailClick,
-        )
-      }
     }
   }
 }
@@ -58,28 +58,34 @@ internal fun UserProfileEmailSection(
 @PreviewLightDark
 @Composable
 private fun Preview() {
-  UserProfileEmailSection(
-    onError = {},
-    onAddEmailClick = {},
-    onVerify = {},
-    emailAddresses =
-      persistentListOf(
-        EmailAddress(
-          id = "123",
-          emailAddress = "user@example.com",
-          verification = Verification(status = Verification.Status.VERIFIED),
-        ),
-        EmailAddress(
-          id = "123",
-          emailAddress = "user@example.com",
-          verification = Verification(status = Verification.Status.UNVERIFIED),
-        ),
-        EmailAddress(
-          id = "123",
-          emailAddress = "user@example.com",
-          linkedTo = listOf(EmailAddress.LinkedEntity(id = "1", type = "email")),
-          verification = Verification(status = Verification.Status.VERIFIED),
-        ),
-      ),
-  )
+  ClerkMaterialTheme {
+    LazyColumn(
+      modifier = Modifier.fillMaxWidth().background(ClerkMaterialTheme.colors.background)
+    ) {
+      userProfileEmailSection(
+        onError = {},
+        onAddEmailClick = {},
+        onVerify = {},
+        emailAddresses =
+          persistentListOf(
+            EmailAddress(
+              id = "email_1",
+              emailAddress = "user@example.com",
+              verification = Verification(status = Verification.Status.VERIFIED),
+            ),
+            EmailAddress(
+              id = "email_2",
+              emailAddress = "user@example.com",
+              verification = Verification(status = Verification.Status.UNVERIFIED),
+            ),
+            EmailAddress(
+              id = "email_3",
+              emailAddress = "user@example.com",
+              linkedTo = listOf(EmailAddress.LinkedEntity(id = "1", type = "email")),
+              verification = Verification(status = Verification.Status.VERIFIED),
+            ),
+          ),
+      )
+    }
+  }
 }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/phone/UserProfilePhoneRow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/phone/UserProfilePhoneRow.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,6 +29,7 @@ import com.clerk.ui.core.badge.Badge
 import com.clerk.ui.core.badge.ClerkBadgeType
 import com.clerk.ui.core.dimens.dp24
 import com.clerk.ui.core.dimens.dp4
+import com.clerk.ui.core.dimens.dp48
 import com.clerk.ui.core.dimens.dp8
 import com.clerk.ui.core.menu.DropDownItem
 import com.clerk.ui.core.menu.ItemMoreMenu
@@ -43,30 +45,33 @@ internal fun UserProfilePhoneRow(
   onError: (String) -> Unit,
   onVerify: (PhoneNumber) -> Unit,
   modifier: Modifier = Modifier,
-  viewModel: UserProfileAddPhoneViewModel = viewModel(),
+  isInteractive: Boolean = true,
+  viewModel: UserProfileAddPhoneViewModel? = if (isInteractive) viewModel() else null,
 ) {
   val isPreview = LocalInspectionMode.current
-  val state by viewModel.state.collectAsStateWithLifecycle()
-  ReportPhoneRowError(state, onError)
+  if (isInteractive && viewModel != null) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    ReportPhoneRowError(state, onError)
+  }
 
-  ClerkMaterialTheme {
-    Row(
-      modifier =
-        Modifier.fillMaxWidth()
-          .background(ClerkMaterialTheme.colors.background)
-          .padding(start = dp24)
-          .padding(vertical = dp8)
-          .then(modifier),
-      verticalAlignment = Alignment.CenterVertically,
-    ) {
-      val canRemove = !Clerk.isPhoneNumberImmutable
-      val isPrimary = phoneNumber.isPrimary
-      val isVerified = phoneNumber.verification?.status == Verification.Status.VERIFIED
-      val shouldShowMenu = canRemove || !isPrimary || !isVerified
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .background(ClerkMaterialTheme.colors.background)
+        .padding(start = dp24)
+        .padding(vertical = dp8)
+        .then(modifier),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    val canRemove = !Clerk.isPhoneNumberImmutable
+    val isPrimary = phoneNumber.isPrimary
+    val isVerified = phoneNumber.verification?.status == Verification.Status.VERIFIED
+    val shouldShowMenu = canRemove || !isPrimary || !isVerified
 
-      PhoneWithBadge(phoneNumber)
-      Spacer(modifier = Modifier.weight(1f))
-      if (!isPreview && shouldShowMenu) {
+    PhoneWithBadge(phoneNumber)
+    Spacer(modifier = Modifier.weight(1f))
+    if (!isPreview && shouldShowMenu) {
+      if (isInteractive && viewModel != null) {
         ItemMoreMenu(
           dropDownItems =
             persistentListOf(
@@ -95,6 +100,8 @@ internal fun UserProfilePhoneRow(
             }
           },
         )
+      } else {
+        Spacer(modifier = Modifier.size(dp48))
       }
     }
   }

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/phone/UserProfilePhoneSection.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/phone/UserProfilePhoneSection.kt
@@ -28,6 +28,7 @@ internal fun LazyListScope.userProfilePhoneSection(
   onError: (String) -> Unit,
   onAddPhoneNumberClick: () -> Unit,
   onVerify: (PhoneNumber) -> Unit,
+  isInteractive: Boolean = true,
 ) {
   item(key = "user_profile_phone_header") {
     Text(
@@ -43,7 +44,12 @@ internal fun LazyListScope.userProfilePhoneSection(
     key = { phoneNumber -> "user_profile_phone_${phoneNumber.id}" },
     contentType = { "user_profile_phone" },
   ) { phoneNumber ->
-    UserProfilePhoneRow(phoneNumber = phoneNumber, onError = onError, onVerify = onVerify)
+    UserProfilePhoneRow(
+      phoneNumber = phoneNumber,
+      onError = onError,
+      onVerify = onVerify,
+      isInteractive = isInteractive,
+    )
   }
   if (!Clerk.isPhoneNumberImmutable) {
     item(key = "user_profile_phone_add") {

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/phone/UserProfilePhoneSection.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/phone/UserProfilePhoneSection.kt
@@ -2,9 +2,11 @@ package com.clerk.ui.userprofile.phone
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -21,34 +23,34 @@ import com.clerk.ui.userprofile.common.UserProfileButtonRow
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
-@Composable
-internal fun UserProfilePhoneSection(
+internal fun LazyListScope.userProfilePhoneSection(
   phoneNumbers: ImmutableList<PhoneNumber>,
   onError: (String) -> Unit,
   onAddPhoneNumberClick: () -> Unit,
-  modifier: Modifier = Modifier,
   onVerify: (PhoneNumber) -> Unit,
 ) {
-
-  ClerkMaterialTheme {
-    Column(modifier = modifier.fillMaxWidth()) {
-      Text(
-        modifier = Modifier.padding(horizontal = dp24),
-        text = stringResource(R.string.phone_number).uppercase(),
-        style = ClerkMaterialTheme.typography.bodySmall.withMediumWeight(),
-        color = ClerkMaterialTheme.colors.mutedForeground,
+  item(key = "user_profile_phone_header") {
+    Text(
+      modifier = Modifier.padding(horizontal = dp24),
+      text = stringResource(R.string.phone_number).uppercase(),
+      style = ClerkMaterialTheme.typography.bodySmall.withMediumWeight(),
+      color = ClerkMaterialTheme.colors.mutedForeground,
+    )
+  }
+  item(key = "user_profile_phone_header_spacing") { Spacers.Vertical.Spacer16() }
+  items(
+    items = phoneNumbers,
+    key = { phoneNumber -> "user_profile_phone_${phoneNumber.id}" },
+    contentType = { "user_profile_phone" },
+  ) { phoneNumber ->
+    UserProfilePhoneRow(phoneNumber = phoneNumber, onError = onError, onVerify = onVerify)
+  }
+  if (!Clerk.isPhoneNumberImmutable) {
+    item(key = "user_profile_phone_add") {
+      UserProfileButtonRow(
+        text = stringResource(R.string.add_phone_number),
+        onClick = onAddPhoneNumberClick,
       )
-      Spacers.Vertical.Spacer16()
-      phoneNumbers.forEach {
-        UserProfilePhoneRow(phoneNumber = it, onError = onError, onVerify = onVerify)
-      }
-
-      if (!Clerk.isPhoneNumberImmutable) {
-        UserProfileButtonRow(
-          text = stringResource(R.string.add_phone_number),
-          onClick = onAddPhoneNumberClick,
-        )
-      }
     }
   }
 }
@@ -58,20 +60,22 @@ internal fun UserProfilePhoneSection(
 private fun Preview() {
   ClerkMaterialTheme {
     Box(modifier = Modifier.background(color = ClerkMaterialTheme.colors.background)) {
-      UserProfilePhoneSection(
-        onError = {},
-        onAddPhoneNumberClick = {},
-        onVerify = {},
-        phoneNumbers =
-          persistentListOf(
-            PhoneNumber(
-              id = "phone_1",
-              phoneNumber = "15555550101",
-              reservedForSecondFactor = true,
+      LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        userProfilePhoneSection(
+          onError = {},
+          onAddPhoneNumberClick = {},
+          onVerify = {},
+          phoneNumbers =
+            persistentListOf(
+              PhoneNumber(
+                id = "phone_1",
+                phoneNumber = "15555550101",
+                reservedForSecondFactor = true,
+              ),
+              PhoneNumber(id = "phone_2", phoneNumber = "447911123456"),
             ),
-            PhoneNumber(id = "phone_2", phoneNumber = "447911123456"),
-          ),
-      )
+        )
+      }
     }
   }
 }

--- a/source/ui/src/test/java/com/clerk/ui/theme/ClerkThemeSnapshotTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/theme/ClerkThemeSnapshotTest.kt
@@ -15,17 +15,25 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.clerk.api.Clerk
+import com.clerk.api.ui.ClerkTheme
 import com.clerk.base.BaseSnapshotTest
 import com.clerk.ui.core.dimens.dp1
 import com.clerk.ui.core.dimens.dp12
 import com.clerk.ui.core.dimens.dp24
 import com.clerk.ui.core.dimens.dp6
 import com.materialkolor.ktx.toHex
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import org.junit.Test
 
 class ClerkThemeSnapshotTest : BaseSnapshotTest() {
@@ -119,6 +127,32 @@ class ClerkThemeSnapshotTest : BaseSnapshotTest() {
         }
       }
     }
+  }
+
+  @Test
+  fun clerkThemeRetainsResolvedObjectsAcrossRecompositions() {
+    val observedColors = mutableListOf<ClerkThemeColors>()
+    val observedColorSchemes = mutableListOf<androidx.compose.material3.ColorScheme>()
+
+    paparazzi.snapshot {
+      var recomposition by remember { mutableIntStateOf(0) }
+      val customTheme =
+        if (recomposition >= 0) ClerkTheme(colors = DefaultColors.clerk) else ClerkTheme()
+
+      ClerkMaterialTheme(clerkTheme = customTheme) {
+        val colors = LocalComposeColors.current
+        val colorScheme = MaterialTheme.colorScheme
+        SideEffect {
+          observedColors += colors
+          observedColorSchemes += colorScheme
+          if (recomposition == 0) recomposition++
+        }
+      }
+    }
+
+    assertTrue(observedColors.size >= 2)
+    assertSame(observedColors.first(), observedColors.last())
+    assertSame(observedColorSchemes.first(), observedColorSchemes.last())
   }
 }
 

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountSectionTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/connectedaccount/UserProfileExternalAccountSectionTest.kt
@@ -1,0 +1,59 @@
+package com.clerk.ui.userprofile.connectedaccount
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.clerk.api.externalaccount.ExternalAccount
+import com.clerk.base.BaseSnapshotTest
+import com.clerk.ui.theme.ClerkMaterialTheme
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.collections.immutable.toImmutableList
+
+class UserProfileExternalAccountSectionTest : BaseSnapshotTest() {
+
+  @Test
+  fun highCardinalityAccountList_onlyComposesVisibleRows() {
+    val externalAccounts =
+      (0 until 20)
+        .map { index ->
+          ExternalAccount(
+            id = "external_account_$index",
+            identificationId = "identification_$index",
+            provider = "oauth_google",
+            providerUserId = "provider_user_$index",
+            emailAddress = "user+$index@example.com",
+            approvedScopes = "email profile",
+            createdAt = index.toLong(),
+          )
+        }
+        .toImmutableList()
+    val composedAccountIds = mutableSetOf<String>()
+
+    paparazzi.snapshot {
+      ClerkMaterialTheme {
+        LazyColumn(modifier = Modifier.fillMaxWidth().height(240.dp)) {
+          userProfileExternalAccountSection(
+            externalAccounts = externalAccounts,
+            onError = {},
+            onClickAddAccount = {},
+            externalAccountRow = { externalAccount ->
+              SideEffect { composedAccountIds += externalAccount.id }
+              Box(modifier = Modifier.fillMaxWidth().height(64.dp))
+            },
+          )
+        }
+      }
+    }
+
+    assertTrue(composedAccountIds.isNotEmpty())
+    assertTrue(
+      composedAccountIds.size < externalAccounts.size,
+      "Expected the lazy list to skip off-screen rows, but composed all ${externalAccounts.size}",
+    )
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/email/UserProfileEmailRowTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/email/UserProfileEmailRowTest.kt
@@ -5,11 +5,33 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
+import com.clerk.api.emailaddress.EmailAddress
+import com.clerk.api.network.model.verification.Verification
 import com.clerk.base.BaseSnapshotTest
+import com.clerk.ui.theme.ClerkMaterialTheme
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class UserProfileEmailRowTest : BaseSnapshotTest() {
+
+  @Test
+  fun navigationTransition_rendersWithoutInteractiveState() {
+    paparazzi.snapshot {
+      ClerkMaterialTheme {
+        UserProfileEmailRow(
+          emailAddress =
+            EmailAddress(
+              id = "email_1",
+              emailAddress = "user@example.com",
+              verification = Verification(Verification.Status.VERIFIED),
+            ),
+          isInteractive = false,
+          onError = {},
+          onVerify = {},
+        )
+      }
+    }
+  }
 
   @Test
   fun failureState_reportsErrorOnceAcrossRecomposition() {


### PR DESCRIPTION
## Summary

- keep the account and Manage account surfaces mounted and animate only their horizontal layer translations
- retain Navigation3 for the rest of the user-profile routes and preserve forward, back-button, and system-back slides
- render Manage account as one flattened lazy list with stable row keys and content types
- defer row ViewModels, action menus, remote provider logos, and client refresh until ordinary navigation destinations settle
- memoize resolved Clerk and Material theme objects across recompositions
- send the active session ID when creating an email address instead of the current user ID
- add high-cardinality, transition-state, and create-email session regression coverage

## Why

The customer has enough email addresses and connected accounts that entering Manage account eagerly composed and measured substantial row content while the navigation transition was already running. Lazy rendering removed the sustained work, but destination setup still produced a visible hitch at the start of the slide.

The final transition keeps both profile surfaces at fixed full-screen positions and moves their existing graphics layers. Manage account is prepared offscreen before the user taps Profile, so the animation does not create, measure, or tear down high-cardinality content. Other profile destinations continue to use the existing Navigation3 stack.

While validating the flow, adding an email returned `authentication_invalid` because `_clerk_session_id` was populated with a `user_...` ID. The create-email endpoint now defaults to the active `sess_...` ID, consistent with the other user endpoints.

## Impact

Forward and reverse Manage account transitions retain the requested slide while avoiding composition and layout work during the animation. The list remains lazy and preserves its layout, scrolling, actions, and refresh behavior. Creating an email address now sends the authentication context expected by the backend.

[MOBILE-621](https://linear.app/clerk/issue/MOBILE-621/android-userprofile-manage-account-transition-stutters-with-many)


https://github.com/user-attachments/assets/892c713a-b894-46fb-b735-8c3dea4d1e8e




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smoother animated transitions and system back navigation for profile detail screens.
  * Improved profile sections and account rows for viewing during navigation and non-interactive states.
  * Added more efficient list rendering for emails, phone numbers, and connected accounts.

* **Bug Fixes**
  * Email address creation now correctly uses the active session ID by default.

* **Performance**
  * Improved theme consistency and reduced unnecessary recalculation during UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->