### PR TITLE
fix(ui): honor explicit password sign-in choice

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorOneView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorOneView.kt
@@ -88,6 +88,8 @@ private fun SignIn.preferredEmailLinkFactor(
   fallback: Factor,
   supportedFactors: List<Factor>,
 ): Factor? {
+  if (fallback.strategy != StrategyKeys.EMAIL_CODE) return null
+
   return if (isEmailIdentifierSignIn(fallback, supportedFactors)) {
     supportedFactors.firstOrNull { it.strategy == StrategyKeys.EMAIL_LINK }
   } else {

--- a/source/ui/src/test/java/com/clerk/ui/signin/SignInFactorOneViewTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/SignInFactorOneViewTest.kt
@@ -114,6 +114,34 @@ class SignInFactorOneViewTest {
   }
 
   @Test
+  fun resolveFirstFactorShouldKeepExplicitPasswordWhenEmailLinkIsSupported() {
+    val passwordFactor = Factor(strategy = StrategyKeys.PASSWORD)
+    every { mockAuth.currentSignIn } returns
+      SignIn(
+        id = "sign_in_123",
+        identifier = "sam@clerk.dev",
+        supportedFirstFactors =
+          listOf(
+            passwordFactor,
+            Factor(
+              strategy = StrategyKeys.EMAIL_CODE,
+              emailAddressId = "email_123",
+              safeIdentifier = "sam@clerk.dev",
+            ),
+            Factor(
+              strategy = StrategyKeys.EMAIL_LINK,
+              emailAddressId = "email_123",
+              safeIdentifier = "sam@clerk.dev",
+            ),
+          ),
+      )
+
+    val resolved = resolveFirstFactor(passwordFactor)
+
+    assertEquals(passwordFactor, resolved)
+  }
+
+  @Test
   fun resolveFirstFactorShouldKeepResetPasswordEmailCodeWhenEmailLinkIsSupported() {
     val resetFactor =
       Factor(


### PR DESCRIPTION
## Summary

- preserve an explicitly selected password first factor when email-link authentication is also supported
- keep the existing email-code-to-email-link preference for automatic email routes
- add regression coverage for password, email code, and email link being offered together

## Root cause

The first-factor resolver checked whether the sign-in used an email identifier and promoted the route to `email_link` before honoring the factor selected by the user. As a result, choosing “Sign in with password” still launched the native magic-link flow.

The resolver now limits email-link promotion to routes whose fallback factor is `email_code`, so explicit password selections remain on the password screen.

## Impact

Users can choose password authentication even when the instance also supports email links. This avoids forcing users into a same-device native magic-link flow after they explicitly select password.

Closes #862

## Validation

- `./gradlew spotlessCheck`
- `./gradlew detekt`
- `./gradlew :source:ui:testDebugUnitTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in factor selection so explicitly chosen password authentication is preserved when email-based options are also available.
  * Prevented email-link preferences from being applied when the fallback authentication method is not email code.

* **Tests**
  * Added coverage for sign-in flows combining password, email code, and email link options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->