### PR TITLE
fix(ui): keep profile details visible without animations

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/UserProfileView.kt
@@ -194,13 +194,18 @@ fun UserProfileView(
                   )
                 },
             )
-            Box(
-              modifier =
-                Modifier.fillMaxSize()
-                  .zIndex(if (detailProgress == 0f) 0f else 1f)
-                  .clerkNavigationForwardEnterTransform(detailProgress, detailAlpha)
-            ) {
-              UserProfileDetailViewWithBackHandler(onBackPressed = { showDetail = false })
+            if (showDetail || detailProgress > 0f) {
+              Box(
+                modifier =
+                  Modifier.fillMaxSize()
+                    .zIndex(1f)
+                    .clerkNavigationForwardEnterTransform(
+                      detailProgress,
+                      if (showDetail) 1f else detailAlpha,
+                    )
+              ) {
+                UserProfileDetailViewWithBackHandler(onBackPressed = { showDetail = false })
+              }
             }
           }
           BackHandler(enabled = showDetail) { showDetail = false }


### PR DESCRIPTION
Keeps the user-profile detail overlay composed, topmost, and opaque from state while it is open. This prevents the detail screen from disappearing when Android system animations are disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the user profile detail overlay’s visibility during transitions.
  * Ensured the overlay remains layered correctly above account navigation.
  * Updated transition behavior for smoother detail view animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->