### PR TITLE
fix(sso): handle browser authentication cancellation

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/externalaccount/ExternalAccountService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/externalaccount/ExternalAccountService.kt
@@ -1,6 +1,6 @@
 package com.clerk.api.externalaccount
 
-import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import androidx.core.net.toUri
 import com.clerk.api.Clerk
 import com.clerk.api.externalaccount.ExternalAccountService.connectExternalAccount
@@ -14,7 +14,7 @@ import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onSuccess
-import com.clerk.api.sso.SSOReceiverActivity
+import com.clerk.api.sso.SSOManagerActivity
 import com.clerk.api.user.User
 import com.clerk.api.user.toMap
 import kotlinx.coroutines.CompletableDeferred
@@ -87,16 +87,22 @@ internal object ExternalAccountService {
           requireNotNull(initialResult.value.verification?.externalVerificationRedirectUrl) {
             "External verification redirect URL is missing"
           }
+        val context =
+          Clerk.applicationContext?.get()
+            ?: return ClerkResult.unknownFailure(
+              IllegalStateException(
+                "Clerk must be initialized before connecting an external account"
+              )
+            )
         val completableDeferred =
           CompletableDeferred<ClerkResult<ExternalAccount, ClerkErrorResponse>>()
         currentPendingExternalAccountConnection = completableDeferred
         currentPendingExternalAccountConnectionId = initialResult.value.id
         val intent =
-          Intent(Clerk.applicationContext?.get(), SSOReceiverActivity::class.java).apply {
-            data = externalUrl.toUri()
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+          SSOManagerActivity.createAuthorizationIntent(context, externalUrl.toUri()).apply {
+            addFlags(FLAG_ACTIVITY_NEW_TASK)
           }
-        Clerk.applicationContext?.get()?.startActivity(intent)
+        context.startActivity(intent)
         completableDeferred.await()
       }
     }

--- a/source/api/src/main/kotlin/com/clerk/api/sso/SSOCancellationException.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/SSOCancellationException.kt
@@ -1,0 +1,9 @@
+package com.clerk.api.sso
+
+/**
+ * Signals that a redirect-based OAuth or SSO authentication attempt ended without completing.
+ *
+ * Check `ClerkResult.Failure.throwable` against this type to distinguish a browser dismissal or
+ * cancelled provider flow from an authentication failure.
+ */
+public class SSOCancellationException internal constructor(message: String) : Exception(message)

--- a/source/api/src/main/kotlin/com/clerk/api/sso/SSOManagerActivity.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/SSOManagerActivity.kt
@@ -202,16 +202,6 @@ internal class SSOManagerActivity : AppCompatActivity() {
     }
   }
 
-  private fun isCallbackUri(uri: Uri): Boolean {
-    return HostedAuthService.canHandle(uri) ||
-      uri.scheme?.startsWith("clerk") == true ||
-      canHandleNativeMagicLink(uri) ||
-      uri.getQueryParameter("rotating_token_nonce") != null ||
-      uri.getQueryParameter("__clerk_status") != null ||
-      uri.getQueryParameter("error") != null ||
-      uri.getQueryParameter("error_description") != null
-  }
-
   /** Finishes an authentication attempt that could not be completed. */
   private fun authorizationFailed() {
     HostedAuthService.cancelPendingAuthentication()
@@ -221,6 +211,17 @@ internal class SSOManagerActivity : AppCompatActivity() {
   }
 
   internal companion object {
+    internal fun isCallbackUri(uri: Uri): Boolean {
+      return HostedAuthService.canHandle(uri) ||
+        uri.scheme?.startsWith("clerk") == true ||
+        canHandleNativeMagicLink(uri) ||
+        uri.getQueryParameter("rotating_token_nonce") != null ||
+        uri.getQueryParameter("__clerk_status") != null ||
+        uri.getQueryParameter("__clerk_error_code") != null ||
+        uri.getQueryParameter("error") != null ||
+        uri.getQueryParameter("error_description") != null
+    }
+
     /**
      * Creates an intent to handle the OAuth/SSO response.
      *

--- a/source/api/src/main/kotlin/com/clerk/api/sso/SSOManagerActivity.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/SSOManagerActivity.kt
@@ -76,7 +76,7 @@ internal class SSOManagerActivity : AppCompatActivity() {
     // subsequent runs, we either got the response back from OAuthReceiverActivity or it was
     // cancelled. If we have a response, complete the flow and only finish after completion to
     // avoid cancelling the in-flight network request.
-    intent.data?.let {
+    intent.data?.takeIf(::isCallbackUri)?.let {
       if (completion == Completion.NONE) {
         completion = Completion.SSO
         pendingCallbackUri = it
@@ -206,12 +206,16 @@ internal class SSOManagerActivity : AppCompatActivity() {
     return HostedAuthService.canHandle(uri) ||
       uri.scheme?.startsWith("clerk") == true ||
       canHandleNativeMagicLink(uri) ||
-      uri.getQueryParameter("rotating_token_nonce") != null
+      uri.getQueryParameter("rotating_token_nonce") != null ||
+      uri.getQueryParameter("__clerk_status") != null ||
+      uri.getQueryParameter("error") != null ||
+      uri.getQueryParameter("error_description") != null
   }
 
   /** Finishes an authentication attempt that could not be completed. */
   private fun authorizationFailed() {
     HostedAuthService.cancelPendingAuthentication()
+    SSOService.cancelPendingAuthentication()
     val response = Intent()
     setResult(RESULT_CANCELED, response)
   }

--- a/source/api/src/main/kotlin/com/clerk/api/sso/SSOReceiverActivity.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/SSOReceiverActivity.kt
@@ -24,7 +24,12 @@ internal class SSOReceiverActivity : Activity() {
     ClerkLog.d("OAuthReceiverActivity started with uri: ${SafeUriLog.describe(intent?.data)}")
     super.onCreate(savedInstanceState)
     val callbackUri = intent?.data
-    if (callbackUri != null && HostedAuthService.isForgedCallback(callbackUri)) {
+    if (callbackUri == null || !SSOManagerActivity.isCallbackUri(callbackUri)) {
+      ClerkLog.w("Ignoring unrecognized OAuth/SSO callback")
+      finish()
+      return
+    }
+    if (HostedAuthService.isForgedCallback(callbackUri)) {
       ClerkLog.w("Ignoring invalid hosted auth callback")
       finish()
       return

--- a/source/api/src/main/kotlin/com/clerk/api/sso/SSOService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/sso/SSOService.kt
@@ -1,6 +1,5 @@
 package com.clerk.api.sso
 
-import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.net.Uri
 import androidx.core.net.toUri
@@ -219,6 +218,11 @@ internal object SSOService {
     redirectFlow: RedirectFlow = RedirectFlow.SIGN_IN,
     signUp: SignUp? = null,
   ): ClerkResult<OAuthResult, ClerkErrorResponse> {
+    val context =
+      Clerk.applicationContext?.get()
+        ?: return ClerkResult.unknownFailure(
+          IllegalStateException("Clerk must be initialized before starting redirect authentication")
+        )
     cancelCompetingAuthenticationFlows()
 
     val completableDeferred = CompletableDeferred<ClerkResult<OAuthResult, ClerkErrorResponse>>()
@@ -229,11 +233,12 @@ internal object SSOService {
     currentSignUp = signUp
 
     val intent =
-      Intent(Clerk.applicationContext?.get(), SSOReceiverActivity::class.java).apply {
-        data = externalVerificationRedirectUrl.toUri()
-        addFlags(FLAG_ACTIVITY_NEW_TASK)
-      }
-    Clerk.applicationContext?.get()?.startActivity(intent)
+      SSOManagerActivity.createAuthorizationIntent(
+          context = context,
+          authorizationUri = externalVerificationRedirectUrl.toUri(),
+        )
+        .apply { addFlags(FLAG_ACTIVITY_NEW_TASK) }
+    context.startActivity(intent)
 
     return completableDeferred.await()
   }
@@ -247,7 +252,7 @@ internal object SSOService {
    *
    * The method handles two authentication scenarios:
    * 1. **Sign In**: When the URI contains a `rotating_token_nonce` parameter
-   * 2. **Sign Up Transfer**: When no nonce is present, indicating a new user registration
+   * 2. **Sign Up Transfer**: When the callback contains Clerk's explicit transfer marker
    *
    * This method is typically triggered internally via [SSOReceiverActivity] when the app receives a
    * redirect URI containing authentication results.
@@ -265,27 +270,31 @@ internal object SSOService {
         return
       }
 
-      val nonce = uri.getQueryParameter("rotating_token_nonce")
+      val nonce = uri.getQueryParameter(ROTATING_TOKEN_NONCE)?.takeIf(String::isNotBlank)
 
       when (currentRedirectFlow) {
         RedirectFlow.SIGN_IN -> {
           if (nonce != null) {
             handleSignIn(nonce)
-          } else if (currentTransferable) {
+          } else if (uri.isTransferCallbackFor(RedirectFlow.SIGN_IN) && currentTransferable) {
             handleSignUpTransfer()
-          } else {
+          } else if (uri.isTransferCallbackFor(RedirectFlow.SIGN_IN)) {
             ClerkLog.d("Sign-up transfer blocked: transferable is false")
             currentPendingAuth?.complete(
               ClerkResult.unknownFailure(Exception("external_account_not_found"))
             )
             clearCurrentAuth()
+          } else {
+            completeCancellation(uri)
           }
         }
         RedirectFlow.SIGN_UP -> {
           if (nonce != null) {
             handleSignUp(nonce)
-          } else {
+          } else if (uri.isTransferCallbackFor(RedirectFlow.SIGN_UP)) {
             handleSignInTransfer()
+          } else {
+            completeCancellation(uri)
           }
         }
       }
@@ -374,6 +383,17 @@ internal object SSOService {
     clearCurrentAuth()
   }
 
+  private fun completeCancellation(uri: Uri) {
+    val reason =
+      uri.getQueryParameter(ERROR_DESCRIPTION)
+        ?: uri.getQueryParameter(ERROR)
+        ?: uri.getQueryParameter(CLERK_ERROR_CODE)
+        ?: AUTHENTICATION_CANCELLED
+    ClerkLog.d("Redirect authentication cancelled")
+    currentPendingAuth?.complete(ClerkResult.unknownFailure(SSOCancellationException(reason)))
+    clearCurrentAuth()
+  }
+
   /**
    * Clears the current authentication state.
    *
@@ -391,7 +411,7 @@ internal object SSOService {
   private fun cancelCompetingAuthenticationFlows() {
     currentPendingAuth?.complete(
       ClerkResult.unknownFailure(
-        Exception("New authentication started, cancelling previous attempt")
+        SSOCancellationException("New authentication started, cancelling previous attempt")
       )
     )
     HostedAuthService.cancelPendingAuthentication(HOSTED_AUTH_CANCELLED_BY_NEW_FLOW)
@@ -407,7 +427,7 @@ internal object SSOService {
    */
   fun cancelPendingAuthentication() {
     currentPendingAuth?.complete(
-      ClerkResult.Companion.unknownFailure(Exception("Authentication cancelled"))
+      ClerkResult.unknownFailure(SSOCancellationException(AUTHENTICATION_CANCELLED))
     )
     clearCurrentAuth()
   }
@@ -440,4 +460,23 @@ internal object SSOService {
     SIGN_IN,
     SIGN_UP,
   }
+
+  private fun Uri.isTransferCallbackFor(redirectFlow: RedirectFlow): Boolean {
+    if (getQueryParameter(CLERK_STATUS) != CLERK_STATUS_FAILED) return false
+
+    return when (redirectFlow) {
+      RedirectFlow.SIGN_IN -> getQueryParameter(CLERK_ERROR_CODE) == EXTERNAL_ACCOUNT_NOT_FOUND
+      RedirectFlow.SIGN_UP -> getQueryParameter(CLERK_ERROR_CODE) == EXTERNAL_ACCOUNT_EXISTS
+    }
+  }
+
+  private const val AUTHENTICATION_CANCELLED = "Authentication cancelled"
+  private const val ROTATING_TOKEN_NONCE = "rotating_token_nonce"
+  private const val CLERK_STATUS = "__clerk_status"
+  private const val CLERK_STATUS_FAILED = "failed"
+  private const val CLERK_ERROR_CODE = "__clerk_error_code"
+  private const val EXTERNAL_ACCOUNT_NOT_FOUND = "external_account_not_found"
+  private const val EXTERNAL_ACCOUNT_EXISTS = "external_account_exists"
+  private const val ERROR = "error"
+  private const val ERROR_DESCRIPTION = "error_description"
 }

--- a/source/api/src/test/java/com/clerk/api/sso/ExternalAccountServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/ExternalAccountServiceTest.kt
@@ -1,6 +1,7 @@
 package com.clerk.api.sso
 
 import android.content.Context
+import android.content.Intent
 import com.clerk.api.Clerk
 import com.clerk.api.externalaccount.ExternalAccount
 import com.clerk.api.externalaccount.ExternalAccountService
@@ -16,16 +17,23 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
+import io.mockk.verify
 import java.lang.ref.WeakReference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -72,6 +80,8 @@ class ExternalAccountServiceTest {
     every { ClerkApi.user } returns mockUserApi
     every { Clerk.applicationContext } returns WeakReference(mockContext)
     every { Clerk.debugMode } returns false
+    every { Clerk.session } returns mockSession
+    every { Clerk.session?.id } returns "session_123"
 
     // Setup verification mock
     every { mockVerification.status } returns Verification.Status.VERIFIED
@@ -139,5 +149,32 @@ class ExternalAccountServiceTest {
 
     // After cancellation, there should be no pending connection
     assertFalse(ExternalAccountService.hasPendingExternalAccountConnection())
+  }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun `connectExternalAccount launches authorization through non-exported manager`() = runTest {
+    coEvery { mockUserApi.createExternalAccount(any(), "session_123") } returns
+      ClerkResult.success(mockExternalAccount)
+    val startedIntent = slot<Intent>()
+
+    val pendingResult = async {
+      ExternalAccountService.connectExternalAccount(
+        User.CreateExternalAccountParams(provider = OAuthProvider.GOOGLE)
+      )
+    }
+    runCurrent()
+
+    verify(exactly = 1) { mockContext.startActivity(capture(startedIntent)) }
+    assertEquals(SSOManagerActivity::class.java.name, startedIntent.captured.component?.className)
+    assertNull(startedIntent.captured.data)
+    assertEquals(
+      mockVerification.externalVerificationRedirectUrl,
+      startedIntent.captured.getStringExtra(SSOManagerActivity.URI_KEY),
+    )
+    assertTrue(startedIntent.captured.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+
+    ExternalAccountService.cancelPendingExternalAccountConnection()
+    pendingResult.await()
   }
 }

--- a/source/api/src/test/java/com/clerk/api/sso/SSOManagerActivityTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/SSOManagerActivityTest.kt
@@ -81,6 +81,24 @@ class SSOManagerActivityTest {
   }
 
   @Test
+  fun errorCodeOnlyCallback_completesWithoutAuthorizationStarted() {
+    mockkObject(SSOService)
+    every { SSOService.hasPendingExternalAccountConnection() } returns false
+    coJustRun { SSOService.completeAuthenticateWithRedirect(any()) }
+
+    val app = ApplicationProvider.getApplicationContext<Application>()
+    val responseUri =
+      Uri.parse("https://example.com/callback?__clerk_error_code=authentication_cancelled")
+    val intent = SSOManagerActivity.createResponseHandlingIntent(app, responseUri)
+
+    val activity =
+      Robolectric.buildActivity(SSOManagerActivity::class.java, intent).create().resume().get()
+
+    coVerify(exactly = 1) { SSOService.completeAuthenticateWithRedirect(responseUri) }
+    assertEquals(Activity.RESULT_OK, Shadows.shadowOf(activity).resultCode)
+  }
+
+  @Test
   fun newAuthorizationIntent_restartsManagerWithNewUrl() {
     val app = ApplicationProvider.getApplicationContext<Application>()
     val firstUri = Uri.parse("https://accounts.example.com/first")

--- a/source/api/src/test/java/com/clerk/api/sso/SSOManagerActivityTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/SSOManagerActivityTest.kt
@@ -105,7 +105,9 @@ class SSOManagerActivityTest {
   @Test
   fun authorizationCanceled_setsResultCanceled_whenNoData() {
     mockkObject(HostedAuthService)
+    mockkObject(SSOService)
     justRun { HostedAuthService.cancelPendingAuthentication(any()) }
+    justRun { SSOService.cancelPendingAuthentication() }
     val app = ApplicationProvider.getApplicationContext<Application>()
     val intent =
       SSOManagerActivity.createBaseIntent(app).apply {
@@ -118,6 +120,29 @@ class SSOManagerActivityTest {
     val shadow = Shadows.shadowOf(activity)
     assertEquals(Activity.RESULT_CANCELED, shadow.resultCode)
     verify(exactly = 1) { HostedAuthService.cancelPendingAuthentication(any()) }
+    verify(exactly = 1) { SSOService.cancelPendingAuthentication() }
+  }
+
+  @Test
+  fun authorizationUrl_isNotTreatedAsCallback_whenBrowserIsDismissed() {
+    mockkObject(HostedAuthService)
+    mockkObject(SSOService)
+    justRun { HostedAuthService.cancelPendingAuthentication(any()) }
+    justRun { SSOService.cancelPendingAuthentication() }
+    coJustRun { SSOService.completeAuthenticateWithRedirect(any()) }
+    val app = ApplicationProvider.getApplicationContext<Application>()
+    val authorizationUri = Uri.parse("https://accounts.example.com/oauth/authorize")
+    val intent =
+      SSOManagerActivity.createResponseHandlingIntent(app, authorizationUri).apply {
+        putExtra(com.clerk.api.Constants.Storage.KEY_AUTHORIZATION_STARTED, true)
+      }
+
+    val activity =
+      Robolectric.buildActivity(SSOManagerActivity::class.java, intent).create().resume().get()
+
+    assertEquals(Activity.RESULT_CANCELED, Shadows.shadowOf(activity).resultCode)
+    coVerify(exactly = 0) { SSOService.completeAuthenticateWithRedirect(any()) }
+    verify(exactly = 1) { SSOService.cancelPendingAuthentication() }
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/sso/SSOReceiverActivityTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/SSOReceiverActivityTest.kt
@@ -52,6 +52,19 @@ class SSOReceiverActivityTest {
     assertEquals(callbackUri, forwardedIntent.data)
   }
 
+  @Test
+  fun unrecognizedExplicitIntentIsNotForwardedToManager() {
+    val callbackUri = Uri.parse("https://attacker.example/fake-sign-in")
+    mockkObject(HostedAuthService)
+    every { HostedAuthService.canHandle(callbackUri) } returns false
+
+    val activity = createReceiver(callbackUri)
+
+    assertNull(Shadows.shadowOf(activity).nextStartedActivity)
+    assertTrue(activity.isFinishing)
+    verify(exactly = 0) { HostedAuthService.isForgedCallback(any()) }
+  }
+
   private fun createReceiver(callbackUri: Uri): SSOReceiverActivity {
     val context = ApplicationProvider.getApplicationContext<Context>()
     val intent = Intent(context, SSOReceiverActivity::class.java).apply { data = callbackUri }

--- a/source/api/src/test/java/com/clerk/api/sso/SSOServiceCancellationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sso/SSOServiceCancellationTest.kt
@@ -1,0 +1,114 @@
+package com.clerk.api.sso
+
+import android.app.Application
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.clerk.api.Clerk
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signup.SignUp
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import java.lang.ref.WeakReference
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SSOServiceCancellationTest {
+
+  @Before
+  fun setUp() {
+    val application = ApplicationProvider.getApplicationContext<Application>()
+    mockkObject(Clerk)
+    every { Clerk.applicationContext } returns WeakReference(application)
+  }
+
+  @After
+  fun tearDown() {
+    SSOService.cancelPendingAuthentication()
+    unmockkAll()
+  }
+
+  @Test
+  fun `cancelPendingAuthentication returns typed cancellation failure`() = runTest {
+    val pendingResult =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        SSOService.authenticateWithPreparedRedirect(AUTHORIZATION_URL)
+      }
+
+    SSOService.cancelPendingAuthentication()
+
+    val failure = pendingResult.await() as ClerkResult.Failure
+    assertTrue(failure.throwable is SSOCancellationException)
+    assertFalse(SSOService.hasPendingAuthentication())
+  }
+
+  @Test
+  fun `callback without success marker returns cancellation instead of starting sign up`() =
+    runTest {
+      mockkObject(SignUp.Companion)
+      val pendingResult =
+        async(start = CoroutineStart.UNDISPATCHED) {
+          SSOService.authenticateWithPreparedRedirect(AUTHORIZATION_URL)
+        }
+
+      SSOService.completeAuthenticateWithRedirect(Uri.parse(CALLBACK_URL))
+
+      val failure = pendingResult.await() as ClerkResult.Failure
+      assertTrue(failure.throwable is SSOCancellationException)
+      coVerify(exactly = 0) { SignUp.create(any<SignUp.CreateParams>()) }
+    }
+
+  @Test
+  fun `provider error callback returns cancellation instead of starting sign up`() = runTest {
+    mockkObject(SignUp.Companion)
+    val pendingResult =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        SSOService.authenticateWithPreparedRedirect(AUTHORIZATION_URL)
+      }
+
+    SSOService.completeAuthenticateWithRedirect(
+      Uri.parse("$CALLBACK_URL?error=access_denied&error_description=User%20cancelled")
+    )
+
+    val failure = pendingResult.await() as ClerkResult.Failure
+    assertTrue(failure.throwable is SSOCancellationException)
+    coVerify(exactly = 0) { SignUp.create(any<SignUp.CreateParams>()) }
+  }
+
+  @Test
+  fun `explicit external account not found marker still transfers to sign up`() = runTest {
+    val signUp = mockk<SignUp>(relaxed = true)
+    mockkObject(SignUp.Companion)
+    coEvery { SignUp.create(SignUp.CreateParams.Transfer) } returns ClerkResult.success(signUp)
+    val pendingResult =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        SSOService.authenticateWithPreparedRedirect(AUTHORIZATION_URL)
+      }
+
+    SSOService.completeAuthenticateWithRedirect(
+      Uri.parse("$CALLBACK_URL?__clerk_status=failed&__clerk_error_code=external_account_not_found")
+    )
+
+    val result = pendingResult.await() as ClerkResult.Success
+    assertSame(signUp, result.value.signUp)
+    coVerify(exactly = 1) { SignUp.create(SignUp.CreateParams.Transfer) }
+  }
+
+  private companion object {
+    const val AUTHORIZATION_URL = "https://accounts.example.com/oauth/authorize"
+    const val CALLBACK_URL = "clerk://com.example.app.callback"
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -19,6 +19,7 @@ import com.clerk.api.signin.startingFirstFactor
 import com.clerk.api.signup.SignUp
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.ResultType
+import com.clerk.api.sso.SSOCancellationException
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineStart
@@ -328,7 +329,14 @@ internal class AuthStartViewModel(private val ioDispatcher: CoroutineDispatcher 
                 AuthState.OAuthState.Error("Unknown result type from OAuth provider")
             }
         }
-        .onFailure { _state.value = AuthState.OAuthState.Error(it.errorMessage) }
+        .onFailure {
+          _state.value =
+            if (it.isSSOCancellation) {
+              AuthState.Idle
+            } else {
+              AuthState.OAuthState.Error(it.errorMessage)
+            }
+        }
     }
   }
 
@@ -386,7 +394,14 @@ internal class AuthStartViewModel(private val ioDispatcher: CoroutineDispatcher 
         }
       }
       .onFailure { failure ->
-        withContext(Dispatchers.Main) { _state.value = AuthState.Error(failure.errorMessage) }
+        withContext(Dispatchers.Main) {
+          _state.value =
+            if (failure.isSSOCancellation) {
+              AuthState.Idle
+            } else {
+              AuthState.Error(failure.errorMessage)
+            }
+        }
       }
   }
 
@@ -435,6 +450,9 @@ internal class AuthStartViewModel(private val ioDispatcher: CoroutineDispatcher 
 
 private fun SignIn.requiresEnterpriseSSO(): Boolean =
   startingFirstFactor?.strategy == "enterprise_sso"
+
+private val ClerkResult.Failure<*>.isSSOCancellation: Boolean
+  get() = throwable is SSOCancellationException
 
 private val emailRegex = Regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")
 

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -569,6 +569,27 @@ class AuthViewModelTest {
   }
 
   @Test
+  fun socialOAuthCancellationReturnsToIdle() = runTest {
+    val cancellation =
+      Class.forName("com.clerk.api.sso.SSOCancellationException")
+        .getDeclaredConstructor(String::class.java)
+        .apply { isAccessible = true }
+        .newInstance("Authentication cancelled") as Throwable
+    mockkObject(SignIn.Companion)
+    coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
+      ClerkResult.unknownFailure(cancellation)
+
+    viewModel.authenticateWithSocialProvider(
+      provider = OAuthProvider.GITHUB,
+      preferGoogleOneTap = false,
+    )
+
+    assertEquals(AuthStartViewModel.AuthState.OAuthState.Loading, viewModel.state.value)
+    testDispatcher.scheduler.advanceUntilIdle()
+    assertEquals(AuthStartViewModel.AuthState.Idle, viewModel.state.value)
+  }
+
+  @Test
   fun socialOAuthCanStartWithSignUp() = runTest {
     mockkObject(SignIn.Companion)
     mockkObject(SignUp.Companion)

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -4,8 +4,12 @@ import app.cash.turbine.test
 import com.clerk.api.Clerk
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error as ClerkError
+import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.signin.SignIn
+import com.clerk.api.signin.authenticateWithPreparedRedirect
+import com.clerk.api.signin.prepareFirstFactor
 import com.clerk.api.signup.SignUp
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.OAuthResult
@@ -15,6 +19,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
@@ -586,6 +591,52 @@ class AuthViewModelTest {
 
     assertEquals(AuthStartViewModel.AuthState.OAuthState.Loading, viewModel.state.value)
     testDispatcher.scheduler.advanceUntilIdle()
+    assertEquals(AuthStartViewModel.AuthState.Idle, viewModel.state.value)
+  }
+
+  @Test
+  fun enterpriseSSOCancellationReturnsToIdle() = runTest {
+    val cancellation =
+      Class.forName("com.clerk.api.sso.SSOCancellationException")
+        .getDeclaredConstructor(String::class.java)
+        .apply { isAccessible = true }
+        .newInstance("Authentication cancelled") as Throwable
+    val signIn =
+      SignIn(
+        id = "sign_in_enterprise",
+        status = SignIn.Status.NEEDS_FIRST_FACTOR,
+        identifier = "user@example.com",
+        supportedFirstFactors =
+          listOf(Factor(strategy = "enterprise_sso", safeIdentifier = "user@example.com")),
+      )
+    val preparedSignIn =
+      signIn.copy(
+        firstFactorVerification =
+          Verification(
+            strategy = "enterprise_sso",
+            externalVerificationRedirectUrl = "https://sso.example.com/start",
+          )
+      )
+    mockkObject(SignIn.Companion)
+    mockkStatic("com.clerk.api.signin.SignInKt")
+    mockkStatic("com.clerk.api.signin.SignInExtensionsKt")
+    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
+      ClerkResult.success(signIn)
+    coEvery {
+      signIn.prepareFirstFactor(any<SignIn.PrepareFirstFactorParams.EnterpriseSSO>())
+    } returns ClerkResult.success(preparedSignIn)
+    coEvery { preparedSignIn.authenticateWithPreparedRedirect(any()) } returns
+      ClerkResult.unknownFailure(cancellation)
+
+    viewModel.startAuth(
+      authMode = AuthMode.SignIn,
+      isPhoneNumberFieldActive = false,
+      phoneNumber = "",
+      identifier = "user@example.com",
+    )
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    coVerify(exactly = 1) { preparedSignIn.authenticateWithPreparedRedirect(false) }
     assertEquals(AuthStartViewModel.AuthState.Idle, viewModel.state.value)
   }
 


### PR DESCRIPTION
## Summary

- cancel pending OAuth/SSO authentication when the browser flow is dismissed
- require explicit Clerk transfer markers before moving between sign-in and sign-up
- expose `SSOCancellationException` so consumers can distinguish cancellation from authentication failure
- return the prebuilt OAuth and Enterprise SSO UI to idle without displaying a cancellation toast

## Root cause

The outbound provider URL remained in the manager activity intent and could be interpreted as an inbound callback after the Custom Tab closed. Because it had no rotating token nonce, the SDK treated it as a sign-up transfer. The activity failure path also canceled hosted auth only, leaving redirect SSO callers suspended in flows without a callback.

## Impact

Closing or cancelling browser OAuth/SSO returns a typed failure to API consumers and quietly restores the prebuilt sign-in UI. Legitimate sign-in/sign-up transfers continue when Clerk supplies the expected transfer marker.

## Testing

- `./gradlew :source:api:test :source:ui:test`
- `./gradlew spotlessCheck detekt`

Closes #863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OAuth and SSO callback handling for dismissed browsers, provider cancellations, and invalid callbacks.
  - Cancelled SSO flows now return clear cancellation errors without incorrectly starting sign-up.
  - Social OAuth and enterprise SSO cancellations now return the authentication screen to its idle state.
  - External account recovery continues to transfer correctly when explicitly indicated.
  - External account authorization now uses more reliable callback handling and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->