### PR TITLE
fix(ui): match React Native Android transitions

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -2,10 +2,6 @@
 
 package com.clerk.ui.auth
 
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -14,7 +10,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.compose.ui.unit.IntOffset
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
@@ -35,6 +30,8 @@ import com.clerk.ui.core.composition.LocalAuthState
 import com.clerk.ui.core.composition.LocalTelemetryCollector
 import com.clerk.ui.core.footer.DevelopmentModeWarningBackground
 import com.clerk.ui.core.footer.DevelopmentModeWarningBox
+import com.clerk.ui.navigation.clerkNavigationForwardTransition
+import com.clerk.ui.navigation.clerkNavigationPopTransition
 import com.clerk.ui.sessiontask.mfa.SessionTaskMfaView
 import com.clerk.ui.sessiontask.organization.SessionTaskChooseOrganizationView
 import com.clerk.ui.sessiontask.organization.SessionTaskCreateOrganizationView
@@ -210,20 +207,9 @@ private fun AuthNavDisplay(
   NavDisplay(
     modifier = modifier,
     backStack = backStack,
-    transitionSpec = {
-      val spec = tween<IntOffset>(durationMillis = 300)
-      slideInHorizontally(animationSpec = spec, initialOffsetX = { it }) togetherWith
-        slideOutHorizontally(animationSpec = spec, targetOffsetX = { -it })
-    },
-    popTransitionSpec = {
-      val spec = tween<IntOffset>(durationMillis = 300)
-      slideInHorizontally(animationSpec = spec, initialOffsetX = { -it }) togetherWith
-        slideOutHorizontally(animationSpec = spec, targetOffsetX = { it })
-    },
-    predictivePopTransitionSpec = { distance ->
-      slideInHorizontally(initialOffsetX = { -distance }) togetherWith
-        slideOutHorizontally(targetOffsetX = { distance })
-    },
+    transitionSpec = { clerkNavigationForwardTransition() },
+    popTransitionSpec = { clerkNavigationPopTransition() },
+    predictivePopTransitionSpec = { clerkNavigationPopTransition() },
     onBack = { authState.navigateBack() },
     entryProvider = authEntryProvider(backStack = backStack, options = options),
   )

--- a/source/ui/src/main/java/com/clerk/ui/navigation/ClerkNavigationTransition.kt
+++ b/source/ui/src/main/java/com/clerk/ui/navigation/ClerkNavigationTransition.kt
@@ -1,0 +1,89 @@
+package com.clerk.ui.navigation
+
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.PathEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.IntOffset
+
+internal const val CLERK_NAVIGATION_TRANSITION_DURATION_MILLIS = 450
+private const val CLERK_NAVIGATION_TRANSITION_DISTANCE_FRACTION = 0.1f
+private const val FOREGROUND_ALPHA_DURATION_MILLIS = 83
+private const val FORWARD_ALPHA_DELAY_MILLIS = 50
+private const val POP_ALPHA_DELAY_MILLIS = 35
+
+private val FastOutExtraSlowInEasing =
+  PathEasing(
+    Path().apply {
+      moveTo(x = 0f, y = 0f)
+      cubicTo(x1 = 0.05f, y1 = 0f, x2 = 0.133333f, y2 = 0.06f, x3 = 0.166666f, y3 = 0.4f)
+      cubicTo(x1 = 0.208333f, y1 = 0.82f, x2 = 0.25f, y2 = 1f, x3 = 1f, y3 = 1f)
+    }
+  )
+
+/** Matches React Navigation's default Android native-stack forward transition. */
+internal fun clerkNavigationForwardTransition(): ContentTransform {
+  val slideSpec = clerkNavigationSlideSpec<IntOffset>()
+  val enter =
+    slideInHorizontally(animationSpec = slideSpec, initialOffsetX = { it / 10 }) +
+      fadeIn(animationSpec = clerkNavigationForwardAlphaSpec(), initialAlpha = 0f)
+  val exit = slideOutHorizontally(animationSpec = slideSpec, targetOffsetX = { -(it / 10) })
+  return enter togetherWith exit
+}
+
+/** Matches React Navigation's default Android native-stack pop transition. */
+internal fun clerkNavigationPopTransition(): ContentTransform {
+  val slideSpec = clerkNavigationSlideSpec<IntOffset>()
+  val enter = slideInHorizontally(animationSpec = slideSpec, initialOffsetX = { -(it / 10) })
+  val exit =
+    slideOutHorizontally(animationSpec = slideSpec, targetOffsetX = { it / 10 }) +
+      fadeOut(animationSpec = clerkNavigationPopAlphaSpec(), targetAlpha = 0f)
+  return enter togetherWith exit
+}
+
+internal fun clerkNavigationSlideProgressSpec(): FiniteAnimationSpec<Float> =
+  clerkNavigationSlideSpec()
+
+internal fun clerkNavigationForwardAlphaSpec(): FiniteAnimationSpec<Float> =
+  tween(
+    durationMillis = FOREGROUND_ALPHA_DURATION_MILLIS,
+    delayMillis = FORWARD_ALPHA_DELAY_MILLIS,
+    easing = LinearEasing,
+  )
+
+internal fun clerkNavigationPopAlphaSpec(): FiniteAnimationSpec<Float> =
+  tween(
+    durationMillis = FOREGROUND_ALPHA_DURATION_MILLIS,
+    delayMillis = POP_ALPHA_DELAY_MILLIS,
+    easing = LinearEasing,
+  )
+
+private fun <T> clerkNavigationSlideSpec(): FiniteAnimationSpec<T> =
+  tween(
+    durationMillis = CLERK_NAVIGATION_TRANSITION_DURATION_MILLIS,
+    easing = FastOutExtraSlowInEasing,
+  )
+
+/** Applies the forward transition's incoming-screen transform at [progress]. */
+internal fun Modifier.clerkNavigationForwardEnterTransform(
+  progress: Float,
+  alpha: Float,
+): Modifier = graphicsLayer {
+  translationX = size.width * CLERK_NAVIGATION_TRANSITION_DISTANCE_FRACTION * (1f - progress)
+  this.alpha = alpha
+}
+
+/** Applies the forward transition's previous-screen transform at [progress]. */
+internal fun Modifier.clerkNavigationForwardExitTransform(progress: Float): Modifier =
+  graphicsLayer {
+    translationX = -size.width * CLERK_NAVIGATION_TRANSITION_DISTANCE_FRACTION * progress
+  }

--- a/source/ui/src/main/java/com/clerk/ui/organizationprofile/OrganizationProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/organizationprofile/OrganizationProfileView.kt
@@ -4,10 +4,6 @@ package com.clerk.ui.organizationprofile
 
 import android.annotation.SuppressLint
 import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -18,7 +14,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.IntOffset
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavBackStack
@@ -35,6 +30,8 @@ import com.clerk.ui.core.composition.LocalTelemetryCollector
 import com.clerk.ui.core.composition.TelemetryProvider
 import com.clerk.ui.core.footer.DevelopmentModeWarningBox
 import com.clerk.ui.core.navigation.rememberDismissHandler
+import com.clerk.ui.navigation.clerkNavigationForwardTransition
+import com.clerk.ui.navigation.clerkNavigationPopTransition
 import com.clerk.ui.organizationprofile.actions.OrganizationProfileActionConfirmationView
 import com.clerk.ui.organizationprofile.actions.OrganizationProfileConfirmationAction
 import com.clerk.ui.organizationprofile.custom.LocalOrganizationProfileCustomNavigator
@@ -150,20 +147,9 @@ private fun OrganizationProfileNavDisplay(
         onNavigateBack = { backStack.removeLastOrNull() },
       )
     },
-    transitionSpec = {
-      val spec = tween<IntOffset>(durationMillis = 300)
-      slideInHorizontally(animationSpec = spec, initialOffsetX = { it }) togetherWith
-        slideOutHorizontally(animationSpec = spec, targetOffsetX = { -it })
-    },
-    popTransitionSpec = {
-      val spec = tween<IntOffset>(durationMillis = 300)
-      slideInHorizontally(animationSpec = spec, initialOffsetX = { -it }) togetherWith
-        slideOutHorizontally(animationSpec = spec, targetOffsetX = { it })
-    },
-    predictivePopTransitionSpec = { distance ->
-      slideInHorizontally(initialOffsetX = { -distance }) togetherWith
-        slideOutHorizontally(targetOffsetX = { distance })
-    },
+    transitionSpec = { clerkNavigationForwardTransition() },
+    popTransitionSpec = { clerkNavigationPopTransition() },
+    predictivePopTransitionSpec = { clerkNavigationPopTransition() },
     entryProvider =
       entryProvider {
         organizationProfileEntries(

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
@@ -4,10 +4,6 @@ import android.annotation.SuppressLint
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -21,8 +17,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
@@ -41,6 +35,13 @@ import com.clerk.ui.core.footer.DevelopmentModeWarningBox
 import com.clerk.ui.core.navigation.pop
 import com.clerk.ui.core.navigation.rememberDismissHandler
 import com.clerk.ui.navigation.LocalClerkHostBackAction
+import com.clerk.ui.navigation.clerkNavigationForwardAlphaSpec
+import com.clerk.ui.navigation.clerkNavigationForwardEnterTransform
+import com.clerk.ui.navigation.clerkNavigationForwardExitTransform
+import com.clerk.ui.navigation.clerkNavigationForwardTransition
+import com.clerk.ui.navigation.clerkNavigationPopAlphaSpec
+import com.clerk.ui.navigation.clerkNavigationPopTransition
+import com.clerk.ui.navigation.clerkNavigationSlideProgressSpec
 import com.clerk.ui.theme.ClerkMaterialTheme
 import com.clerk.ui.theme.ClerkThemeOverrideProvider
 import com.clerk.ui.userprofile.account.UserProfileAccountSwitcherSheet
@@ -147,15 +148,26 @@ fun UserProfileView(
           val detailProgress by
             animateFloatAsState(
               targetValue = if (showDetail) 1f else 0f,
-              animationSpec = tween(durationMillis = 300),
-              label = "user profile detail slide",
+              animationSpec = clerkNavigationSlideProgressSpec(),
+              label = "user profile detail transition",
+            )
+          val detailAlpha by
+            animateFloatAsState(
+              targetValue = if (showDetail) 1f else 0f,
+              animationSpec =
+                if (showDetail) {
+                  clerkNavigationForwardAlphaSpec()
+                } else {
+                  clerkNavigationPopAlphaSpec()
+                },
+              label = "user profile detail alpha",
             )
           Box(modifier = Modifier.fillMaxSize().clipToBounds()) {
             NavDisplay(
               modifier =
-                Modifier.fillMaxSize().graphicsLayer {
-                  translationX = -size.width * detailProgress
-                },
+                Modifier.fillMaxSize()
+                  .zIndex(if (detailProgress == 0f) 1f else 0f)
+                  .clerkNavigationForwardExitTransform(detailProgress),
               backStack = backStack,
               onBack = {
                 handleUserProfileBack(
@@ -165,21 +177,9 @@ fun UserProfileView(
                   onNavigateBack = { backStack.removeLastOrNull() },
                 )
               },
-              transitionSpec = {
-                val spec = tween<IntOffset>(durationMillis = 300)
-                slideInHorizontally(animationSpec = spec, initialOffsetX = { it }) togetherWith
-                  slideOutHorizontally(animationSpec = spec, targetOffsetX = { -it })
-              },
-              popTransitionSpec = {
-                val spec = tween<IntOffset>(durationMillis = 300)
-                slideInHorizontally(animationSpec = spec, initialOffsetX = { -it }) togetherWith
-                  slideOutHorizontally(animationSpec = spec, targetOffsetX = { it })
-              },
-              predictivePopTransitionSpec = { distance ->
-                // Use the provided distance to align with the system back gesture
-                slideInHorizontally(initialOffsetX = { -distance }) togetherWith
-                  slideOutHorizontally(targetOffsetX = { distance })
-              },
+              transitionSpec = { clerkNavigationForwardTransition() },
+              popTransitionSpec = { clerkNavigationPopTransition() },
+              predictivePopTransitionSpec = { clerkNavigationPopTransition() },
               entryProvider =
                 entryProvider {
                   userProfileEntries(
@@ -196,9 +196,9 @@ fun UserProfileView(
             )
             Box(
               modifier =
-                Modifier.fillMaxSize().zIndex(1f).graphicsLayer {
-                  translationX = size.width * (1f - detailProgress)
-                }
+                Modifier.fillMaxSize()
+                  .zIndex(if (detailProgress == 0f) 0f else 1f)
+                  .clerkNavigationForwardEnterTransform(detailProgress, detailAlpha)
             ) {
               UserProfileDetailViewWithBackHandler(onBackPressed = { showDetail = false })
             }


### PR DESCRIPTION
## Summary

- replace the SDK's full-width 300 ms navigation animation with the modern React Native native-stack Android transition
- use a 450 ms horizontal push/pop with 10% parallax and the platform foreground fade timing
- share the transition across auth, user profile, and organization profile navigation
- preserve the mounted Manage Account detail screen while applying the same transition

## Why

Android navigation did not match the React Native SDK's Expo/native-stack behavior. The existing custom animation traveled the full screen width and used different timing, making navigation feel materially different between SDKs.

Linear: [MOBILE-623](https://linear.app/clerk/issue/MOBILE-623/android-should-match-expo-transition-behavior)


https://github.com/user-attachments/assets/b26b573b-03b5-4ced-ad91-7037305f7513



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated navigation animations across authentication, organization profile, and user profile screens.
  * Added smoother forward, back, and predictive back transitions with coordinated sliding and fading effects.
  * Standardized screen transitions for a more consistent navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->