### PR TITLE
fix(ui): handle SSO cancellation and support email

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -242,6 +242,15 @@ object Clerk {
     get() = environment?.displayConfig?.applicationName
 
   /**
+   * The support email address configured for this application in the Clerk Dashboard.
+   *
+   * Prebuilt UI components use this address when directing users to contact support. Returns `null`
+   * if the SDK is not initialized or no support email is configured.
+   */
+  val supportEmail: String?
+    get() = environment?.displayConfig?.supportEmail?.takeIf { it.isNotBlank() }
+
+  /**
    * The current version of the Clerk Android SDK.
    *
    * @return A string representing the semantic version of the SDK (e.g., "1.0.0").

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/DisplayConfig.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/DisplayConfig.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.Serializable
  * @property instanceEnvironmentType The type of environment (development, staging, production)
  * @property applicationName The display name of the application
  * @property preferredSignInStrategy The preferred sign-in strategy for the application
+ * @property supportEmail The support email configured for the application (optional)
  * @property showDevModeWarning Whether development mode warnings should be shown
  * @property branded Whether the application uses Clerk branding
  * @property logoImageUrl URL of the application's logo image
@@ -33,6 +34,9 @@ internal data class DisplayConfig(
   /** The preferred sign-in strategy for the application */
   @SerialName("preferred_sign_in_strategy")
   val preferredSignInStrategy: PreferredSignInStrategy = PreferredSignInStrategy.UNKNOWN,
+
+  /** The support email configured for the application */
+  @SerialName("support_email") val supportEmail: String? = null,
 
   /** Whether development mode warnings should be shown */
   @SerialName("show_devmode_warning") val showDevModeWarning: Boolean = false,

--- a/source/api/src/test/java/com/clerk/api/network/model/environment/DisplayConfigSerializationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/model/environment/DisplayConfigSerializationTest.kt
@@ -1,6 +1,7 @@
 package com.clerk.api.network.model.environment
 
 import com.clerk.api.network.ClerkApi
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -22,9 +23,23 @@ class DisplayConfigSerializationTest {
     assertFalse(displayConfig.showDevModeWarning)
   }
 
-  private fun displayConfigJson(showDevModeWarning: Boolean?): String {
+  @Test
+  fun `support email deserializes correctly`() {
+    val displayConfig =
+      ClerkApi.json.decodeFromString<DisplayConfig>(
+        displayConfigJson(showDevModeWarning = false, supportEmail = "help@example.com")
+      )
+
+    assertEquals("help@example.com", displayConfig.supportEmail)
+  }
+
+  private fun displayConfigJson(
+    showDevModeWarning: Boolean?,
+    supportEmail: String? = null,
+  ): String {
     val showDevModeWarningJson =
       showDevModeWarning?.let { """"show_devmode_warning":$it,""" }.orEmpty()
+    val supportEmailJson = supportEmail?.let { """"support_email":"$it",""" }.orEmpty()
 
     return """
       {
@@ -32,6 +47,7 @@ class DisplayConfigSerializationTest {
         "application_name":"Test App",
         "preferred_sign_in_strategy":"password",
         $showDevModeWarningJson
+        $supportEmailJson
         "branded":true,
         "logo_image_url":"https://example.com/logo.png",
         "home_url":"/",

--- a/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
+++ b/source/api/src/test/java/com/clerk/api/sdk/ClerkTest.kt
@@ -82,6 +82,7 @@ class ClerkTest {
     every { mockEnvironment.userSettings } returns mockUserSettings
     every { mockDisplayConfig.logoImageUrl } returns "https://example.com/logo.png"
     every { mockDisplayConfig.applicationName } returns "Test App"
+    every { mockDisplayConfig.supportEmail } returns null
     every { mockUserSettings.social } returns emptyMap()
     every { mockEnvironment.passkeyIsEnabled } returns false
     every { mockEnvironment.mfaIsEnabled } returns false
@@ -134,6 +135,7 @@ class ClerkTest {
         every { uninitializedEnvironment.userSettings } returns uninitializedUserSettings
         every { uninitializedDisplayConfig.logoImageUrl } returns ""
         every { uninitializedDisplayConfig.applicationName } returns ""
+        every { uninitializedDisplayConfig.supportEmail } returns null
         every { uninitializedUserSettings.social } returns emptyMap()
         every { uninitializedEnvironment.passkeyIsEnabled } returns false
         every { uninitializedEnvironment.mfaIsEnabled } returns false
@@ -193,6 +195,7 @@ class ClerkTest {
     every { uninitializedEnvironment.userSettings } returns uninitializedUserSettings
     every { uninitializedDisplayConfig.logoImageUrl } returns ""
     every { uninitializedDisplayConfig.applicationName } returns ""
+    every { uninitializedDisplayConfig.supportEmail } returns null
     every { uninitializedUserSettings.social } returns emptyMap()
     every { uninitializedEnvironment.passkeyIsEnabled } returns false
     every { uninitializedEnvironment.emailIsEnabled } returns false
@@ -527,6 +530,25 @@ class ClerkTest {
 
     // Then
     assertEquals(expectedAppName, applicationName)
+  }
+
+  @Test
+  fun `supportEmail returns configured address when environment is initialized`() = runTest {
+    val expectedSupportEmail = "help@example.com"
+    every { mockDisplayConfig.supportEmail } returns expectedSupportEmail
+    initializeClerkWithEnvironment()
+
+    val supportEmail = Clerk.supportEmail
+
+    assertEquals(expectedSupportEmail, supportEmail)
+  }
+
+  @Test
+  fun `supportEmail ignores blank configured address`() = runTest {
+    every { mockDisplayConfig.supportEmail } returns ""
+    initializeClerkWithEnvironment()
+
+    assertNull(Clerk.supportEmail)
   }
 
   @Test

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -19,7 +19,6 @@ import com.clerk.api.signin.startingFirstFactor
 import com.clerk.api.signup.SignUp
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.ResultType
-import com.clerk.api.sso.SSOCancellationException
 import com.clerk.api.trusteddevice.TrustedDeviceKeyManagerException
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CoroutineDispatcher
@@ -488,9 +487,6 @@ internal class AuthStartViewModel(private val ioDispatcher: CoroutineDispatcher 
 
 private fun SignIn.requiresEnterpriseSSO(): Boolean =
   startingFirstFactor?.strategy == "enterprise_sso"
-
-private val ClerkResult.Failure<*>.isSSOCancellation: Boolean
-  get() = throwable is SSOCancellationException
 
 internal val ClerkResult.Failure<*>.isTrustedDeviceCancellation: Boolean
   get() =

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthenticationViewState.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthenticationViewState.kt
@@ -1,9 +1,11 @@
 package com.clerk.ui.auth
 
 import com.clerk.api.Clerk
+import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
+import com.clerk.api.sso.SSOCancellationException
 import com.clerk.ui.signin.code.VerificationState
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -34,6 +36,9 @@ internal sealed interface AuthenticationViewState {
 
   data class Error(val message: String?) : AuthenticationViewState
 }
+
+internal val ClerkResult.Failure<*>.isSSOCancellation: Boolean
+  get() = throwable is SSOCancellationException
 
 /** States for the code verification text, since it's not 1:1 with the view model states. */
 internal sealed interface VerificationUiState {

--- a/source/ui/src/main/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModel.kt
@@ -9,6 +9,7 @@ import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.ResultType
 import com.clerk.ui.auth.AuthenticationViewState
+import com.clerk.ui.auth.isSSOCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -33,7 +34,14 @@ internal class AlternativeMethodsViewModel : ViewModel() {
               ResultType.UNKNOWN -> AuthenticationViewState.Error("Unknown result type")
             }
         }
-        .onFailure { _state.value = AuthenticationViewState.Error(it.errorMessage) }
+        .onFailure {
+          _state.value =
+            if (it.isSSOCancellation) {
+              AuthenticationViewState.NotStarted
+            } else {
+              AuthenticationViewState.Error(it.errorMessage)
+            }
+        }
     }
   }
 

--- a/source/ui/src/main/java/com/clerk/ui/signin/help/SignInGetHelpView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/help/SignInGetHelpView.kt
@@ -2,6 +2,7 @@ package com.clerk.ui.signin.help
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
@@ -12,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.core.net.toUri
+import com.clerk.api.Clerk
 import com.clerk.api.log.ClerkLog
 import com.clerk.ui.R
 import com.clerk.ui.auth.PreviewAuthStateProvider
@@ -35,20 +36,18 @@ fun SignInGetHelpView(modifier: Modifier = Modifier) {
     onBackPressed = { authState.navigateBack() },
   ) {
     val context = LocalContext.current
-    val supportEmail = stringResource(R.string.support_clerk_com)
+    val defaultSupportEmail = stringResource(R.string.support_clerk_com)
+    val supportEmail = Clerk.supportEmail ?: defaultSupportEmail
     val noEmailClientsMessage = stringResource(R.string.no_email_clients_installed_on_device)
-    val emailIntent =
-      Intent(Intent.ACTION_SENDTO).apply {
-        data = "mailto:".toUri()
-        putExtra(Intent.EXTRA_EMAIL, arrayOf(supportEmail))
-      }
+    val emailSupportTitle = stringResource(R.string.email_support)
+    val emailIntent = remember(supportEmail) { supportEmailIntent(supportEmail) }
 
     ClerkButton(
       modifier = Modifier.fillMaxWidth(),
       text = stringResource(R.string.email_support),
       onClick = {
         try {
-          context.startActivity(Intent.createChooser(emailIntent, "Contact Clerk Support"))
+          context.startActivity(Intent.createChooser(emailIntent, emailSupportTitle))
         } catch (_: ActivityNotFoundException) {
           ClerkLog.e("No email clients installed on device.")
           scope.launch {
@@ -62,6 +61,9 @@ fun SignInGetHelpView(modifier: Modifier = Modifier) {
     )
   }
 }
+
+internal fun supportEmailIntent(supportEmail: String): Intent =
+  Intent(Intent.ACTION_SENDTO, Uri.fromParts("mailto", supportEmail, null))
 
 @PreviewLightDark
 @Composable

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModel.kt
@@ -11,20 +11,24 @@ import com.clerk.api.resetPasswordFactor
 import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.ResultType
+import com.clerk.ui.auth.isSSOCancellation
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-internal class ForgotPasswordViewModel : ViewModel() {
+internal class ForgotPasswordViewModel(
+  private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : ViewModel() {
 
   private val _state = MutableStateFlow<ResetPasswordViewState>(ResetPasswordViewState.Idle)
   val state = _state.asStateFlow()
 
   fun signInWithProvider(provider: OAuthProvider, transferable: Boolean = true) {
     _state.value = ResetPasswordViewState.Loading
-    viewModelScope.launch(Dispatchers.IO) {
+    viewModelScope.launch(ioDispatcher) {
       SignIn.authenticateWithRedirect(
           SignIn.AuthenticateWithRedirectParams.OAuth(provider),
           transferable = transferable,
@@ -40,7 +44,12 @@ internal class ForgotPasswordViewModel : ViewModel() {
         }
         .onFailure {
           withContext(Dispatchers.Main) {
-            _state.value = ResetPasswordViewState.Error(it.errorMessage)
+            _state.value =
+              if (it.isSSOCancellation) {
+                ResetPasswordViewState.NotStarted
+              } else {
+                ResetPasswordViewState.Error(it.errorMessage)
+              }
           }
         }
     }

--- a/source/ui/src/test/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModelTest.kt
@@ -1,0 +1,52 @@
+package com.clerk.ui.signin.alternativemethods
+
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.api.sso.OAuthProvider
+import com.clerk.ui.auth.AuthenticationViewState
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AlternativeMethodsViewModelTest {
+
+  @get:Rule val dispatcherRule = MainDispatcherRule()
+
+  @Before
+  fun setUp() {
+    mockkObject(SignIn.Companion)
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `OAuth cancellation returns to auth start`() = runTest {
+    coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
+      ClerkResult.unknownFailure(ssoCancellation())
+    val viewModel = AlternativeMethodsViewModel()
+
+    viewModel.signInWithProvider(OAuthProvider.GITHUB)
+    advanceUntilIdle()
+
+    assertEquals(AuthenticationViewState.NotStarted, viewModel.state.value)
+  }
+
+  private fun ssoCancellation(): Throwable =
+    Class.forName("com.clerk.api.sso.SSOCancellationException")
+      .getDeclaredConstructor(String::class.java)
+      .apply { isAccessible = true }
+      .newInstance("Authentication cancelled") as Throwable
+}

--- a/source/ui/src/test/java/com/clerk/ui/signin/help/SignInGetHelpViewTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/help/SignInGetHelpViewTest.kt
@@ -1,0 +1,17 @@
+package com.clerk.ui.signin.help
+
+import android.content.Intent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SignInGetHelpViewTest {
+
+  @Test
+  fun `support email intent addresses configured recipient`() {
+    val intent = supportEmailIntent("help@example.com")
+
+    assertEquals(Intent.ACTION_SENDTO, intent.action)
+    assertEquals("mailto", intent.data?.scheme)
+    assertEquals("help@example.com", intent.data?.schemeSpecificPart)
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModelTest.kt
@@ -1,0 +1,54 @@
+package com.clerk.ui.signin.password.forgot
+
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.api.sso.OAuthProvider
+import com.clerk.ui.userprofile.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ForgotPasswordViewModelTest {
+
+  private val testDispatcher = StandardTestDispatcher()
+  @get:Rule val dispatcherRule = MainDispatcherRule(testDispatcher)
+
+  @Before
+  fun setUp() {
+    mockkObject(SignIn.Companion)
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `OAuth cancellation returns to auth start`() =
+    runTest(testDispatcher) {
+      coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
+        ClerkResult.unknownFailure(ssoCancellation())
+      val viewModel = ForgotPasswordViewModel(ioDispatcher = testDispatcher)
+
+      viewModel.signInWithProvider(OAuthProvider.GITHUB)
+      advanceUntilIdle()
+
+      assertEquals(ResetPasswordViewState.NotStarted, viewModel.state.value)
+    }
+
+  private fun ssoCancellation(): Throwable =
+    Class.forName("com.clerk.api.sso.SSOCancellationException")
+      .getDeclaredConstructor(String::class.java)
+      .apply { isAccessible = true }
+      .newInstance("Authentication cancelled") as Throwable
+}


### PR DESCRIPTION
Fixes #893.

Returns nested OAuth cancellations to the auth start screen and uses the instance-configured support email in the Get help screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and accessing a support email address.
  * Sign-in help now uses the configured support email, with a localized fallback and chooser label.

* **Bug Fixes**
  * OAuth and SSO cancellations now return authentication flows to their initial state instead of showing an error.
  * Improved forgot-password cancellation handling.

* **Tests**
  * Added coverage for support email configuration, email intents, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->