### PR TITLE
fix(ui): reset sign-in credential state

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,6 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4096M -XX\:+UseG1GC -XX\:MaxMetaspaceSize\=1g -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 org.gradle.parallel=true
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
@@ -125,6 +125,7 @@ internal class AuthState(
   override fun navigateBack() {
     if (backStack.size <= 1) return
     backStack.removeLastOrNull()
+    clearSignInCredentialsIfAtRoot()
   }
 
   override fun clearBackStack() {
@@ -137,6 +138,7 @@ internal class AuthState(
 
   override fun pop(numberOfScreens: Int) {
     backStack.pop(numberOfScreens)
+    clearSignInCredentialsIfAtRoot()
   }
 
   /**
@@ -147,6 +149,7 @@ internal class AuthState(
     if (backStack.size > 1) {
       backStack.pop(backStack.size - 1)
     }
+    clearSignInCredentialsIfAtRoot()
   }
 
   override fun popTo(destination: AuthDestination) {
@@ -157,6 +160,16 @@ internal class AuthState(
     if (toPop > 0) {
       backStack.pop(toPop) // non-inclusive: leaves `destination` on top
     }
+    clearSignInCredentialsIfAtRoot()
+  }
+
+  private fun clearSignInCredentialsIfAtRoot() {
+    if (backStack.size != 1 || backStack.lastOrNull() != AuthDestination.AuthStart) return
+
+    signInPassword = ""
+    signInNewPassword = ""
+    signInConfirmNewPassword = ""
+    signInBackupCode = ""
   }
 
   internal fun setToStepForStatus(

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStateEffects.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStateEffects.kt
@@ -3,8 +3,10 @@ package com.clerk.ui.auth
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.res.stringResource
 import com.clerk.ui.R
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun AuthStateEffects(
@@ -15,11 +17,13 @@ internal fun AuthStateEffects(
   onReset: () -> Unit = {},
 ) {
   val defaultErrorMessage = stringResource(R.string.something_went_wrong_please_try_again)
+  val snackbarScope = rememberCoroutineScope()
   LaunchedEffect(state, defaultErrorMessage) {
     when (state) {
       is AuthenticationViewState.Error -> {
         val msg = state.message ?: defaultErrorMessage
-        snackbarHostState.showSnackbar(msg)
+        snackbarScope.launch { snackbarHostState.showSnackbar(msg) }
+        onReset()
       }
       AuthenticationViewState.NotStarted -> authState.clearBackStack()
       is AuthenticationViewState.Success.SignIn -> {

--- a/source/ui/src/main/java/com/clerk/ui/signin/backupcode/SigninFactorTwoBackupCodeView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/backupcode/SigninFactorTwoBackupCodeView.kt
@@ -97,8 +97,9 @@ private fun SignInFactorTwoBackupCodeViewImpl(
           onGo = {
             if (
               authState.signInBackupCode.isNotEmpty() && state !is AuthenticationViewState.Loading
-            )
+            ) {
               viewModel.submit(authState.signInBackupCode)
+            }
           }
         ),
     )

--- a/source/ui/src/main/java/com/clerk/ui/signin/backupcode/SigninFactorTwoBackupCodeView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/backupcode/SigninFactorTwoBackupCodeView.kt
@@ -68,6 +68,11 @@ private fun SignInFactorTwoBackupCodeViewImpl(
   val authState = LocalAuthState.current
   val state by viewModel.state.collectAsStateWithLifecycle()
   val snackbarHostState = remember { SnackbarHostState() }
+  val onSubmit = {
+    if (authState.signInBackupCode.isNotEmpty() && state !is AuthenticationViewState.Loading) {
+      viewModel.submit(authState.signInBackupCode)
+    }
+  }
 
   AuthStateEffects(
     authState = authState,
@@ -92,23 +97,15 @@ private fun SignInFactorTwoBackupCodeViewImpl(
       onValueChange = { authState.signInBackupCode = it },
       label = stringResource(R.string.backup_code),
       keyboardOptions = KeyboardOptions(imeAction = ImeAction.Go),
-      keyboardActions =
-        KeyboardActions(
-          onGo = {
-            if (
-              authState.signInBackupCode.isNotEmpty() && state !is AuthenticationViewState.Loading
-            ) {
-              viewModel.submit(authState.signInBackupCode)
-            }
-          }
-        ),
+      keyboardActions = KeyboardActions(onGo = { onSubmit() }),
     )
     Spacers.Vertical.Spacer24()
     ClerkButton(
       modifier = Modifier.fillMaxWidth(),
       text = stringResource(R.string.continue_text),
       isLoading = state is AuthenticationViewState.Loading,
-      onClick = { viewModel.submit(authState.signInBackupCode) },
+      isEnabled = authState.signInBackupCode.isNotEmpty(),
+      onClick = onSubmit,
       icons = ClerkButtonDefaults.icons(trailingIcon = R.drawable.ic_triangle_right),
     )
     Spacers.Vertical.Spacer24()

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/set/SignInFactorOnePasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/set/SignInFactorOnePasswordView.kt
@@ -85,6 +85,11 @@ private fun SignInFactorOnePasswordViewImpl(
   val authState = LocalAuthState.current
   val state by viewModel.state.collectAsStateWithLifecycle()
   val snackbarHostState = remember { SnackbarHostState() }
+  val onSubmit = {
+    if (authState.signInPassword.isNotEmpty() && state !is AuthenticationViewState.Loading) {
+      viewModel.submitPassword(authState.signInPassword)
+    }
+  }
 
   AuthStateEffects(
     authState = authState,
@@ -104,30 +109,15 @@ private fun SignInFactorOnePasswordViewImpl(
     title = stringResource(R.string.enter_password),
     subtitle = stringResource(R.string.enter_the_password_associated_with_your_account),
   ) {
-    ClerkTextField(
-      value = authState.signInPassword,
+    PasswordInput(
+      password = authState.signInPassword,
       onValueChange = { authState.signInPassword = it },
-      label = stringResource(R.string.enter_your_password),
-      visualTransformation = PasswordVisualTransformation(),
-      inputContentType = ContentType.Password,
-      keyboardOptions =
-        KeyboardOptions(
-          autoCorrectEnabled = false,
-          keyboardType = KeyboardType.Password,
-          imeAction = ImeAction.Go,
-        ),
-      keyboardActions =
-        KeyboardActions(
-          onGo = {
-            if (authState.signInPassword.isNotEmpty() && state !is AuthenticationViewState.Loading)
-              viewModel.submitPassword(authState.signInPassword)
-          }
-        ),
+      onSubmit = onSubmit,
     )
     Spacer(Modifier.height(dp24))
     ClerkButton(
       modifier = Modifier.fillMaxWidth(),
-      onClick = { viewModel.submitPassword(password = authState.signInPassword) },
+      onClick = onSubmit,
       text = stringResource(R.string.continue_text),
       isEnabled = authState.signInPassword.isNotEmpty(),
       isLoading = state is AuthenticationViewState.Loading,
@@ -140,6 +130,24 @@ private fun SignInFactorOnePasswordViewImpl(
     Spacer(Modifier.height(dp24))
     Footer(authState, factor)
   }
+}
+
+@Composable
+private fun PasswordInput(password: String, onValueChange: (String) -> Unit, onSubmit: () -> Unit) {
+  ClerkTextField(
+    value = password,
+    onValueChange = onValueChange,
+    label = stringResource(R.string.enter_your_password),
+    visualTransformation = PasswordVisualTransformation(),
+    inputContentType = ContentType.Password,
+    keyboardOptions =
+      KeyboardOptions(
+        autoCorrectEnabled = false,
+        keyboardType = KeyboardType.Password,
+        imeAction = ImeAction.Go,
+      ),
+    keyboardActions = KeyboardActions(onGo = { onSubmit() }),
+  )
 }
 
 @Composable

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthStateCredentialResetTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthStateCredentialResetTest.kt
@@ -1,0 +1,32 @@
+package com.clerk.ui.auth
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import com.clerk.api.Constants
+import com.clerk.api.network.model.factor.Factor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AuthStateCredentialResetTest {
+
+  @Test
+  fun navigatingBackToAuthStartClearsSignInCredentials() {
+    val factor = Factor(strategy = Constants.Strategy.PASSWORD)
+    val backStack =
+      NavBackStack<NavKey>(AuthDestination.AuthStart, AuthDestination.SignInFactorOne(factor))
+    val authState =
+      AuthState(backStack = backStack, sharedPreferences = InMemorySharedPreferences())
+    authState.signInPassword = "Password123!"
+    authState.signInNewPassword = "NewPassword123!"
+    authState.signInConfirmNewPassword = "NewPassword123!"
+    authState.signInBackupCode = "backup-code"
+
+    authState.navigateBack()
+    authState.navigateTo(AuthDestination.SignInFactorOne(factor))
+
+    assertEquals("", authState.signInPassword)
+    assertEquals("", authState.signInNewPassword)
+    assertEquals("", authState.signInConfirmNewPassword)
+    assertEquals("", authState.signInBackupCode)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthStateEffectsTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthStateEffectsTest.kt
@@ -1,0 +1,29 @@
+package com.clerk.ui.auth
+
+import androidx.compose.material3.SnackbarHostState
+import com.clerk.base.BaseSnapshotTest
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AuthStateEffectsTest : BaseSnapshotTest() {
+
+  @Test
+  fun errorStateIsResetImmediately() {
+    var resetCalls = 0
+    val authState = mockk<AuthState>(relaxed = true)
+    val snackbarHostState = SnackbarHostState()
+
+    paparazzi.snapshot {
+      AuthStateEffects(
+        authState = authState,
+        state = AuthenticationViewState.Error("Invalid password"),
+        snackbarHostState = snackbarHostState,
+        onAuthComplete = {},
+        onReset = { resetCalls++ },
+      )
+    }
+
+    assertEquals(1, resetCalls)
+  }
+}


### PR DESCRIPTION
## Summary

- keep sign-in credentials in the shared auth state, matching the iOS state-ownership model
- clear password, new-password, confirmation, and backup-code values whenever auth navigation returns to `AuthStart`
- reset authentication error state immediately while snackbar presentation continues in the composition scope
- add regression coverage for the exact password-screen back/forward flow and error-state reset

## Why

The credential fields belong to `AuthState`, which lives above the navigation back stack. Navigation back to the identifier screen did not clear that state, so submitting the identifier again rebound the password screen to the previous value.

Error states also remained active while `showSnackbar` was suspended. Navigating away during that time could cancel the effect before the view model reset, causing the stale error to display again on re-entry.

## Impact

After a failed password attempt, navigating back to the identifier screen and forward again now presents an empty password field with no stale error. Other sign-in secrets are cleared at the same auth-root boundary.

## Testing

- `./gradlew :source:ui:testDebugUnitTest spotlessCheck :source:ui:detekt`
- targeted regression tests: `AuthStateCredentialResetTest` and `AuthStateEffectsTest`
- `git diff --check`
- `./gradlew :source:ui:lintDebug` *(currently fails on four unrelated existing violations: direct view-model construction in a snapshot test, two missing-translation entries, and composable parameter ordering in `OrganizationSwitcher.kt`)*

Closes #864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in credentials are now cleared when returning to the authentication start screen.
  * Authentication errors reset the related state after displaying an error message.
  * Password and backup-code submissions now behave consistently from the keyboard and button, while preventing empty or duplicate submissions.

* **Tests**
  * Added coverage for credential clearing and authentication error resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->