### PR TITLE
fix: show network error while offline

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/configuration/connectivity/NetworkConnectivityMonitor.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/connectivity/NetworkConnectivityMonitor.kt
@@ -209,7 +209,8 @@ internal object NetworkConnectivityMonitor {
    *
    * @return true if connected, false otherwise.
    */
-  fun isCurrentlyConnected(): Boolean = _isConnected.value
+  fun isCurrentlyConnected(): Boolean =
+    if (isMonitoring) checkCurrentConnectivity() else _isConnected.value
 
   /**
    * Resets the monitor state for testing purposes.

--- a/source/api/src/main/kotlin/com/clerk/api/network/serialization/ClerkResult.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/serialization/ClerkResult.kt
@@ -2,8 +2,12 @@ package com.clerk.api.network.serialization
 
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.firstMessage
+import java.io.IOException
 import kotlin.reflect.KClass
 import toUnmodifiableMap
+
+private const val NETWORK_ERROR_MESSAGE =
+  "No internet connection detected. Please check your network connection and try again."
 
 /**
  * ClerkResult is a sealed interface used throughout the Clerk SDK to represent the result of an API
@@ -111,12 +115,17 @@ public sealed interface ClerkResult<out T : Any, out E : Any> {
 fun ClerkResult.Failure<ClerkErrorResponse>.shortErrorMessageOrNull() = this.error?.firstMessage()
 
 /**
- * Convenience function to extract the long error message from a [ClerkResult.Failure].
+ * Convenience function to extract a user-facing error message from a [ClerkResult.Failure].
  *
- * @return The error message, or null.
+ * API-provided messages take precedence. Transport failures use a connectivity-specific message,
+ * while all other failures fall back to a generic message.
  */
 val ClerkResult.Failure<ClerkErrorResponse>.errorMessage: String
   get() =
     this.error?.errors?.firstOrNull()?.longMessage
       ?: this.error?.firstMessage()
-      ?: "Error occurred with unknown message."
+      ?: if (this.throwable is IOException) {
+        NETWORK_ERROR_MESSAGE
+      } else {
+        "Error occurred with unknown message."
+      }

--- a/source/api/src/main/kotlin/com/clerk/api/network/serialization/ClerkResult.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/serialization/ClerkResult.kt
@@ -1,5 +1,6 @@
 package com.clerk.api.network.serialization
 
+import com.clerk.api.configuration.connectivity.NetworkConnectivityMonitor
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.firstMessage
 import java.io.IOException
@@ -117,14 +118,14 @@ fun ClerkResult.Failure<ClerkErrorResponse>.shortErrorMessageOrNull() = this.err
 /**
  * Convenience function to extract a user-facing error message from a [ClerkResult.Failure].
  *
- * API-provided messages take precedence. Transport failures use a connectivity-specific message,
- * while all other failures fall back to a generic message.
+ * API-provided messages take precedence. I/O failures that occur while the device is offline use a
+ * connectivity-specific message, while all other failures fall back to a generic message.
  */
 val ClerkResult.Failure<ClerkErrorResponse>.errorMessage: String
   get() =
     this.error?.errors?.firstOrNull()?.longMessage
       ?: this.error?.firstMessage()
-      ?: if (this.throwable is IOException) {
+      ?: if (this.throwable is IOException && !NetworkConnectivityMonitor.isCurrentlyConnected()) {
         NETWORK_ERROR_MESSAGE
       } else {
         "Error occurred with unknown message."

--- a/source/api/src/test/java/com/clerk/api/configuration/connectivity/NetworkConnectivityMonitorTest.kt
+++ b/source/api/src/test/java/com/clerk/api/configuration/connectivity/NetworkConnectivityMonitorTest.kt
@@ -124,6 +124,27 @@ class NetworkConnectivityMonitorTest {
   }
 
   @Test
+  fun `isCurrentlyConnected checks latest connectivity`() {
+    val mockContext = mockk<Context>(relaxed = true)
+    val mockAppContext = mockk<Context>(relaxed = true)
+
+    every { mockContext.applicationContext } returns mockAppContext
+    every { mockAppContext.getSystemService(Context.CONNECTIVITY_SERVICE) } returns
+      mockConnectivityManager
+    every { mockConnectivityManager.activeNetwork } returns mockNetwork
+    every { mockConnectivityManager.getNetworkCapabilities(mockNetwork) } returns
+      mockNetworkCapabilities
+    every { mockNetworkCapabilities.hasCapability(any()) } returns true
+
+    NetworkConnectivityMonitor.configure(mockContext)
+    assertTrue(NetworkConnectivityMonitor.isCurrentlyConnected())
+
+    every { mockConnectivityManager.activeNetwork } returns null
+
+    assertFalse(NetworkConnectivityMonitor.isCurrentlyConnected())
+  }
+
+  @Test
   fun `stop unregisters network callback and cleans up resources`() {
     // Given
     val mockContext = mockk<Context>(relaxed = true)

--- a/source/api/src/test/java/com/clerk/api/network/serialization/ClerkResultTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/serialization/ClerkResultTest.kt
@@ -1,14 +1,32 @@
 package com.clerk.api.network.serialization
 
+import com.clerk.api.configuration.connectivity.NetworkConnectivityMonitor
 import com.clerk.api.network.model.error.ClerkErrorResponse
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import java.io.IOException
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 
 class ClerkResultTest {
 
+  @Before
+  fun setup() {
+    mockkObject(NetworkConnectivityMonitor)
+    every { NetworkConnectivityMonitor.isCurrentlyConnected() } returns true
+  }
+
+  @After
+  fun tearDown() {
+    unmockkObject(NetworkConnectivityMonitor)
+  }
+
   @Test
-  fun `errorMessage describes network failures`() {
+  fun `errorMessage describes IO failures while offline`() {
+    every { NetworkConnectivityMonitor.isCurrentlyConnected() } returns false
     val result: ClerkResult.Failure<ClerkErrorResponse> =
       ClerkResult.unknownFailure(IOException("Unable to resolve host api.clerk.com"))
 
@@ -19,7 +37,16 @@ class ClerkResultTest {
   }
 
   @Test
-  fun `errorMessage keeps generic fallback for non-network failures`() {
+  fun `errorMessage keeps generic fallback for IO failures while connected`() {
+    val result: ClerkResult.Failure<ClerkErrorResponse> =
+      ClerkResult.unknownFailure(IOException("Connection reset"))
+
+    assertEquals("Error occurred with unknown message.", result.errorMessage)
+  }
+
+  @Test
+  fun `errorMessage keeps generic fallback for non-IO failures while offline`() {
+    every { NetworkConnectivityMonitor.isCurrentlyConnected() } returns false
     val result: ClerkResult.Failure<ClerkErrorResponse> =
       ClerkResult.unknownFailure(IllegalStateException("Unexpected failure"))
 

--- a/source/api/src/test/java/com/clerk/api/network/serialization/ClerkResultTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/serialization/ClerkResultTest.kt
@@ -1,0 +1,28 @@
+package com.clerk.api.network.serialization
+
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClerkResultTest {
+
+  @Test
+  fun `errorMessage describes network failures`() {
+    val result: ClerkResult.Failure<ClerkErrorResponse> =
+      ClerkResult.unknownFailure(IOException("Unable to resolve host api.clerk.com"))
+
+    assertEquals(
+      "No internet connection detected. Please check your network connection and try again.",
+      result.errorMessage,
+    )
+  }
+
+  @Test
+  fun `errorMessage keeps generic fallback for non-network failures`() {
+    val result: ClerkResult.Failure<ClerkErrorResponse> =
+      ClerkResult.unknownFailure(IllegalStateException("Unexpected failure"))
+
+    assertEquals("Error occurred with unknown message.", result.errorMessage)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -22,7 +22,6 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
-import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -113,36 +112,10 @@ class AuthViewModelTest {
   }
 
   @Test
-  fun startAuthWithSignInModeShouldSurfaceNetworkFailure() = runTest {
-    mockkObject(SignIn.Companion)
-    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
-      ClerkResult.unknownFailure(IOException("Unable to resolve host api.clerk.com"))
-
-    viewModel.state.test {
-      assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
-
-      viewModel.startAuth(
-        authMode = AuthMode.SignIn,
-        isPhoneNumberFieldActive = false,
-        phoneNumber = "",
-        identifier = "test@example.com",
-      )
-
-      assertEquals(AuthStartViewModel.AuthState.Loading, awaitItem())
-      assertEquals(
-        AuthStartViewModel.AuthState.Error(
-          "No internet connection detected. Please check your network connection and try again."
-        ),
-        awaitItem(),
-      )
-    }
-  }
-
-  @Test
   fun startAuthWithSignInModeShouldSurfaceUnknownFailure() = runTest {
     mockkObject(SignIn.Companion)
     coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
-      ClerkResult.unknownFailure(IllegalStateException("Unexpected failure"))
+      ClerkResult.unknownFailure(IllegalStateException("Network unavailable"))
 
     viewModel.state.test {
       assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthViewModelTest.kt
@@ -22,6 +22,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
+import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -112,10 +113,36 @@ class AuthViewModelTest {
   }
 
   @Test
+  fun startAuthWithSignInModeShouldSurfaceNetworkFailure() = runTest {
+    mockkObject(SignIn.Companion)
+    coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
+      ClerkResult.unknownFailure(IOException("Unable to resolve host api.clerk.com"))
+
+    viewModel.state.test {
+      assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())
+
+      viewModel.startAuth(
+        authMode = AuthMode.SignIn,
+        isPhoneNumberFieldActive = false,
+        phoneNumber = "",
+        identifier = "test@example.com",
+      )
+
+      assertEquals(AuthStartViewModel.AuthState.Loading, awaitItem())
+      assertEquals(
+        AuthStartViewModel.AuthState.Error(
+          "No internet connection detected. Please check your network connection and try again."
+        ),
+        awaitItem(),
+      )
+    }
+  }
+
+  @Test
   fun startAuthWithSignInModeShouldSurfaceUnknownFailure() = runTest {
     mockkObject(SignIn.Companion)
     coEvery { SignIn.create(any<SignIn.CreateParams.Strategy>()) } returns
-      ClerkResult.unknownFailure(IllegalStateException("Network unavailable"))
+      ClerkResult.unknownFailure(IllegalStateException("Unexpected failure"))
 
     viewModel.state.test {
       assertEquals(AuthStartViewModel.AuthState.Idle, awaitItem())


### PR DESCRIPTION
### What & why
<!-- The diff shows what changed. Reviewers want to know the why. Why do we need this change? Is there context we won't get from the diff alone? Were there notable alternative solutions considered? -->
- Offline authentication attempts currently display “Error occurred with unknown message.” because the shared error resolver ignores the preserved transport exception and device connectivity state.
- Show “No internet connection detected. Please check your network connection and try again.” only when the request failed with an `IOException` and Android reports no active, validated internet connection.
- Re-query `ConnectivityManager` when resolving the failure so the result does not rely solely on cached callback state.
- Preserve API-provided messages and the generic fallback for connected I/O failures and non-I/O failures.
- Add regression coverage for current connectivity checks and all error-resolution branches.
- Validated with the API unit suite, targeted UI tests, Spotless, Detekt, and `git diff --check`.
- Closes #877.

### What to focus on
<!-- Where should the reviewers look the hardest? Anything risky or we are unsure about? Want another opinion on a decision we made? Delete this section if the change is trivial. -->
- Whether requiring both `IOException` and a missing validated network is the right threshold for presenting the offline-specific message.
- The synchronous connectivity refresh in `NetworkConnectivityMonitor.isCurrentlyConnected()`.

### Screenshots / video

https://github.com/user-attachments/assets/ec89b053-8e47-44d2-b9c3-49dcd571f265

