### PR TITLE
feat(api): Allow disabling client refresh on foreground

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -1299,9 +1299,34 @@ data class ClerkConfigurationOptions(
   val customHeaders: Map<String, String>
     get() = _customHeaders
 
+  private var _autoRefreshOnForeground: Boolean = true
+
+  /**
+   * Whether the client and environment are refreshed from the server every time the app returns to
+   * the foreground. Defaults to `true`.
+   */
+  val autoRefreshOnForeground: Boolean
+    get() = _autoRefreshOnForeground
+
   /** Returns a copy of these options with additional outgoing request headers configured. */
   fun withCustomHeaders(customHeaders: Map<String, String>): ClerkConfigurationOptions =
-    copy().also { it._customHeaders = customHeaders.toMap() }
+    copyWithNonConstructorState().also { it._customHeaders = customHeaders.toMap() }
+
+  /**
+   * Returns a copy of these options that skips the client and environment refresh on app
+   * foreground. Intended for host SDKs (for example, the Expo SDK) that own client state and
+   * perform their own refreshes; the initial refresh during [Clerk.initialize] and periodic session
+   * token refresh are unaffected.
+   */
+  @FrameworkIntegrationApi
+  fun withForegroundRefreshDisabled(): ClerkConfigurationOptions =
+    copyWithNonConstructorState().also { it._autoRefreshOnForeground = false }
+
+  private fun copyWithNonConstructorState(): ClerkConfigurationOptions =
+    copy().also {
+      it._customHeaders = _customHeaders
+      it._autoRefreshOnForeground = _autoRefreshOnForeground
+    }
 }
 
 /**

--- a/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/configuration/ConfigurationManager.kt
@@ -288,8 +288,10 @@ internal class ConfigurationManager {
       if (hasConfigured) {
         scope.launch {
           Clerk.sharedSessionSyncCoordinator?.reloadFromSharedStorage()
-          deferForegroundRefreshDuringPendingAuth()
-          refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+          if (shouldRefreshOnForeground(attempt.options)) {
+            deferForegroundRefreshDuringPendingAuth()
+            refreshClientAndEnvironment(attempt, RefreshMode.INITIALIZATION)
+          }
           startTokenRefresh()
         }
       }
@@ -471,6 +473,9 @@ internal class ConfigurationManager {
       SSOService.hasPendingExternalAccountConnection() ||
       HostedAuthService.hasPendingAuthentication()
   }
+
+  internal fun shouldRefreshOnForeground(options: ClerkConfigurationOptions?): Boolean =
+    options?.autoRefreshOnForeground != false
 
   private suspend fun refreshClientAndEnvironment(
     attempt: RefreshAttempt,

--- a/source/api/src/test/java/com/clerk/api/configuration/ConfigurationManagerForegroundRefreshTest.kt
+++ b/source/api/src/test/java/com/clerk/api/configuration/ConfigurationManagerForegroundRefreshTest.kt
@@ -1,0 +1,39 @@
+package com.clerk.api.configuration
+
+import com.clerk.api.ClerkConfigurationOptions
+import com.clerk.api.FrameworkIntegrationApi
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+@OptIn(FrameworkIntegrationApi::class)
+class ConfigurationManagerForegroundRefreshTest {
+  @Test
+  fun `foreground refresh runs when no options are provided`() {
+    assertTrue(ConfigurationManager().shouldRefreshOnForeground(null))
+  }
+
+  @Test
+  fun `foreground refresh runs by default`() {
+    assertTrue(ConfigurationManager().shouldRefreshOnForeground(ClerkConfigurationOptions()))
+  }
+
+  @Test
+  fun `foreground refresh is skipped when disabled via withForegroundRefreshDisabled`() {
+    assertFalse(
+      ConfigurationManager()
+        .shouldRefreshOnForeground(ClerkConfigurationOptions().withForegroundRefreshDisabled())
+    )
+  }
+
+  @Test
+  fun `withCustomHeaders preserves a disabled foreground refresh`() {
+    val options =
+      ClerkConfigurationOptions()
+        .withForegroundRefreshDisabled()
+        .withCustomHeaders(mapOf("x-test" to "value"))
+
+    assertFalse(ConfigurationManager().shouldRefreshOnForeground(options))
+    assertTrue(options.customHeaders.containsKey("x-test"))
+  }
+}


### PR DESCRIPTION
### What & why

When clerk-android runs embedded in Expo, the JS layer owns client state. Returning from a browser-based OAuth flow (`useSSO`) foregrounds the app, and the lifecycle hook's `Client.get()` races the JS layer's nonce redemption with a stale rotating token. FAPI then mints a brand-new client, which the native sync layer can propagate to JS and break the just-created session with 401s. See [clerk/javascript#9217](https://github.com/clerk/javascript/issues/9217).

More info in this [Slack thread](https://clerkinc.slack.com/archives/C065VEK864A/p1786469063273069)

### What to focus on

New `ClerkConfigurationOptions.withForegroundRefreshDisabled()`, gated behind `@FrameworkIntegrationApi` since it only makes sense for Clerk's own wrapper SDKs. When applied, the foreground lifecycle hook skips the client/environment refresh. The initial refresh during initialize, shared-session reload, and periodic session token refresh all still run. Standalone apps are unchanged.

A follow-up PR in clerk/javascript will have the Expo module apply `withForegroundRefreshDisabled()`.

### Screenshots / video


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to disable automatic refresh when the app returns to the foreground.
  * Configuration copies now preserve foreground refresh preferences and custom headers.

* **Bug Fixes**
  * Foreground refresh now respects the configured setting while continuing to refresh client and environment data by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->