### PR TITLE
docs(api): point createExternalAccount KDoc at the current social connections docs

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/user/User.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/user/User.kt
@@ -750,8 +750,8 @@ suspend fun User.createPasskey(): ClerkResult<Passkey, ClerkErrorResponse> {
  * with that provider in the future.
  *
  * **Note:** The social provider that you want to connect to must be enabled in your app's settings
- * in the Clerk Dashboard. See: (Social
- * connections)[https://clerk.com/docs/guides/configure/auth-strategies/sign-up-sign-in-options#social-connections-oauth]
+ * in the Clerk Dashboard. See the social connections documentation:
+ * <https://clerk.com/docs/guides/configure/auth-strategies/sign-up-sign-in-options#social-connections-oauth>
  *
  * After calling `createExternalAccount`, the initial state of the returned [ExternalAccount] will
  * be unverified. To initiate the connection with the external provider, redirect the user to the

--- a/source/api/src/main/kotlin/com/clerk/api/user/User.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/user/User.kt
@@ -751,7 +751,7 @@ suspend fun User.createPasskey(): ClerkResult<Passkey, ClerkErrorResponse> {
  *
  * **Note:** The social provider that you want to connect to must be enabled in your app's settings
  * in the Clerk Dashboard. See: (Social
- * connections)[https://clerk.com/docs/authentication/configuration/sign-up-sign-in-options#social-connections-o-auth]
+ * connections)[https://clerk.com/docs/guides/configure/auth-strategies/sign-up-sign-in-options#social-connections-oauth]
  *
  * After calling `createExternalAccount`, the initial state of the returned [ExternalAccount] will
  * be unverified. To initiate the connection with the external provider, redirect the user to the


### PR DESCRIPTION
## Summary

clerk.com stopped decamelizing heading anchors ([clerk/clerk#3161](https://github.com/clerk/clerk/pull/3161), [DOCS-11886](https://linear.app/clerk/issue/DOCS-11886)), and the page this KDoc links to moved during the docs restructure. The old URL still redirects, but the `#social-connections-o-auth` fragment no longer lands on a section. The link now points at the current canonical page and anchor: `/docs/guides/configure/auth-strategies/sign-up-sign-in-options#social-connections-oauth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `createExternalAccount` documentation link to the current social connections page.
  * Revised the link formatting for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->