### PR TITLE
chore: Add forward compatible resource values

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
@@ -30,8 +30,12 @@ import com.clerk.api.sso.SSOService
 import com.clerk.api.trusteddevice.TrustedDevices
 import com.clerk.automap.annotations.AutoMap
 import com.clerk.automap.annotations.MapProperty
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 /**
  * The `SignIn` object holds the state of the current sign-in process and provides helper methods to
@@ -64,6 +68,7 @@ import kotlinx.serialization.Serializable
  *
  * @property id Unique identifier for this sign in.
  * @property status The status of the current sign-in.
+ * @property statusRawValue The status value exactly as returned by the Clerk API.
  * @property supportedIdentifiers Array of all the authentication identifiers that are supported for
  *   this sign in.
  * @property identifier The authentication identifier value for the current sign-in.
@@ -79,8 +84,10 @@ import kotlinx.serialization.Serializable
  * @property createdSessionId The identifier of the session that was created upon completion of the
  *   current sign-in.
  */
-@Serializable
-data class SignIn(
+@Serializable(with = SignInSerializer::class)
+@ConsistentCopyVisibility
+data class SignIn
+private constructor(
   /** Unique identifier for this sign in. */
   val id: String,
 
@@ -139,7 +146,61 @@ data class SignIn(
    * The value of this property is null if the sign-in status is not `complete`.
    */
   @SerialName("created_session_id") val createdSessionId: String? = null,
+
+  /** The status value exactly as returned by the Clerk API. */
+  val statusRawValue: String,
 ) {
+
+  constructor(
+    id: String,
+    status: Status = Status.UNKNOWN,
+    supportedIdentifiers: List<String>? = null,
+    identifier: String? = null,
+    supportedFirstFactors: List<Factor>? = null,
+    supportedSecondFactors: List<Factor>? = null,
+    firstFactorVerification: Verification? = null,
+    secondFactorVerification: Verification? = null,
+    userData: UserData? = null,
+    createdSessionId: String? = null,
+  ) : this(
+    id = id,
+    status = status,
+    supportedIdentifiers = supportedIdentifiers,
+    identifier = identifier,
+    supportedFirstFactors = supportedFirstFactors,
+    supportedSecondFactors = supportedSecondFactors,
+    firstFactorVerification = firstFactorVerification,
+    secondFactorVerification = secondFactorVerification,
+    userData = userData,
+    createdSessionId = createdSessionId,
+    statusRawValue = status.serializedValue,
+  )
+
+  fun copy(
+    id: String = this.id,
+    status: Status = this.status,
+    supportedIdentifiers: List<String>? = this.supportedIdentifiers,
+    identifier: String? = this.identifier,
+    supportedFirstFactors: List<Factor>? = this.supportedFirstFactors,
+    supportedSecondFactors: List<Factor>? = this.supportedSecondFactors,
+    firstFactorVerification: Verification? = this.firstFactorVerification,
+    secondFactorVerification: Verification? = this.secondFactorVerification,
+    userData: UserData? = this.userData,
+    createdSessionId: String? = this.createdSessionId,
+  ): SignIn =
+    SignIn(
+      id = id,
+      status = status,
+      supportedIdentifiers = supportedIdentifiers,
+      identifier = identifier,
+      supportedFirstFactors = supportedFirstFactors,
+      supportedSecondFactors = supportedSecondFactors,
+      firstFactorVerification = firstFactorVerification,
+      secondFactorVerification = secondFactorVerification,
+      userData = userData,
+      createdSessionId = createdSessionId,
+      statusRawValue = if (status == this.status) statusRawValue else status.serializedValue,
+    )
 
   /**
    * An object containing information about the user of the current sign-in. This property is
@@ -195,7 +256,32 @@ data class SignIn(
     @SerialName("needs_client_trust") NEEDS_CLIENT_TRUST,
 
     /** The sign-in process is in an unknown state. */
-    UNKNOWN,
+    UNKNOWN;
+
+    internal val serializedValue: String
+      get() =
+        when (this) {
+          COMPLETE -> "complete"
+          NEEDS_FIRST_FACTOR -> "needs_first_factor"
+          NEEDS_SECOND_FACTOR -> "needs_second_factor"
+          NEEDS_IDENTIFIER -> "needs_identifier"
+          NEEDS_NEW_PASSWORD -> "needs_new_password"
+          NEEDS_CLIENT_TRUST -> "needs_client_trust"
+          UNKNOWN -> "unknown"
+        }
+
+    internal companion object {
+      fun fromSerializedValue(value: String): Status =
+        when (value) {
+          "complete" -> COMPLETE
+          "needs_first_factor" -> NEEDS_FIRST_FACTOR
+          "needs_second_factor" -> NEEDS_SECOND_FACTOR
+          "needs_identifier" -> NEEDS_IDENTIFIER
+          "needs_new_password" -> NEEDS_NEW_PASSWORD
+          "needs_client_trust" -> NEEDS_CLIENT_TRUST
+          else -> UNKNOWN
+        }
+    }
   }
 
   /**
@@ -649,6 +735,21 @@ data class SignIn(
   }
 
   companion object {
+    internal fun fromPayload(payload: SignInPayload): SignIn =
+      SignIn(
+        id = payload.id,
+        status = Status.fromSerializedValue(payload.status),
+        supportedIdentifiers = payload.supportedIdentifiers,
+        identifier = payload.identifier,
+        supportedFirstFactors = payload.supportedFirstFactors,
+        supportedSecondFactors = payload.supportedSecondFactors,
+        firstFactorVerification = payload.firstFactorVerification,
+        secondFactorVerification = payload.secondFactorVerification,
+        userData = payload.userData,
+        createdSessionId = payload.createdSessionId,
+        statusRawValue = payload.status,
+      )
+
     /**
      * Starts the sign in process.
      *
@@ -775,6 +876,48 @@ data class SignIn(
         credentialTypes = credentialTypes
       )
     }
+  }
+}
+
+@Serializable
+internal data class SignInPayload(
+  val id: String,
+  val status: String = "unknown",
+  @SerialName("supported_identifiers") val supportedIdentifiers: List<String>? = null,
+  val identifier: String? = null,
+  @SerialName("supported_first_factors") val supportedFirstFactors: List<Factor>? = null,
+  @SerialName("supported_second_factors") val supportedSecondFactors: List<Factor>? = null,
+  @SerialName("first_factor_verification") val firstFactorVerification: Verification? = null,
+  @SerialName("second_factor_verification") val secondFactorVerification: Verification? = null,
+  @SerialName("user_data") val userData: SignIn.UserData? = null,
+  @SerialName("created_session_id") val createdSessionId: String? = null,
+)
+
+internal object SignInSerializer : KSerializer<SignIn> {
+  override val descriptor: SerialDescriptor =
+    SerialDescriptor("com.clerk.api.signin.SignIn", SignInPayload.serializer().descriptor)
+
+  override fun serialize(encoder: Encoder, value: SignIn) {
+    encoder.encodeSerializableValue(
+      SignInPayload.serializer(),
+      SignInPayload(
+        id = value.id,
+        status = value.statusRawValue,
+        supportedIdentifiers = value.supportedIdentifiers,
+        identifier = value.identifier,
+        supportedFirstFactors = value.supportedFirstFactors,
+        supportedSecondFactors = value.supportedSecondFactors,
+        firstFactorVerification = value.firstFactorVerification,
+        secondFactorVerification = value.secondFactorVerification,
+        userData = value.userData,
+        createdSessionId = value.createdSessionId,
+      ),
+    )
+  }
+
+  override fun deserialize(decoder: Decoder): SignIn {
+    val payload = decoder.decodeSerializableValue(SignInPayload.serializer())
+    return SignIn.fromPayload(payload)
   }
 }
 

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
@@ -236,51 +236,33 @@ private constructor(
    * Each status indicates the current state of the sign-in flow and what action is required next.
    */
   @Serializable
-  enum class Status {
+  enum class Status(internal val serializedValue: String) {
     /** The sign-in process is complete. */
-    @SerialName("complete") COMPLETE,
+    @SerialName("complete") COMPLETE("complete"),
 
     /** The sign-in process needs a first factor verification. */
-    @SerialName("needs_first_factor") NEEDS_FIRST_FACTOR,
+    @SerialName("needs_first_factor") NEEDS_FIRST_FACTOR("needs_first_factor"),
 
     /** The sign-in process needs a second factor verification. */
-    @SerialName("needs_second_factor") NEEDS_SECOND_FACTOR,
+    @SerialName("needs_second_factor") NEEDS_SECOND_FACTOR("needs_second_factor"),
 
     /** The sign-in process needs an identifier. */
-    @SerialName("needs_identifier") NEEDS_IDENTIFIER,
+    @SerialName("needs_identifier") NEEDS_IDENTIFIER("needs_identifier"),
 
     /** The user needs to create a new password. */
-    @SerialName("needs_new_password") NEEDS_NEW_PASSWORD,
+    @SerialName("needs_new_password") NEEDS_NEW_PASSWORD("needs_new_password"),
 
     /** Device trust verification is required. */
-    @SerialName("needs_client_trust") NEEDS_CLIENT_TRUST,
+    @SerialName("needs_client_trust") NEEDS_CLIENT_TRUST("needs_client_trust"),
 
     /** The sign-in process is in an unknown state. */
-    UNKNOWN;
-
-    internal val serializedValue: String
-      get() =
-        when (this) {
-          COMPLETE -> "complete"
-          NEEDS_FIRST_FACTOR -> "needs_first_factor"
-          NEEDS_SECOND_FACTOR -> "needs_second_factor"
-          NEEDS_IDENTIFIER -> "needs_identifier"
-          NEEDS_NEW_PASSWORD -> "needs_new_password"
-          NEEDS_CLIENT_TRUST -> "needs_client_trust"
-          UNKNOWN -> "unknown"
-        }
+    UNKNOWN("unknown");
 
     internal companion object {
-      fun fromSerializedValue(value: String): Status =
-        when (value) {
-          "complete" -> COMPLETE
-          "needs_first_factor" -> NEEDS_FIRST_FACTOR
-          "needs_second_factor" -> NEEDS_SECOND_FACTOR
-          "needs_identifier" -> NEEDS_IDENTIFIER
-          "needs_new_password" -> NEEDS_NEW_PASSWORD
-          "needs_client_trust" -> NEEDS_CLIENT_TRUST
-          else -> UNKNOWN
-        }
+      private val entriesBySerializedValue: Map<String, Status> =
+        entries.associateBy(Status::serializedValue)
+
+      fun fromSerializedValue(value: String): Status = entriesBySerializedValue[value] ?: UNKNOWN
     }
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/trusteddevice/TrustedDevice.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/trusteddevice/TrustedDevice.kt
@@ -123,51 +123,31 @@ private constructor(
 
   /** The platform a trusted-device credential belongs to. */
   @Serializable
-  enum class Platform {
-    @SerialName("ios") IOS,
-    @SerialName("android") ANDROID,
-    UNKNOWN;
-
-    internal val serializedValue: String
-      get() =
-        when (this) {
-          IOS -> "ios"
-          ANDROID -> "android"
-          UNKNOWN -> "unknown"
-        }
+  enum class Platform(internal val serializedValue: String) {
+    @SerialName("ios") IOS("ios"),
+    @SerialName("android") ANDROID("android"),
+    UNKNOWN("unknown");
 
     internal companion object {
-      fun fromSerializedValue(value: String): Platform =
-        when (value) {
-          "ios" -> IOS
-          "android" -> ANDROID
-          else -> UNKNOWN
-        }
+      private val entriesBySerializedValue: Map<String, Platform> =
+        entries.associateBy(Platform::serializedValue)
+
+      fun fromSerializedValue(value: String): Platform = entriesBySerializedValue[value] ?: UNKNOWN
     }
   }
 
   /** The server-side trusted-device credential status. */
   @Serializable
-  enum class Status {
-    @SerialName("active") ACTIVE,
-    @SerialName("revoked") REVOKED,
-    UNKNOWN;
-
-    internal val serializedValue: String
-      get() =
-        when (this) {
-          ACTIVE -> "active"
-          REVOKED -> "revoked"
-          UNKNOWN -> "unknown"
-        }
+  enum class Status(internal val serializedValue: String) {
+    @SerialName("active") ACTIVE("active"),
+    @SerialName("revoked") REVOKED("revoked"),
+    UNKNOWN("unknown");
 
     internal companion object {
-      fun fromSerializedValue(value: String): Status =
-        when (value) {
-          "active" -> ACTIVE
-          "revoked" -> REVOKED
-          else -> UNKNOWN
-        }
+      private val entriesBySerializedValue: Map<String, Status> =
+        entries.associateBy(Status::serializedValue)
+
+      fun fromSerializedValue(value: String): Status = entriesBySerializedValue[value] ?: UNKNOWN
     }
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/trusteddevice/TrustedDevice.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/trusteddevice/TrustedDevice.kt
@@ -1,7 +1,11 @@
 package com.clerk.api.trusteddevice
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 /**
  * A biometric-gated trusted-device credential associated with a user.
@@ -11,17 +15,21 @@ import kotlinx.serialization.Serializable
  *
  * @property id The unique identifier of the trusted-device credential.
  * @property platform The platform this credential belongs to.
+ * @property platformRawValue The platform value exactly as returned by the Clerk API.
  * @property appIdentifier The native app identifier this credential is bound to.
  * @property name The user-facing credential name.
  * @property algorithm The signature algorithm used by the credential.
  * @property status The credential status.
+ * @property statusRawValue The status value exactly as returned by the Clerk API.
  * @property createdAt The time when the credential was created, in milliseconds since epoch.
  * @property updatedAt The time when the credential was last updated, in milliseconds since epoch.
  * @property lastUsedAt The time when the credential was last used, in milliseconds since epoch.
  * @property revokedAt The time when the credential was revoked, in milliseconds since epoch.
  */
-@Serializable
-data class TrustedDevice(
+@Serializable(with = TrustedDeviceSerializer::class)
+@ConsistentCopyVisibility
+data class TrustedDevice
+private constructor(
   /** The unique identifier of the trusted-device credential. */
   val id: String,
 
@@ -51,14 +59,91 @@ data class TrustedDevice(
 
   /** The time when the credential was revoked, in milliseconds since epoch. */
   @SerialName("revoked_at") val revokedAt: Long? = null,
+
+  /** The platform value exactly as returned by the Clerk API. */
+  val platformRawValue: String,
+
+  /** The status value exactly as returned by the Clerk API. */
+  val statusRawValue: String,
 ) {
+
+  constructor(
+    id: String,
+    platform: Platform = Platform.UNKNOWN,
+    appIdentifier: String,
+    name: String? = null,
+    algorithm: String = ES256_ALGORITHM,
+    status: Status = Status.UNKNOWN,
+    createdAt: Long,
+    updatedAt: Long,
+    lastUsedAt: Long? = null,
+    revokedAt: Long? = null,
+  ) : this(
+    id = id,
+    platform = platform,
+    appIdentifier = appIdentifier,
+    name = name,
+    algorithm = algorithm,
+    status = status,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    lastUsedAt = lastUsedAt,
+    revokedAt = revokedAt,
+    platformRawValue = platform.serializedValue,
+    statusRawValue = status.serializedValue,
+  )
+
+  fun copy(
+    id: String = this.id,
+    platform: Platform = this.platform,
+    appIdentifier: String = this.appIdentifier,
+    name: String? = this.name,
+    algorithm: String = this.algorithm,
+    status: Status = this.status,
+    createdAt: Long = this.createdAt,
+    updatedAt: Long = this.updatedAt,
+    lastUsedAt: Long? = this.lastUsedAt,
+    revokedAt: Long? = this.revokedAt,
+  ): TrustedDevice =
+    TrustedDevice(
+      id = id,
+      platform = platform,
+      appIdentifier = appIdentifier,
+      name = name,
+      algorithm = algorithm,
+      status = status,
+      createdAt = createdAt,
+      updatedAt = updatedAt,
+      lastUsedAt = lastUsedAt,
+      revokedAt = revokedAt,
+      platformRawValue =
+        if (platform == this.platform) platformRawValue else platform.serializedValue,
+      statusRawValue = if (status == this.status) statusRawValue else status.serializedValue,
+    )
 
   /** The platform a trusted-device credential belongs to. */
   @Serializable
   enum class Platform {
     @SerialName("ios") IOS,
     @SerialName("android") ANDROID,
-    UNKNOWN,
+    UNKNOWN;
+
+    internal val serializedValue: String
+      get() =
+        when (this) {
+          IOS -> "ios"
+          ANDROID -> "android"
+          UNKNOWN -> "unknown"
+        }
+
+    internal companion object {
+      fun fromSerializedValue(value: String): Platform =
+        when (value) {
+          "ios" -> IOS
+          "android" -> ANDROID
+          else -> UNKNOWN
+        }
+    }
   }
 
   /** The server-side trusted-device credential status. */
@@ -66,11 +151,89 @@ data class TrustedDevice(
   enum class Status {
     @SerialName("active") ACTIVE,
     @SerialName("revoked") REVOKED,
-    UNKNOWN,
+    UNKNOWN;
+
+    internal val serializedValue: String
+      get() =
+        when (this) {
+          ACTIVE -> "active"
+          REVOKED -> "revoked"
+          UNKNOWN -> "unknown"
+        }
+
+    internal companion object {
+      fun fromSerializedValue(value: String): Status =
+        when (value) {
+          "active" -> ACTIVE
+          "revoked" -> REVOKED
+          else -> UNKNOWN
+        }
+    }
   }
 
   companion object {
     /** The signature algorithm used by trusted-device credentials on Android. */
     const val ES256_ALGORITHM: String = "ES256"
+
+    internal fun fromPayload(payload: TrustedDevicePayload): TrustedDevice =
+      TrustedDevice(
+        id = payload.id,
+        platform = Platform.fromSerializedValue(payload.platform),
+        appIdentifier = payload.appIdentifier,
+        name = payload.name,
+        algorithm = payload.algorithm,
+        status = Status.fromSerializedValue(payload.status),
+        createdAt = payload.createdAt,
+        updatedAt = payload.updatedAt,
+        lastUsedAt = payload.lastUsedAt,
+        revokedAt = payload.revokedAt,
+        platformRawValue = payload.platform,
+        statusRawValue = payload.status,
+      )
+  }
+}
+
+@Serializable
+internal data class TrustedDevicePayload(
+  val id: String,
+  val platform: String = "unknown",
+  @SerialName("app_identifier") val appIdentifier: String,
+  val name: String? = null,
+  val algorithm: String = TrustedDevice.ES256_ALGORITHM,
+  val status: String = "unknown",
+  @SerialName("created_at") val createdAt: Long,
+  @SerialName("updated_at") val updatedAt: Long,
+  @SerialName("last_used_at") val lastUsedAt: Long? = null,
+  @SerialName("revoked_at") val revokedAt: Long? = null,
+)
+
+internal object TrustedDeviceSerializer : KSerializer<TrustedDevice> {
+  override val descriptor: SerialDescriptor =
+    SerialDescriptor(
+      "com.clerk.api.trusteddevice.TrustedDevice",
+      TrustedDevicePayload.serializer().descriptor,
+    )
+
+  override fun serialize(encoder: Encoder, value: TrustedDevice) {
+    encoder.encodeSerializableValue(
+      TrustedDevicePayload.serializer(),
+      TrustedDevicePayload(
+        id = value.id,
+        platform = value.platformRawValue,
+        appIdentifier = value.appIdentifier,
+        name = value.name,
+        algorithm = value.algorithm,
+        status = value.statusRawValue,
+        createdAt = value.createdAt,
+        updatedAt = value.updatedAt,
+        lastUsedAt = value.lastUsedAt,
+        revokedAt = value.revokedAt,
+      ),
+    )
+  }
+
+  override fun deserialize(decoder: Decoder): TrustedDevice {
+    val payload = decoder.decodeSerializableValue(TrustedDevicePayload.serializer())
+    return TrustedDevice.fromPayload(payload)
   }
 }

--- a/source/api/src/test/java/com/clerk/api/signin/SignInSerializationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signin/SignInSerializationTest.kt
@@ -1,0 +1,93 @@
+package com.clerk.api.signin
+
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.client.Client
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class SignInSerializationTest {
+
+  @Test
+  fun `serializer preserves the public descriptor name`() {
+    assertEquals("com.clerk.api.signin.SignIn", SignIn.serializer().descriptor.serialName)
+  }
+
+  @Test
+  fun `sign in decodes known status values`() {
+    val signIn =
+      ClerkApi.json.decodeFromString<SignIn>("""{"id":"sia_123","status":"needs_client_trust"}""")
+
+    assertEquals(SignIn.Status.NEEDS_CLIENT_TRUST, signIn.status)
+    assertEquals("needs_client_trust", signIn.statusRawValue)
+  }
+
+  @Test
+  fun `sign in preserves unknown status values`() {
+    val json =
+      """
+      {
+        "id": "sia_123",
+        "status": "future_sign_in_status",
+        "supported_identifiers": ["email_address"],
+        "identifier": "user@example.com",
+        "created_session_id": null
+      }
+      """
+        .trimIndent()
+
+    val signIn = ClerkApi.json.decodeFromString<SignIn>(json)
+
+    assertEquals(SignIn.Status.UNKNOWN, signIn.status)
+    assertEquals("future_sign_in_status", signIn.statusRawValue)
+    assertEquals(listOf("email_address"), signIn.supportedIdentifiers)
+    assertEquals("user@example.com", signIn.identifier)
+
+    val copied = signIn.copy(identifier = "updated@example.com")
+    val encodedCopy = ClerkApi.json.encodeToString(SignIn.serializer(), copied)
+    val decodedCopy = ClerkApi.json.decodeFromString<SignIn>(encodedCopy)
+
+    assertEquals("updated@example.com", decodedCopy.identifier)
+    assertEquals("future_sign_in_status", decodedCopy.statusRawValue)
+
+    val otherStatus =
+      ClerkApi.json.decodeFromString<SignIn>(
+        json.replace("future_sign_in_status", "another_future_status")
+      )
+    assertNotEquals(signIn, otherStatus)
+  }
+
+  @Test
+  fun `client preserves an unknown nested sign in status`() {
+    val client =
+      ClerkApi.json.decodeFromString<Client>(
+        """
+        {
+          "id": "client_123",
+          "sign_in": {
+            "id": "sia_123",
+            "status": "future_sign_in_status"
+          },
+          "sessions": []
+        }
+        """
+          .trimIndent()
+      )
+
+    assertEquals(SignIn.Status.UNKNOWN, client.signIn?.status)
+    assertEquals("future_sign_in_status", client.signIn?.statusRawValue)
+  }
+
+  @Test
+  fun `copying with a different status uses its serialized value`() {
+    val signIn =
+      ClerkApi.json.decodeFromString<SignIn>(
+        """{"id":"sia_123","status":"future_sign_in_status"}"""
+      )
+
+    val completed = signIn.copy(status = SignIn.Status.COMPLETE)
+
+    assertEquals(SignIn.Status.COMPLETE, completed.status)
+    assertEquals("complete", completed.statusRawValue)
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/trusteddevice/TrustedDeviceSerializationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/trusteddevice/TrustedDeviceSerializationTest.kt
@@ -5,12 +5,21 @@ import com.clerk.api.network.model.environment.AuthConfig
 import com.clerk.api.network.model.verification.Verification
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class TrustedDeviceSerializationTest {
+
+  @Test
+  fun `serializer preserves the public descriptor name`() {
+    assertEquals(
+      "com.clerk.api.trusteddevice.TrustedDevice",
+      TrustedDevice.serializer().descriptor.serialName,
+    )
+  }
 
   @Test
   fun `trusted device decodes from snake_case json`() {
@@ -36,10 +45,12 @@ class TrustedDeviceSerializationTest {
 
     assertEquals("td_123", trustedDevice.id)
     assertEquals(TrustedDevice.Platform.ANDROID, trustedDevice.platform)
+    assertEquals("android", trustedDevice.platformRawValue)
     assertEquals("com.example.app", trustedDevice.appIdentifier)
     assertEquals("Pixel 9", trustedDevice.name)
     assertEquals("ES256", trustedDevice.algorithm)
     assertEquals(TrustedDevice.Status.ACTIVE, trustedDevice.status)
+    assertEquals("active", trustedDevice.statusRawValue)
     assertEquals(1720000000000, trustedDevice.createdAt)
     assertEquals(1720000001000, trustedDevice.updatedAt)
     assertEquals(1720000002000L, trustedDevice.lastUsedAt)
@@ -47,7 +58,7 @@ class TrustedDeviceSerializationTest {
   }
 
   @Test
-  fun `trusted device coerces unknown platform and status`() {
+  fun `trusted device preserves unknown platform and status values`() {
     val json =
       """
       {
@@ -66,6 +77,23 @@ class TrustedDeviceSerializationTest {
 
     assertEquals(TrustedDevice.Platform.UNKNOWN, trustedDevice.platform)
     assertEquals(TrustedDevice.Status.UNKNOWN, trustedDevice.status)
+    assertEquals("vision_pro", trustedDevice.platformRawValue)
+    assertEquals("paused", trustedDevice.statusRawValue)
+
+    val copied = trustedDevice.copy(name = "Updated device")
+    val encodedCopy = ClerkApi.json.encodeToString(TrustedDevice.serializer(), copied)
+    val decodedCopy = ClerkApi.json.decodeFromString<TrustedDevice>(encodedCopy)
+
+    assertEquals("Updated device", decodedCopy.name)
+    assertEquals("vision_pro", decodedCopy.platformRawValue)
+    assertEquals("paused", decodedCopy.statusRawValue)
+
+    val otherPlatform =
+      ClerkApi.json.decodeFromString<TrustedDevice>(json.replace("vision_pro", "visionos"))
+    val otherStatus =
+      ClerkApi.json.decodeFromString<TrustedDevice>(json.replace("paused", "suspended"))
+    assertNotEquals(trustedDevice, otherPlatform)
+    assertNotEquals(trustedDevice, otherStatus)
   }
 
   @Test


### PR DESCRIPTION
### What & why

- Preserve unknown trusted-device platform/status and sign-in status strings instead of permanently reducing them to `UNKNOWN`. This allows downstream consumers such as Expo to receive future Clerk API values while retaining Android’s existing typed enum API.
- Add raw-value properties and custom serializers that keep known enum behavior unchanged and preserve unknown values through decoding, encoding, equality, and `copy()`.
- Preserve existing constructor, `copy()`, and serializer descriptor identities for compatibility. Using enum cases with associated raw values was considered, but would require replacing the existing public enums and create a larger breaking API change.

### What to focus on

- The custom serializer and data-class compatibility approach in `SignIn` and `TrustedDevice`.
- Whether raw values remain synchronized with their typed enums during construction, deserialization, and `copy()`.
- Preservation of the original serializer descriptor names and existing public constructor/`copy()` behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Sign-in and trusted-device data now remain compatible with newer or unrecognized status and platform values returned by the API.
  - Unknown values are safely represented while preserving their original values during serialization, copying, and nested data handling.
  - Existing construction patterns remain supported, minimizing disruption for integrations.

- **Tests**
  - Added coverage for known and unknown values, serialization, copying, and nested sign-in data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->