### PR TITLE
feat(passkeys): support passkeys as a second factor

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Constants.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Constants.kt
@@ -26,7 +26,7 @@ object Constants {
   object Http {
     const val NO_CONTENT = 204
     const val RESET_CONTENT = 205
-    const val CURRENT_API_VERSION = "2026-05-12"
+    const val CURRENT_API_VERSION = "2026-08-20"
     const val CURRENT_SDK_VERSION = BuildConfig.SDK_VERSION
     const val IS_MOBILE_HEADER_VALUE = "1"
     const val AUTHORIZATION_HEADER = "Authorization"

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/factor/FactorComparators.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/factor/FactorComparators.kt
@@ -29,7 +29,12 @@ internal object FactorComparators {
     )
 
   val strategySortOrderBackupCodePref =
-    listOf(Constants.Strategy.TOTP, Constants.Strategy.PHONE_CODE, Constants.Strategy.BACKUP_CODE)
+    listOf(
+      Constants.Strategy.PASSKEY,
+      Constants.Strategy.TOTP,
+      Constants.Strategy.PHONE_CODE,
+      Constants.Strategy.BACKUP_CODE,
+    )
 
   val passwordPrefComparator: Comparator<Factor> = Comparator { lhs, rhs ->
     val order1 = strategySortOrderPasswordPref.indexOf(lhs.strategy)

--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/GoogleCredentialAuthenticationService.kt
@@ -23,9 +23,13 @@ import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
 import com.clerk.api.session.SessionVerification
 import com.clerk.api.session.attemptFirstFactorVerification
+import com.clerk.api.session.attemptSecondFactorVerification
 import com.clerk.api.session.prepareFirstFactorVerification
+import com.clerk.api.session.prepareSecondFactorVerification
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signin.attemptFirstFactor
+import com.clerk.api.signin.attemptSecondFactor
+import com.clerk.api.signin.prepareSecondFactor
 import com.clerk.api.sso.GoogleCredentialManagerImpl
 import com.clerk.api.sso.GoogleSignInService
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
@@ -185,6 +189,90 @@ internal object GoogleCredentialAuthenticationService {
     }
   }
 
+  /**
+   * Authenticates an existing sign-in with a passkey when passkey is offered as a second factor.
+   */
+  suspend fun authenticateWithPasskey(
+    signIn: SignIn,
+    allowedCredentialIds: List<String> = emptyList(),
+  ): ClerkResult<SignIn, ClerkErrorResponse> {
+    val isSecondFactorStatus =
+      signIn.status == SignIn.Status.NEEDS_SECOND_FACTOR ||
+        signIn.status == SignIn.Status.NEEDS_CLIENT_TRUST
+    val hasPasskeySecondFactor =
+      signIn.supportedSecondFactors?.any { it.strategy == PasskeyHelper.passkeyStrategy } == true
+
+    return when {
+      !isSecondFactorStatus || !hasPasskeySecondFactor ->
+        signInWithGoogleCredential(
+          credentialTypes = listOf(SignIn.CredentialType.PASSKEY),
+          allowedCredentialIds = allowedCredentialIds,
+        )
+      Clerk.credentialActivity() == null ->
+        ClerkResult.unknownFailure(CredentialFlowException.MissingActivity()).also {
+          ClerkLog.e("Passkey second-factor sign-in requires an active Activity")
+        }
+      else -> {
+        val activity = requireNotNull(Clerk.credentialActivity())
+        val prepareResult =
+          signIn.prepareSecondFactor(strategy = SignIn.PrepareSecondFactorStrategy.Passkey)
+        when (prepareResult) {
+          is ClerkResult.Failure -> {
+            ClerkLog.e("Failed to prepare passkey second-factor sign-in: ${prepareResult.error}")
+            prepareResult
+          }
+          is ClerkResult.Success -> {
+            val nonce = prepareResult.value.secondFactorVerification?.nonce
+            if (nonce == null) {
+              missingPreparedVerificationNonceFailure("secondFactorVerification")
+            } else {
+              attemptSignInPasskeySecondFactor(
+                activity = activity,
+                signIn = prepareResult.value,
+                allowedCredentialIds = allowedCredentialIds,
+                nonce = nonce,
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private suspend fun attemptSignInPasskeySecondFactor(
+    activity: android.app.Activity,
+    signIn: SignIn,
+    allowedCredentialIds: List<String>,
+    nonce: String,
+  ): ClerkResult<SignIn, ClerkErrorResponse> {
+    return try {
+      val credential =
+        getCredentialFromManager(
+          activity = activity,
+          nonce = nonce,
+          allowedCredentialIds = allowedCredentialIds,
+          credentialRequestTypes = listOf(SignIn.CredentialType.PASSKEY),
+        )
+
+      if (credential is PublicKeyCredential) {
+        signIn.attemptSecondFactor(
+          SignIn.AttemptSecondFactorParams.Passkey(credential.authenticationResponseJson)
+        )
+      } else {
+        ClerkResult.unknownFailure(IllegalStateException("Unsupported credential type"))
+      }
+    } catch (e: GetCredentialException) {
+      ClerkLog.e("Passkey second-factor sign-in failed: ${e.message}")
+      classifyGetCredentialFailure(e, listOf(SignIn.CredentialType.PASSKEY))
+    } catch (e: CredentialFlowException) {
+      ClerkLog.e("Passkey second-factor sign-in cannot start: ${e.message}")
+      ClerkResult.unknownFailure(e)
+    } catch (e: Exception) {
+      ClerkLog.e("Passkey second-factor sign-in failed: ${e.message}")
+      ClerkResult.unknownFailure(e)
+    }
+  }
+
   private fun clearSuppressedAutomaticSignInAttempt(
     preferImmediatelyAvailableCredentials: Boolean,
     signIn: SignIn,
@@ -210,6 +298,7 @@ internal object GoogleCredentialAuthenticationService {
   suspend fun verifySessionWithPasskey(
     session: Session,
     allowedCredentialIds: List<String> = emptyList(),
+    level: SessionVerification.Level = SessionVerification.Level.FIRST_FACTOR,
   ): ClerkResult<SessionVerification, ClerkErrorResponse> {
     ClerkLog.d("Starting passkey session reverification")
     val activity =
@@ -218,33 +307,61 @@ internal object GoogleCredentialAuthenticationService {
           ClerkLog.e("Passkey session reverification requires an active Activity")
         }
 
-    return verifySessionWithPasskey(activity, session, allowedCredentialIds)
+    return verifySessionWithPasskey(activity, session, allowedCredentialIds, level)
   }
 
   private suspend fun verifySessionWithPasskey(
     activity: android.app.Activity,
     session: Session,
     allowedCredentialIds: List<String>,
+    level: SessionVerification.Level,
   ): ClerkResult<SessionVerification, ClerkErrorResponse> {
-    val prepareResult = session.prepareFirstFactorVerification(PasskeyHelper.passkeyStrategy)
+    if (
+      level != SessionVerification.Level.FIRST_FACTOR &&
+        level != SessionVerification.Level.SECOND_FACTOR
+    ) {
+      return ClerkResult.unknownFailure(
+        IllegalArgumentException("Passkey verification level must be first_factor or second_factor")
+      )
+    }
+
+    val prepareResult =
+      if (level == SessionVerification.Level.SECOND_FACTOR) {
+        session.prepareSecondFactorVerification(PasskeyHelper.passkeyStrategy)
+      } else {
+        session.prepareFirstFactorVerification(PasskeyHelper.passkeyStrategy)
+      }
     return when (prepareResult) {
       is ClerkResult.Failure -> {
         ClerkLog.e("Failed to prepare passkey session reverification: ${prepareResult.error}")
         prepareResult
       }
       is ClerkResult.Success -> {
-        val nonce = prepareResult.value.firstFactorVerification?.nonce
+        val nonce =
+          if (level == SessionVerification.Level.SECOND_FACTOR) {
+            prepareResult.value.secondFactorVerification?.nonce
+          } else {
+            prepareResult.value.firstFactorVerification?.nonce
+          }
         if (nonce == null) {
-          missingPreparedVerificationNonceFailure()
+          missingPreparedVerificationNonceFailure(
+            if (level == SessionVerification.Level.SECOND_FACTOR) {
+              "secondFactorVerification"
+            } else {
+              "firstFactorVerification"
+            }
+          )
         } else {
-          attemptSessionPasskeyVerification(activity, session, allowedCredentialIds, nonce)
+          attemptSessionPasskeyVerification(activity, session, allowedCredentialIds, nonce, level)
         }
       }
     }
   }
 
-  private fun missingPreparedVerificationNonceFailure(): ClerkResult.Failure<Nothing> {
-    ClerkLog.e("Missing nonce in preparedVerification.firstFactorVerification")
+  private fun missingPreparedVerificationNonceFailure(
+    verificationField: String
+  ): ClerkResult.Failure<Nothing> {
+    ClerkLog.e("Missing nonce in prepared verification $verificationField")
     return ClerkResult.unknownFailure(
       IllegalStateException("Missing nonce in prepared verification")
     )
@@ -255,6 +372,7 @@ internal object GoogleCredentialAuthenticationService {
     session: Session,
     allowedCredentialIds: List<String>,
     nonce: String,
+    level: SessionVerification.Level,
   ): ClerkResult<SessionVerification, ClerkErrorResponse> {
     return try {
       val credential =
@@ -268,9 +386,16 @@ internal object GoogleCredentialAuthenticationService {
       if (credential is PublicKeyCredential) {
         ClerkLog.d("Attempting passkey session reverification")
         val result =
-          session.attemptFirstFactorVerification(
-            Session.AttemptFirstFactorParams.Passkey(credential.authenticationResponseJson)
-          )
+          if (level == SessionVerification.Level.SECOND_FACTOR) {
+            session.attemptSecondFactorVerification(
+              strategy = PasskeyHelper.passkeyStrategy,
+              publicKeyCredential = credential.authenticationResponseJson,
+            )
+          } else {
+            session.attemptFirstFactorVerification(
+              Session.AttemptFirstFactorParams.Passkey(credential.authenticationResponseJson)
+            )
+          }
 
         if (result is ClerkResult.Failure) {
           ClerkLog.e("Passkey session reverification failed: ${result.error}")

--- a/source/api/src/main/kotlin/com/clerk/api/passkeys/PasskeyService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/passkeys/PasskeyService.kt
@@ -32,6 +32,17 @@ internal object PasskeyService {
     )
   }
 
+  /** Authenticates an existing sign-in with a passkey when it is offered as a second factor. */
+  suspend fun authenticateWithPasskey(
+    signIn: SignIn,
+    allowedCredentialIds: List<String> = emptyList(),
+  ): ClerkResult<SignIn, ClerkErrorResponse> {
+    return GoogleCredentialAuthenticationService.authenticateWithPasskey(
+      signIn = signIn,
+      allowedCredentialIds = allowedCredentialIds,
+    )
+  }
+
   /**
    * Completes an in-session reverification flow using passkeys.
    *
@@ -42,10 +53,12 @@ internal object PasskeyService {
   suspend fun verifySessionWithPasskey(
     session: Session,
     allowedCredentialIds: List<String> = emptyList(),
+    level: SessionVerification.Level = SessionVerification.Level.FIRST_FACTOR,
   ): ClerkResult<SessionVerification, ClerkErrorResponse> {
     return GoogleCredentialAuthenticationService.verifySessionWithPasskey(
       session = session,
       allowedCredentialIds = allowedCredentialIds,
+      level = level,
     )
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/Session.kt
@@ -120,9 +120,20 @@ data class Session(
   )
 
   /** Parameters for attempting a second factor in an in-session reverification flow. */
-  @Serializable
-  @AutoMap
-  internal data class AttemptSecondFactorParams(val strategy: String, val code: String)
+  internal sealed interface AttemptSecondFactorParams {
+    val strategy: String
+
+    @Serializable
+    @AutoMap
+    data class Code(override val strategy: String, val code: String) : AttemptSecondFactorParams
+
+    @Serializable
+    @AutoMap
+    data class Passkey(
+      @SerialName("public_key_credential") val publicKeyCredential: String,
+      override val strategy: String = PASSKEY,
+    ) : AttemptSecondFactorParams
+  }
 }
 
 @Serializable data class SessionTask(val key: String)

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationConvenienceExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationConvenienceExtensions.kt
@@ -91,7 +91,8 @@ suspend fun Session.verifyWithBackupCode(
 
 /** Verifies the current session with a passkey via Android Credential Manager. */
 suspend fun Session.verifyWithPasskey(
-  allowedCredentialIds: List<String> = emptyList()
+  allowedCredentialIds: List<String> = emptyList(),
+  level: SessionVerification.Level = SessionVerification.Level.FIRST_FACTOR,
 ): ClerkResult<SessionVerification, ClerkErrorResponse> {
-  return PasskeyService.verifySessionWithPasskey(this, allowedCredentialIds)
+  return PasskeyService.verifySessionWithPasskey(this, allowedCredentialIds, level)
 }

--- a/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/session/SessionVerificationExtensions.kt
@@ -81,10 +81,16 @@ internal suspend fun Session.prepareSecondFactorVerification(
 /** Attempts the second factor of an in-session reverification flow. */
 internal suspend fun Session.attemptSecondFactorVerification(
   strategy: String,
-  code: String,
+  code: String? = null,
+  publicKeyCredential: String? = null,
 ): ClerkResult<SessionVerification, ClerkErrorResponse> {
-  return ClerkApi.session.attemptSecondFactorVerification(
-    sessionId = id,
-    params = Session.AttemptSecondFactorParams(strategy = strategy, code = code).toMap(),
-  )
+  val params =
+    when {
+      publicKeyCredential != null ->
+        Session.AttemptSecondFactorParams.Passkey(publicKeyCredential = publicKeyCredential)
+      code != null -> Session.AttemptSecondFactorParams.Code(strategy = strategy, code = code)
+      else -> error("One of code or publicKeyCredential is required")
+    }
+
+  return ClerkApi.session.attemptSecondFactorVerification(sessionId = id, params = params.toMap())
 }

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
@@ -382,6 +382,13 @@ private constructor(
     @Serializable
     data class EmailCode(val code: String, override val strategy: String = EMAIL_CODE) :
       AttemptSecondFactorParams
+
+    @AutoMap
+    @Serializable
+    data class Passkey(
+      @SerialName("public_key_credential") val publicKeyCredential: String,
+      override val strategy: String = PASSKEY,
+    ) : AttemptSecondFactorParams
   }
 
   /**
@@ -547,6 +554,7 @@ private constructor(
     companion object {
       const val PHONE_CODE = "phone_code"
       const val EMAIL_CODE = "email_code"
+      const val PASSKEY = "passkey"
     }
   }
 
@@ -555,6 +563,8 @@ private constructor(
     data class PhoneCode(val phoneNumberId: String? = null) : PrepareSecondFactorStrategy()
 
     data class EmailCode(val emailAddressId: String? = null) : PrepareSecondFactorStrategy()
+
+    data object Passkey : PrepareSecondFactorStrategy()
 
     fun toParams(): PrepareSecondFactorParams =
       when (this) {
@@ -568,6 +578,7 @@ private constructor(
             strategy = PrepareSecondFactorParams.EMAIL_CODE,
             emailAddressId = emailAddressId,
           )
+        Passkey -> PrepareSecondFactorParams(strategy = PrepareSecondFactorParams.PASSKEY)
       }
   }
 
@@ -1040,7 +1051,7 @@ suspend fun SignIn.prepareSecondFactor(
   return ClerkApi.signIn.prepareSecondFactor(id = id, params = params.toMap())
 }
 
-private fun invalidPrepareState(
+internal fun invalidPrepareState(
   code: String,
   longMessage: String,
 ): ClerkResult.Failure<ClerkErrorResponse> {

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
@@ -95,6 +95,11 @@ val SignIn.startingFirstFactor: Factor?
 val SignIn.startingSecondFactor: Factor?
   get() {
     supportedSecondFactors
+      ?.firstOrNull { it.strategy == "passkey" }
+      ?.let {
+        return it
+      }
+    supportedSecondFactors
       ?.firstOrNull { it.strategy == "totp" }
       ?.let {
         return it

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignInPasskeyExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignInPasskeyExtensions.kt
@@ -1,0 +1,33 @@
+package com.clerk.api.signin
+
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.passkeys.PasskeyService
+
+/** Prepares an explicit second-factor strategy, including passkeys. */
+suspend fun SignIn.prepareSecondFactor(
+  strategy: SignIn.PrepareSecondFactorStrategy
+): ClerkResult<SignIn, ClerkErrorResponse> {
+  if (status != SignIn.Status.NEEDS_SECOND_FACTOR && status != SignIn.Status.NEEDS_CLIENT_TRUST) {
+    return invalidPrepareState(
+      code = "sign_in_status_invalid",
+      longMessage = "Cannot prepare second factor while sign-in status is ${status.name}",
+    )
+  }
+
+  return ClerkApi.signIn.prepareSecondFactor(id = id, params = strategy.toParams().toMap())
+}
+
+/**
+ * Authenticates this sign-in with a passkey.
+ *
+ * If this sign-in requires a second factor and advertises passkey support, the existing sign-in is
+ * prepared and attempted as a second factor. Otherwise, this starts the existing first-factor
+ * passkey flow.
+ */
+suspend fun SignIn.authenticateWithPasskey(
+  allowedCredentialIds: List<String> = emptyList()
+): ClerkResult<SignIn, ClerkErrorResponse> {
+  return PasskeyService.authenticateWithPasskey(this, allowedCredentialIds)
+}

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyAuthenticationServiceTest.kt
@@ -20,6 +20,7 @@ import com.clerk.api.network.api.SignInApi
 import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
+import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.session.Session
@@ -58,6 +59,8 @@ class PasskeyAuthenticationServiceTest {
   private lateinit var mockPublicKeyCredential: PublicKeyCredential
   private lateinit var mockPasswordCredential: PasswordCredential
   private lateinit var mockCustomCredential: CustomCredential
+  private lateinit var mockSignInApi: SignInApi
+  private lateinit var mockSessionApi: SessionApi
 
   @Before
   fun setup() {
@@ -77,8 +80,8 @@ class PasskeyAuthenticationServiceTest {
 
     // Mock ClerkApi and its nested objects
     mockkObject(ClerkApi)
-    val mockSignInApi = mockk<SignInApi>(relaxed = true)
-    val mockSessionApi = mockk<SessionApi>(relaxed = true)
+    mockSignInApi = mockk(relaxed = true)
+    mockSessionApi = mockk(relaxed = true)
     every { ClerkApi.signIn } returns mockSignInApi
     every { ClerkApi.session } returns mockSessionApi
 
@@ -166,6 +169,51 @@ class PasskeyAuthenticationServiceTest {
     assertTrue(result is ClerkResult.Success)
     assertTrue(requestSlot.captured.preferImmediatelyAvailableCredentials)
   }
+
+  @Test
+  fun `authenticateWithPasskey uses second factor endpoints for an in-progress sign in`() =
+    runTest {
+      val nonce = """{"challenge":"test-challenge"}"""
+      val authResponseJson = """{"type":"public-key","id":"credential-123"}"""
+      val signIn =
+        SignIn(
+          id = "sign_in_123",
+          status = SignIn.Status.NEEDS_SECOND_FACTOR,
+          supportedSecondFactors = listOf(Factor(strategy = "passkey")),
+        )
+      val preparedSignIn =
+        signIn.copy(secondFactorVerification = Verification(nonce = nonce, strategy = "passkey"))
+      val completedSignIn = preparedSignIn.copy(status = SignIn.Status.COMPLETE)
+
+      every { mockGetCredentialResponse.credential } returns mockPublicKeyCredential
+      every { mockPublicKeyCredential.authenticationResponseJson } returns authResponseJson
+      coEvery { mockCredentialManager.getCredential(any(), any()) } returns
+        mockGetCredentialResponse
+      coEvery {
+        mockSignInApi.prepareSecondFactor("sign_in_123", mapOf("strategy" to "passkey"))
+      } returns ClerkResult.success(preparedSignIn)
+      coEvery {
+        mockSignInApi.attemptSecondFactor(
+          "sign_in_123",
+          mapOf("public_key_credential" to authResponseJson, "strategy" to "passkey"),
+        )
+      } returns ClerkResult.success(completedSignIn)
+
+      val result = GoogleCredentialAuthenticationService.authenticateWithPasskey(signIn)
+
+      assertTrue(result is ClerkResult.Success)
+      assertEquals(completedSignIn, (result as ClerkResult.Success).value)
+      coVerify(exactly = 0) { mockSignInApi.createSignIn(any()) }
+      coVerify(exactly = 1) {
+        mockSignInApi.prepareSecondFactor("sign_in_123", mapOf("strategy" to "passkey"))
+      }
+      coVerify(exactly = 1) {
+        mockSignInApi.attemptSecondFactor(
+          "sign_in_123",
+          mapOf("public_key_credential" to authResponseJson, "strategy" to "passkey"),
+        )
+      }
+    }
 
   @Test
   fun `signInWithPasskey returns error when SignIn creation fails`() = runTest {
@@ -269,7 +317,9 @@ class PasskeyAuthenticationServiceTest {
       )
 
     assertTrue(result is ClerkResult.Failure)
-    assertTrue((result as ClerkResult.Failure).throwable is CredentialFlowException.ProviderUnavailable)
+    assertTrue(
+      (result as ClerkResult.Failure).throwable is CredentialFlowException.ProviderUnavailable
+    )
     verify(exactly = 1) { Clerk.updateClient(client.copy(signIn = null)) }
   }
 
@@ -451,6 +501,53 @@ class PasskeyAuthenticationServiceTest {
       assertEquals("Missing nonce in prepared verification", failure.throwable?.message)
       coVerify(exactly = 0) { mockCredentialManager.getCredential(any(), any()) }
     }
+
+  @Test
+  fun `verifySessionWithPasskey uses second factor endpoints when requested`() = runTest {
+    val session = testSession()
+    val nonce = """{"challenge":"test-challenge"}"""
+    val authResponseJson = """{"type":"public-key","id":"credential-123"}"""
+    val preparedVerification =
+      SessionVerification(
+        id = "ver_123",
+        status = SessionVerification.Status.NEEDS_SECOND_FACTOR,
+        level = SessionVerification.Level.MULTI_FACTOR,
+        secondFactorVerification = Verification(nonce = nonce, strategy = "passkey"),
+      )
+    val completedVerification =
+      preparedVerification.copy(status = SessionVerification.Status.COMPLETE)
+
+    every { mockGetCredentialResponse.credential } returns mockPublicKeyCredential
+    every { mockPublicKeyCredential.authenticationResponseJson } returns authResponseJson
+    coEvery { mockCredentialManager.getCredential(any(), any()) } returns mockGetCredentialResponse
+    coEvery {
+      mockSessionApi.prepareSecondFactorVerification("sess_123", mapOf("strategy" to "passkey"))
+    } returns ClerkResult.success(preparedVerification)
+    coEvery {
+      mockSessionApi.attemptSecondFactorVerification(
+        "sess_123",
+        mapOf("public_key_credential" to authResponseJson, "strategy" to "passkey"),
+      )
+    } returns ClerkResult.success(completedVerification)
+
+    val result =
+      GoogleCredentialAuthenticationService.verifySessionWithPasskey(
+        session = session,
+        level = SessionVerification.Level.SECOND_FACTOR,
+      )
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(completedVerification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) {
+      mockSessionApi.prepareSecondFactorVerification("sess_123", mapOf("strategy" to "passkey"))
+    }
+    coVerify(exactly = 1) {
+      mockSessionApi.attemptSecondFactorVerification(
+        "sess_123",
+        mapOf("public_key_credential" to authResponseJson, "strategy" to "passkey"),
+      )
+    }
+  }
 
   private fun testSession(): Session {
     return Session(

--- a/source/api/src/test/java/com/clerk/api/passkeys/PasskeyServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/passkeys/PasskeyServiceTest.kt
@@ -113,6 +113,28 @@ class PasskeyServiceTest {
   }
 
   @Test
+  fun `authenticateWithPasskey delegates an existing sign in`() = runTest {
+    val allowedCredentialIds = listOf("credential-1")
+    coEvery {
+      GoogleCredentialAuthenticationService.authenticateWithPasskey(
+        signIn = mockSignIn,
+        allowedCredentialIds = allowedCredentialIds,
+      )
+    } returns ClerkResult.success(mockSignIn)
+
+    val result = PasskeyService.authenticateWithPasskey(mockSignIn, allowedCredentialIds)
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(mockSignIn, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) {
+      GoogleCredentialAuthenticationService.authenticateWithPasskey(
+        signIn = mockSignIn,
+        allowedCredentialIds = allowedCredentialIds,
+      )
+    }
+  }
+
+  @Test
   fun `signInWithPasskey returns error when PasskeyAuthenticationService fails`() = runTest {
     // Given
     val error =

--- a/source/api/src/test/java/com/clerk/api/session/SessionVerificationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/session/SessionVerificationTest.kt
@@ -275,14 +275,51 @@ class SessionVerificationTest {
     val verification = testVerification(status = SessionVerification.Status.COMPLETE)
     val allowedCredentialIds = listOf("credential_123")
     mockkObject(PasskeyService)
-    coEvery { PasskeyService.verifySessionWithPasskey(session, allowedCredentialIds) } returns
-      ClerkResult.success(verification)
+    coEvery {
+      PasskeyService.verifySessionWithPasskey(
+        session,
+        allowedCredentialIds,
+        SessionVerification.Level.FIRST_FACTOR,
+      )
+    } returns ClerkResult.success(verification)
 
     val result = session.verifyWithPasskey(allowedCredentialIds = allowedCredentialIds)
 
     assertTrue(result is ClerkResult.Success)
     assertSame(verification, (result as ClerkResult.Success).value)
-    coVerify(exactly = 1) { PasskeyService.verifySessionWithPasskey(session, allowedCredentialIds) }
+    coVerify(exactly = 1) {
+      PasskeyService.verifySessionWithPasskey(
+        session,
+        allowedCredentialIds,
+        SessionVerification.Level.FIRST_FACTOR,
+      )
+    }
+  }
+
+  @Test
+  fun `verify with passkey delegates second factor level to passkey service`() = runTest {
+    val session = testSession()
+    val verification = testVerification(status = SessionVerification.Status.COMPLETE)
+    mockkObject(PasskeyService)
+    coEvery {
+      PasskeyService.verifySessionWithPasskey(
+        session,
+        emptyList(),
+        SessionVerification.Level.SECOND_FACTOR,
+      )
+    } returns ClerkResult.success(verification)
+
+    val result = session.verifyWithPasskey(level = SessionVerification.Level.SECOND_FACTOR)
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(verification, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) {
+      PasskeyService.verifySessionWithPasskey(
+        session,
+        emptyList(),
+        SessionVerification.Level.SECOND_FACTOR,
+      )
+    }
   }
 
   @Test

--- a/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorTwoView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorTwoView.kt
@@ -10,6 +10,7 @@ import com.clerk.ui.core.common.StrategyKeys
 import com.clerk.ui.signin.backupcode.SignInFactorTwoBackupCodeView
 import com.clerk.ui.signin.code.SignInFactorCodeView
 import com.clerk.ui.signin.help.SignInGetHelpView
+import com.clerk.ui.signin.passkey.SignInFactorTwoPasskeyView
 import com.clerk.ui.theme.ClerkThemeOverrideProvider
 
 /**
@@ -45,6 +46,12 @@ fun SignInFactorTwoView(
         SignInFactorTwoBackupCodeView(
           modifier = modifier,
           factor = factor,
+          onAuthComplete = onAuthComplete,
+        )
+      StrategyKeys.PASSKEY ->
+        SignInFactorTwoPasskeyView(
+          factor = factor,
+          modifier = modifier,
           onAuthComplete = onAuthComplete,
         )
       else -> SignInGetHelpView(modifier = modifier)

--- a/source/ui/src/main/java/com/clerk/ui/signin/clienttrust/SignInClientTrustView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/clienttrust/SignInClientTrustView.kt
@@ -15,6 +15,7 @@ import com.clerk.ui.core.common.StrategyKeys
 import com.clerk.ui.core.dimens.dp16
 import com.clerk.ui.signin.code.SignInFactorCodeView
 import com.clerk.ui.signin.help.SignInGetHelpView
+import com.clerk.ui.signin.passkey.SignInFactorTwoPasskeyView
 import com.clerk.ui.theme.ClerkMaterialTheme
 import com.clerk.ui.theme.ClerkThemeOverrideProvider
 
@@ -49,6 +50,12 @@ fun SignInClientTrustView(
           factor = factor,
           isSecondFactor = true,
           isClientTrust = true,
+          modifier = modifier,
+          onAuthComplete = onAuthComplete,
+        )
+      StrategyKeys.PASSKEY ->
+        SignInFactorTwoPasskeyView(
+          factor = factor,
           modifier = modifier,
           onAuthComplete = onAuthComplete,
         )

--- a/source/ui/src/main/java/com/clerk/ui/signin/passkey/PasskeyViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/passkey/PasskeyViewModel.kt
@@ -8,6 +8,7 @@ import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
 import com.clerk.api.signin.SignIn
+import com.clerk.api.signin.authenticateWithPasskey
 import com.clerk.ui.auth.AuthenticationViewState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,10 +19,13 @@ internal class PasskeyViewModel : ViewModel() {
   private val _state = MutableStateFlow<AuthenticationViewState>(AuthenticationViewState.Idle)
   val state = _state.asStateFlow()
 
-  fun authenticate() {
+  fun authenticate(signIn: SignIn? = null) {
     _state.value = AuthenticationViewState.Loading
     viewModelScope.launch {
-      SignIn.authenticateWithGoogleCredential(listOf(SignIn.CredentialType.PASSKEY))
+      val result =
+        signIn?.authenticateWithPasskey()
+          ?: SignIn.authenticateWithGoogleCredential(listOf(SignIn.CredentialType.PASSKEY))
+      result
         .onSuccess { _state.value = AuthenticationViewState.Success.SignIn(it) }
         .onFailure {
           ClerkLog.e("Passkey authentication failed: $it")

--- a/source/ui/src/main/java/com/clerk/ui/signin/passkey/SignInFactorOnePasskeyView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/passkey/SignInFactorOnePasskeyView.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.clerk.api.Clerk
 import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.R
@@ -49,14 +50,16 @@ fun SignInFactorOnePasskeyView(
     SignInFactorOnePasskeyViewImpl(
       modifier = modifier,
       factor = factor,
+      isSecondFactor = false,
       onAuthComplete = onAuthComplete,
     )
   }
 }
 
 @Composable
-private fun SignInFactorOnePasskeyViewImpl(
+internal fun SignInFactorOnePasskeyViewImpl(
   factor: Factor,
+  isSecondFactor: Boolean,
   modifier: Modifier = Modifier,
   viewModel: PasskeyViewModel = viewModel(),
   onAuthComplete: () -> Unit,
@@ -93,7 +96,9 @@ private fun SignInFactorOnePasskeyViewImpl(
     Spacers.Vertical.Spacer32()
     ClerkButton(
       text = stringResource(R.string.continue_text),
-      onClick = { viewModel.authenticate() },
+      onClick = {
+        viewModel.authenticate(signIn = Clerk.auth.currentSignIn.takeIf { isSecondFactor })
+      },
       modifier = Modifier.fillMaxWidth(),
       isLoading = state is AuthenticationViewState.Loading,
       icons =
@@ -105,9 +110,13 @@ private fun SignInFactorOnePasskeyViewImpl(
     Spacers.Vertical.Spacer16()
     ClerkTextButton(
       onClick = {
-        authState.navigateTo(
-          AuthDestination.SignInFactorOneUseAnotherMethod(currentFactor = factor)
-        )
+        val destination =
+          if (isSecondFactor) {
+            AuthDestination.SignInFactorTwoUseAnotherMethod(currentFactor = factor)
+          } else {
+            AuthDestination.SignInFactorOneUseAnotherMethod(currentFactor = factor)
+          }
+        authState.navigateTo(destination)
       },
       text = stringResource(R.string.use_a_different_method),
     )

--- a/source/ui/src/main/java/com/clerk/ui/signin/passkey/SignInFactorTwoPasskeyView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/passkey/SignInFactorTwoPasskeyView.kt
@@ -1,0 +1,39 @@
+package com.clerk.ui.signin.passkey
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.ui.ClerkTheme
+import com.clerk.ui.auth.PreviewAuthStateProvider
+import com.clerk.ui.core.common.StrategyKeys
+import com.clerk.ui.theme.ClerkThemeOverrideProvider
+
+/** Displays passkey authentication for the second factor of an in-progress sign-in. */
+@Composable
+fun SignInFactorTwoPasskeyView(
+  factor: Factor,
+  modifier: Modifier = Modifier,
+  clerkTheme: ClerkTheme? = null,
+  onAuthComplete: () -> Unit,
+) {
+  ClerkThemeOverrideProvider(clerkTheme) {
+    SignInFactorOnePasskeyViewImpl(
+      modifier = modifier,
+      factor = factor,
+      isSecondFactor = true,
+      onAuthComplete = onAuthComplete,
+    )
+  }
+}
+
+@PreviewLightDark
+@Composable
+private fun Preview() {
+  PreviewAuthStateProvider {
+    SignInFactorTwoPasskeyView(
+      factor = Factor(strategy = StrategyKeys.PASSKEY),
+      onAuthComplete = {},
+    )
+  }
+}

--- a/workbench/src/main/java/com/clerk/workbench/UiActivity1.kt
+++ b/workbench/src/main/java/com/clerk/workbench/UiActivity1.kt
@@ -8,34 +8,23 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import com.clerk.api.Clerk
-import com.clerk.ui.core.button.standard.ClerkButton
 import com.clerk.workbench.ui.theme.WorkbenchTheme
-import kotlinx.coroutines.launch
 
 class UiActivity1 : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
     setContent {
-      val scope = rememberCoroutineScope()
       WorkbenchTheme {
         Box(
           modifier = Modifier.fillMaxSize().background(color = Color(0xFFF9F9F9)),
           contentAlignment = Alignment.Center,
         ) {
-          WorkbenchAuthGate {
-            ClerkButton(
-              modifier = Modifier.align(Alignment.Center),
-              text = "Sign Out",
-              onClick = { scope.launch { Clerk.auth.signOut() } },
-            )
-          }
+          WorkbenchAuthGate { UserProfileTopBar() }
         }
       }
     }


### PR DESCRIPTION
Supports passkeys as a second factor for sign-in and session reverification. Adds prebuilt UI routing for passkey MFA and exposes profile settings in Workbench.


https://github.com/user-attachments/assets/fca1ac87-7532-4ee6-b7c2-750a31fd01e8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passkey authentication for second-factor sign-in and session verification.
  * Added passkey support for client-trust verification.
  * Sign-in now prioritizes passkeys when available.
  * Added dedicated second-factor passkey sign-in screens and navigation.
  * Updated the API version and factor ordering to prioritize passkeys.

* **Bug Fixes**
  * Improved handling of passkey and code-based second-factor attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->