### PR TITLE
refactor: simplify biometric credential naming

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -332,19 +332,19 @@ object Clerk {
     get() = environment?.userSettings?.passkeySettings?.allowAutofill ?: false
 
   /**
-   * Indicates whether biometric-credential (biometric) sign-in is enabled for this instance.
+   * Indicates whether biometric sign-in is enabled for this instance.
    *
-   * Requires both the Clerk Native API and the biometric-credential feature to be enabled for your
+   * Requires both the Clerk Native API and the biometric sign-in feature to be enabled for your
    * Clerk instance.
    *
-   * @return `true` if biometric-credential sign-in is enabled, `false` otherwise. Returns `false`
-   *   if the SDK is not yet initialized.
+   * @return `true` if biometric sign-in is enabled, `false` otherwise. Returns `false` if the SDK
+   *   is not yet initialized.
    */
   val biometricSignInIsEnabled: Boolean
     get() = environment?.biometricSignInIsEnabled ?: false
 
   /**
-   * Indicates whether the biometric-credential enrollment prompt should be offered after sign-in.
+   * Indicates whether the biometric credential enrollment prompt should be offered after sign-in.
    *
    * @return `true` if the prompt is enabled, `false` otherwise. Returns `false` if the SDK is not
    *   yet initialized.
@@ -353,7 +353,7 @@ object Clerk {
     get() = environment?.biometricCredentialPromptAfterSignInIsEnabled ?: false
 
   /**
-   * Indicates whether the biometric-credential enrollment prompt should be offered after sign-up.
+   * Indicates whether the biometric credential enrollment prompt should be offered after sign-up.
    *
    * @return `true` if the prompt is enabled, `false` otherwise. Returns `false` if the SDK is not
    *   yet initialized.
@@ -727,7 +727,7 @@ object Clerk {
   val auth: Auth = Auth()
 
   /**
-   * The main entry point for biometric-credential (biometric sign-in) credential operations.
+   * The main entry point for biometric credential operations.
    *
    * ### Example usage:
    * ```kotlin

--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -364,7 +364,7 @@ class Auth internal constructor() {
   }
 
   /**
-   * Signs in with a locally enrolled biometric-credential (biometric) credential.
+   * Signs in with a locally enrolled biometric credential.
    *
    * The biometric-credential domain owns local credential selection, key access, challenge signing,
    * and stale local credential cleanup.

--- a/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentialAvailability.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentialAvailability.kt
@@ -9,10 +9,7 @@ sealed interface BiometricCredentialAvailability {
   /** Biometric sign-in is unavailable for the given [reason]. */
   data class Unavailable(val reason: UnavailableReason) : BiometricCredentialAvailability
 
-  /**
-   * Whether the SDK has a local credential and key that can be used for biometric-credential
-   * sign-in.
-   */
+  /** Whether the SDK has a local credential and key that can be used for biometric sign-in. */
   val isAvailable: Boolean
     get() = this is Available
 

--- a/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentialAvailability.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentialAvailability.kt
@@ -1,12 +1,12 @@
 package com.clerk.api.biometriccredential
 
-/** Local availability state for biometric-credential sign-in. */
+/** Local availability state for biometric sign-in. */
 sealed interface BiometricCredentialAvailability {
 
-  /** Biometric-credential sign-in can be started with a local credential on this device. */
+  /** Biometric sign-in can be started with a local credential on this device. */
   data object Available : BiometricCredentialAvailability
 
-  /** Biometric-credential sign-in is unavailable for the given [reason]. */
+  /** Biometric sign-in is unavailable for the given [reason]. */
   data class Unavailable(val reason: UnavailableReason) : BiometricCredentialAvailability
 
   /**
@@ -16,11 +16,11 @@ sealed interface BiometricCredentialAvailability {
   val isAvailable: Boolean
     get() = this is Available
 
-  /** The reason biometric-credential sign-in is unavailable, if any. */
+  /** The reason biometric sign-in is unavailable, if any. */
   val unavailableReason: UnavailableReason?
     get() = (this as? Unavailable)?.reason
 
-  /** The reason biometric-credential sign-in is unavailable. */
+  /** The reason biometric sign-in is unavailable. */
   enum class UnavailableReason {
     /** The Clerk environment has not been loaded yet. */
     ENVIRONMENT_UNAVAILABLE,
@@ -28,7 +28,7 @@ sealed interface BiometricCredentialAvailability {
     /** The Clerk Native API is disabled for this instance. */
     NATIVE_API_DISABLED,
 
-    /** Biometric-credential sign-in is disabled for this instance. */
+    /** Biometric sign-in is disabled for this instance. */
     FEATURE_DISABLED,
 
     /** Biometric authentication is not available or not enrolled on this device. */

--- a/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentialKeyManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentialKeyManager.kt
@@ -52,7 +52,7 @@ internal constructor(val code: Code, message: String, cause: Throwable? = null) 
 
   /** The category of biometric-credential key management error. */
   enum class Code {
-    /** Biometric-credential sign-in requires Android 9 (API 28) or later. */
+    /** Biometric sign-in requires Android 9 (API 28) or later. */
     UNSUPPORTED_PLATFORM,
 
     /** Biometric authentication is not available or not enrolled on this device. */
@@ -80,7 +80,7 @@ internal constructor(val code: Code, message: String, cause: Throwable? = null) 
   }
 }
 
-/** Manager for local, biometric-gated biometric-credential private keys. */
+/** Manager for local biometric-credential private keys. */
 internal interface BiometricCredentialKeyManager {
   /**
    * Whether biometric-credential keys protected by [policy] can be created and used on this device.
@@ -152,7 +152,7 @@ internal object DefaultBiometricCredentialKeyManager : BiometricCredentialKeyMan
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
       throw BiometricCredentialKeyManagerException(
         BiometricCredentialKeyManagerException.Code.UNSUPPORTED_PLATFORM,
-        "Biometric-credential sign-in requires Android 9 (API 28) or later.",
+        "Biometric sign-in requires Android 9 (API 28) or later.",
       )
     }
     if (!isSupported(policy)) {
@@ -207,7 +207,7 @@ internal object DefaultBiometricCredentialKeyManager : BiometricCredentialKeyMan
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
       throw BiometricCredentialKeyManagerException(
         BiometricCredentialKeyManagerException.Code.UNSUPPORTED_PLATFORM,
-        "Biometric-credential sign-in requires Android 9 (API 28) or later.",
+        "Biometric sign-in requires Android 9 (API 28) or later.",
       )
     }
 
@@ -279,7 +279,7 @@ internal object DefaultBiometricCredentialKeyManager : BiometricCredentialKeyMan
       Clerk.credentialActivity()
         ?: throw BiometricCredentialKeyManagerException(
           BiometricCredentialKeyManagerException.Code.SIGNING_FAILED,
-          "Biometric-credential sign-in requires an active Activity.",
+          "Biometric sign-in requires an active Activity.",
         )
 
     return withContext(Dispatchers.Main) {

--- a/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentialLocalStore.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentialLocalStore.kt
@@ -26,7 +26,7 @@ import kotlinx.serialization.json.jsonPrimitive
  * @property updatedAt The time the credential was last updated, in milliseconds since epoch.
  */
 @Serializable
-internal data class BiometricCredentialLocalCredential(
+internal data class BiometricCredentialLocalRecord(
   val id: String,
   @SerialName("localKeyId") val localKeyId: String,
   @SerialName("userId") val userId: String,
@@ -52,16 +52,15 @@ internal data class BiometricCredentialLocalCredential(
 }
 
 /** Store for local biometric credential metadata. */
-internal interface BiometricCredentialLocalCredentialStore {
-  fun all(): List<BiometricCredentialLocalCredential>
+internal interface BiometricCredentialLocalStore {
+  fun all(): List<BiometricCredentialLocalRecord>
 
-  fun all(appIdentifier: String): List<BiometricCredentialLocalCredential> =
+  fun all(appIdentifier: String): List<BiometricCredentialLocalRecord> =
     all().filter { it.appIdentifier == appIdentifier }
 
-  fun credential(id: String): BiometricCredentialLocalCredential? =
-    all().firstOrNull { it.id == id }
+  fun credential(id: String): BiometricCredentialLocalRecord? = all().firstOrNull { it.id == id }
 
-  fun save(credential: BiometricCredentialLocalCredential)
+  fun save(credential: BiometricCredentialLocalRecord)
 
   fun delete(id: String)
 
@@ -69,18 +68,17 @@ internal interface BiometricCredentialLocalCredentialStore {
 }
 
 /**
- * Default [BiometricCredentialLocalCredentialStore] persisting credential metadata as encrypted
- * JSON via [StorageHelper].
+ * Default [BiometricCredentialLocalStore] persisting credential metadata as encrypted JSON via
+ * [StorageHelper].
  *
  * Malformed records are dropped on read instead of failing the whole list, so a single corrupt
- * entry can't lock out biometric-credential sign-in.
+ * entry can't lock out biometric sign-in.
  */
-internal object DefaultBiometricCredentialLocalCredentialStore :
-  BiometricCredentialLocalCredentialStore {
+internal object DefaultBiometricCredentialLocalStore : BiometricCredentialLocalStore {
 
   // Keep the trusted-device storage key so SDK upgrades can read existing enrollments.
   @Suppress("ReturnCount")
-  override fun all(): List<BiometricCredentialLocalCredential> {
+  override fun all(): List<BiometricCredentialLocalRecord> {
     val stored =
       StorageHelper.loadValue(StorageKey.TRUSTED_DEVICE_CREDENTIALS) ?: return emptyList()
     val elements =
@@ -93,7 +91,7 @@ internal object DefaultBiometricCredentialLocalCredentialStore :
     return elements.mapNotNull { element -> decodeCredential(element) }
   }
 
-  override fun save(credential: BiometricCredentialLocalCredential) {
+  override fun save(credential: BiometricCredentialLocalRecord) {
     persist(all().filterNot { it.id == credential.id } + credential)
   }
 
@@ -105,14 +103,14 @@ internal object DefaultBiometricCredentialLocalCredentialStore :
     StorageHelper.deleteValue(StorageKey.TRUSTED_DEVICE_CREDENTIALS)
   }
 
-  private fun persist(credentials: List<BiometricCredentialLocalCredential>) {
+  private fun persist(credentials: List<BiometricCredentialLocalRecord>) {
     if (credentials.isEmpty()) {
       deleteAll()
       return
     }
 
     val elements = credentials.map {
-      ClerkApi.json.encodeToJsonElement(BiometricCredentialLocalCredential.serializer(), it)
+      ClerkApi.json.encodeToJsonElement(BiometricCredentialLocalRecord.serializer(), it)
     }
     StorageHelper.saveValue(
       StorageKey.TRUSTED_DEVICE_CREDENTIALS,
@@ -120,10 +118,10 @@ internal object DefaultBiometricCredentialLocalCredentialStore :
     )
   }
 
-  private fun decodeCredential(element: JsonElement): BiometricCredentialLocalCredential? {
+  private fun decodeCredential(element: JsonElement): BiometricCredentialLocalRecord? {
     return runCatching {
         ClerkApi.json.decodeFromJsonElement(
-          BiometricCredentialLocalCredential.serializer(),
+          BiometricCredentialLocalRecord.serializer(),
           element,
         )
       }
@@ -148,7 +146,7 @@ internal object BiometricCredentialPendingCleanupStore {
           .filterTo(mutableSetOf()) { it.isNotBlank() }
       }
       .getOrElse {
-        ClerkLog.w("Biometric-credential pending cleanup metadata is malformed, clearing it.")
+        ClerkLog.w("Biometric credential cleanup metadata is malformed, clearing it.")
         StorageHelper.deleteValue(StorageKey.PENDING_TRUSTED_DEVICE_CREDENTIAL_CLEANUP)
         emptySet()
       }

--- a/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentialValidation.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentialValidation.kt
@@ -2,7 +2,7 @@ package com.clerk.api.biometriccredential
 
 import kotlinx.serialization.Serializable
 
-/** The server-side validation result for a local biometric-credential sign-in credential. */
+/** The server-side validation result for a local biometric credential. */
 @Serializable
 internal data class BiometricCredentialValidation(
   /** Whether the biometric credential can be used for sign-in. */

--- a/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentials.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/biometriccredential/BiometricCredentials.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * The main entry point for biometric-credential (biometric sign-in) credential operations.
+ * The main entry point for biometric credential operations.
  *
  * Access via [Clerk.biometricCredentials].
  *
@@ -41,8 +41,7 @@ object BiometricCredentials {
   internal var keyManager: BiometricCredentialKeyManager = DefaultBiometricCredentialKeyManager
 
   @VisibleForTesting
-  internal var credentialStore: BiometricCredentialLocalCredentialStore =
-    DefaultBiometricCredentialLocalCredentialStore
+  internal var credentialStore: BiometricCredentialLocalStore = DefaultBiometricCredentialLocalStore
 
   /**
    * Lists active biometric credentials for the signed-in user.
@@ -55,11 +54,11 @@ object BiometricCredentials {
   }
 
   /**
-   * Returns local biometric-credential sign-in availability.
+   * Returns local biometric sign-in availability.
    *
    * When a Clerk session is active, this also reconciles the local credential with the server.
    * Without an active session, this reports whether the local biometric-gated credential can be
-   * used to start biometric-credential sign-in.
+   * used to start biometric sign-in.
    *
    * @param id The biometric credential ID to check. When omitted, the available local credential is
    *   used.
@@ -77,8 +76,8 @@ object BiometricCredentials {
   }
 
   /**
-   * Returns biometric-credential sign-in availability for the current signed-in user, reconciling
-   * the local credential with the server.
+   * Returns biometric sign-in availability for the current signed-in user, reconciling the local
+   * credential with the server.
    */
   suspend fun currentUserAvailability(): BiometricCredentialAvailability {
     val userId =
@@ -94,9 +93,7 @@ object BiometricCredentials {
     }
   }
 
-  /**
-   * Returns local biometric-credential sign-in availability without reconciling with the server.
-   */
+  /** Returns local biometric sign-in availability without reconciling with the server. */
   fun localAvailability(
     id: String? = null,
     identifierHint: String? = null,
@@ -109,8 +106,8 @@ object BiometricCredentials {
   }
 
   /**
-   * Returns local biometric-credential sign-in availability for the current signed-in user without
-   * reconciling with the server.
+   * Returns local biometric sign-in availability for the current signed-in user without reconciling
+   * with the server.
    */
   fun currentUserLocalAvailability(): BiometricCredentialAvailability {
     val userId =
@@ -263,7 +260,7 @@ object BiometricCredentials {
     BiometricCredentialPendingCleanupStore.all().forEach { deletedUserId ->
       runCatching { forgetLocalCredentials(deletedUserId) }
         .onSuccess { BiometricCredentialPendingCleanupStore.remove(deletedUserId) }
-        .onFailure { ClerkLog.w("Failed to retry biometric-credential local credential cleanup.") }
+        .onFailure { ClerkLog.w("Failed to retry biometric local credential cleanup.") }
     }
   }
 
@@ -288,7 +285,7 @@ object BiometricCredentials {
       when (val result = selectedLocalCredential(id, identifierHint, userId = null)) {
         is LocalCredentialResult.Available -> result.credential
         is LocalCredentialResult.Unavailable ->
-          return clientFailure("Biometric-credential sign-in is unavailable.")
+          return clientFailure("Biometric sign-in is unavailable.")
       }
 
     val createResult =
@@ -307,7 +304,7 @@ object BiometricCredentials {
 
     val challenge =
       signIn.firstFactorVerification?.biometricCredentialChallenge
-        ?: return clientFailure("Biometric-credential sign-in did not return a challenge.")
+        ?: return clientFailure("Biometric sign-in did not return a challenge.")
 
     val signature =
       try {
@@ -400,7 +397,7 @@ object BiometricCredentials {
     }
   }
 
-  /** Whether biometric-gated biometric-credential keys can be created and used on this device. */
+  /** Whether biometric-gated keys can be created and used on this device. */
   val deviceSupportsBiometricAuthentication: Boolean
     get() = keyManager.isSupported(BiometricCredentialPolicy.BIOMETRY_OR_DEVICE_PASSCODE)
 
@@ -456,13 +453,12 @@ object BiometricCredentials {
   ): ClerkResult.Failure<ClerkErrorResponse>? {
     return try {
       credentialStore.save(
-        BiometricCredentialLocalCredential(
+        BiometricCredentialLocalRecord(
           id = biometricCredential.id,
           localKeyId = localKey.localKeyId,
           userId = userId,
           appIdentifier = biometricCredential.appIdentifier,
-          identifierHint =
-            BiometricCredentialLocalCredential.normalizedIdentifierHint(identifierHint),
+          identifierHint = BiometricCredentialLocalRecord.normalizedIdentifierHint(identifierHint),
           policy = localKey.policy,
           createdAt = biometricCredential.createdAt,
           updatedAt = biometricCredential.updatedAt,
@@ -489,14 +485,14 @@ object BiometricCredentials {
   }
 
   private sealed interface LocalCredentialResult {
-    data class Available(val credential: BiometricCredentialLocalCredential) : LocalCredentialResult
+    data class Available(val credential: BiometricCredentialLocalRecord) : LocalCredentialResult
 
     data class Unavailable(val reason: BiometricCredentialAvailability.UnavailableReason) :
       LocalCredentialResult
   }
 
   private sealed interface LocalCredentialsResult {
-    data class Available(val credentials: List<BiometricCredentialLocalCredential>) :
+    data class Available(val credentials: List<BiometricCredentialLocalRecord>) :
       LocalCredentialsResult
 
     data class Unavailable(val reason: BiometricCredentialAvailability.UnavailableReason) :
@@ -604,7 +600,7 @@ object BiometricCredentials {
     id: String?,
     identifierHint: String?,
     userId: String?,
-  ): List<BiometricCredentialLocalCredential> {
+  ): List<BiometricCredentialLocalRecord> {
     var credentials = storedLocalCredentialsForCurrentApp()
     if (id != null) {
       credentials = credentials.filter { it.id == id }
@@ -616,20 +612,20 @@ object BiometricCredentials {
         credentials.filter { it.matches(identifierHint) }
       }
     return credentials.sortedWith(
-      compareByDescending<BiometricCredentialLocalCredential> { it.createdAt }
+      compareByDescending<BiometricCredentialLocalRecord> { it.createdAt }
         .thenByDescending { it.updatedAt }
         .thenByDescending { it.id }
     )
   }
 
-  private fun storedLocalCredentialsForCurrentApp(): List<BiometricCredentialLocalCredential> {
+  private fun storedLocalCredentialsForCurrentApp(): List<BiometricCredentialLocalRecord> {
     val appIdentifier = Clerk.applicationId ?: return emptyList()
     return credentialStore.all(appIdentifier)
   }
 
   private fun localCredentialsWithExistingKeys(
-    credentials: List<BiometricCredentialLocalCredential>
-  ): List<BiometricCredentialLocalCredential> {
+    credentials: List<BiometricCredentialLocalRecord>
+  ): List<BiometricCredentialLocalRecord> {
     return credentials.filter { credential ->
       val hasKey = runCatching { keyManager.hasKey(credential.localKeyId) }.getOrDefault(false)
       if (!hasKey) {
@@ -640,7 +636,7 @@ object BiometricCredentials {
   }
 
   private fun deleteLocalCredential(
-    credential: BiometricCredentialLocalCredential,
+    credential: BiometricCredentialLocalRecord,
     propagateKeyDeletionFailure: Boolean = false,
   ) {
     val keyDeletionResult = runCatching { keyManager.deleteKey(credential.localKeyId) }
@@ -670,19 +666,19 @@ object BiometricCredentials {
     val message =
       when (reason) {
         BiometricCredentialAvailability.UnavailableReason.ENVIRONMENT_UNAVAILABLE ->
-          "Unable to use biometric-credential sign-in before the Clerk environment is loaded."
+          "Unable to use biometric sign-in before the Clerk environment is loaded."
         BiometricCredentialAvailability.UnavailableReason.NATIVE_API_DISABLED ->
-          "Unable to use biometric-credential sign-in because Native API is disabled."
+          "Unable to use biometric sign-in because Native API is disabled."
         BiometricCredentialAvailability.UnavailableReason.FEATURE_DISABLED ->
-          "Unable to use biometric-credential sign-in because it is disabled."
-        else -> "Biometric-credential sign-in is unavailable."
+          "Unable to use biometric sign-in because it is disabled."
+        else -> "Biometric sign-in is unavailable."
       }
     return clientFailure(message)
   }
 
   private fun <T : Any> handleBiometricSignInError(
     failure: ClerkResult.Failure<ClerkErrorResponse>,
-    localCredential: BiometricCredentialLocalCredential,
+    localCredential: BiometricCredentialLocalRecord,
   ): ClerkResult<T, ClerkErrorResponse> {
     if (!failure.isMissingBiometricCredential) {
       return failure

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/AuthConfig.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/AuthConfig.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.Serializable
  * @property singleSessionMode Whether the application is configured for single session mode. When
  *   true, only one active session is allowed per user at a time.
  * @property sessionMinter Whether session token minting at the edge is enabled.
- * @property nativeSettings Native-app specific settings, such as biometric-credential sign-in.
+ * @property nativeSettings Native-app specific settings, such as biometric sign-in.
  */
 @Serializable
 internal data class AuthConfig(
@@ -25,7 +25,7 @@ internal data class AuthConfig(
   /** Whether session token minting at the edge is enabled. */
   @SerialName("session_minter") val sessionMinter: Boolean = false,
 
-  /** Native-app specific settings, such as biometric-credential sign-in. */
+  /** Native-app specific settings, such as biometric sign-in. */
   @SerialName("native_settings") val nativeSettings: NativeSettings = NativeSettings(),
 ) {
 
@@ -33,7 +33,7 @@ internal data class AuthConfig(
    * Native-app specific settings from the Clerk environment.
    *
    * @property apiEnabled Whether the Clerk Native API is enabled for this instance.
-   * @property biometricSignInEnabled Whether biometric-credential (biometric) sign-in is enabled.
+   * @property biometricSignInEnabled Whether biometric sign-in is enabled.
    * @property biometricCredentialPromptAfterSignInEnabled Whether the biometric-credential
    *   enrollment prompt should be offered after sign-in.
    * @property biometricCredentialPromptAfterSignUpEnabled Whether the biometric-credential
@@ -44,14 +44,14 @@ internal data class AuthConfig(
     /** Whether the Clerk Native API is enabled for this instance. */
     @SerialName("api_enabled") val apiEnabled: Boolean = false,
 
-    /** Whether biometric-credential (biometric) sign-in is enabled. */
+    /** Whether biometric sign-in is enabled. */
     @SerialName("trusted_device_sign_in_enabled") val biometricSignInEnabled: Boolean = false,
 
-    /** Whether the biometric-credential enrollment prompt should be offered after sign-in. */
+    /** Whether the biometric credential enrollment prompt should be offered after sign-in. */
     @SerialName("trusted_device_enrollment_prompt_after_sign_in_enabled")
     val biometricCredentialPromptAfterSignInEnabled: Boolean = false,
 
-    /** Whether the biometric-credential enrollment prompt should be offered after sign-up. */
+    /** Whether the biometric credential enrollment prompt should be offered after sign-up. */
     @SerialName("trusted_device_enrollment_prompt_after_sign_up_enabled")
     val biometricCredentialPromptAfterSignUpEnabled: Boolean = false,
   )

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/verification/Verification.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/verification/Verification.kt
@@ -22,7 +22,7 @@ data class Verification(
   val externalVerificationRedirectUrl: String? = null,
   /** The nonce pertaining to the verification. */
   val nonce: String? = null,
-  /** The challenge payload for biometric-credential sign-in verifications. */
+  /** The challenge payload for biometric sign-in verifications. */
   @SerialName("trusted_device_challenge")
   val biometricCredentialChallenge: BiometricCredentialChallenge? = null,
 ) {

--- a/source/api/src/test/java/com/clerk/api/biometriccredential/BiometricCredentialLocalStoreTest.kt
+++ b/source/api/src/test/java/com/clerk/api/biometriccredential/BiometricCredentialLocalStoreTest.kt
@@ -15,9 +15,9 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
-class BiometricCredentialLocalCredentialStoreTest {
+class BiometricCredentialLocalStoreTest {
 
-  private val store = DefaultBiometricCredentialLocalCredentialStore
+  private val store = DefaultBiometricCredentialLocalStore
 
   @Before
   fun setup() {
@@ -104,13 +104,13 @@ class BiometricCredentialLocalCredentialStoreTest {
     userId: String = "user_1",
     appIdentifier: String = "com.example.app",
     identifierHint: String? = null,
-  ): BiometricCredentialLocalCredential {
-    return BiometricCredentialLocalCredential(
+  ): BiometricCredentialLocalRecord {
+    return BiometricCredentialLocalRecord(
       id = id,
       localKeyId = "tdlk_$id",
       userId = userId,
       appIdentifier = appIdentifier,
-      identifierHint = BiometricCredentialLocalCredential.normalizedIdentifierHint(identifierHint),
+      identifierHint = BiometricCredentialLocalRecord.normalizedIdentifierHint(identifierHint),
       policy = BiometricCredentialPolicy.BIOMETRY_OR_DEVICE_PASSCODE,
       createdAt = 1L,
       updatedAt = 2L,

--- a/source/api/src/test/java/com/clerk/api/biometriccredential/BiometricCredentialsTest.kt
+++ b/source/api/src/test/java/com/clerk/api/biometriccredential/BiometricCredentialsTest.kt
@@ -33,7 +33,7 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class BiometricCredentialsTest {
 
-  private lateinit var previousCredentialStore: BiometricCredentialLocalCredentialStore
+  private lateinit var previousCredentialStore: BiometricCredentialLocalStore
   private lateinit var previousKeyManager: BiometricCredentialKeyManager
   private lateinit var credentialStore: InMemoryCredentialStore
   private lateinit var keyManager: FakeKeyManager
@@ -172,7 +172,7 @@ class BiometricCredentialsTest {
   }
 
   private fun credential(id: String, userId: String) =
-    BiometricCredentialLocalCredential(
+    BiometricCredentialLocalRecord(
       id = id,
       localKeyId = "tdlk_$id",
       userId = userId,
@@ -184,13 +184,13 @@ class BiometricCredentialsTest {
   private fun biometricCredential(id: String) =
     BiometricCredential(id = id, appIdentifier = APP_IDENTIFIER, createdAt = 1, updatedAt = 1)
 
-  private class InMemoryCredentialStore : BiometricCredentialLocalCredentialStore {
-    val credentials = mutableListOf<BiometricCredentialLocalCredential>()
+  private class InMemoryCredentialStore : BiometricCredentialLocalStore {
+    val credentials = mutableListOf<BiometricCredentialLocalRecord>()
     var deleteFails = false
 
-    override fun all(): List<BiometricCredentialLocalCredential> = credentials.toList()
+    override fun all(): List<BiometricCredentialLocalRecord> = credentials.toList()
 
-    override fun save(credential: BiometricCredentialLocalCredential) {
+    override fun save(credential: BiometricCredentialLocalRecord) {
       credentials.removeAll { it.id == credential.id }
       credentials += credential
     }

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartView.kt
@@ -365,7 +365,7 @@ private fun dismissTrailingContent(
 }
 
 /**
- * Resolves whether biometric-credential sign-in can be offered on the auth start screen.
+ * Resolves whether biometric sign-in can be offered on the auth start screen.
  *
  * Starts from fast local availability and then validates the local credential against the server,
  * cleaning up stale local state when the server no longer recognizes it.

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthStartViewModel.kt
@@ -120,7 +120,7 @@ internal class AuthStartViewModel(private val ioDispatcher: CoroutineDispatcher 
   }
 
   /**
-   * Signs in with the locally enrolled biometric-credential (biometric) credential.
+   * Signs in with the locally enrolled biometric credential.
    *
    * User-canceled biometric prompts reset the state silently instead of surfacing an error.
    */
@@ -457,7 +457,7 @@ internal class AuthStartViewModel(private val ioDispatcher: CoroutineDispatcher 
       data class SignUpSuccess(val signUp: SignUp?) : Success
     }
 
-    /** States specific to biometric-credential (biometric) sign-in. */
+    /** States specific to biometric sign-in. */
     sealed interface BiometricCredentialState : AuthState {
       data object Loading : BiometricCredentialState
     }

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
@@ -226,7 +226,7 @@ internal class AuthState(
   }
 
   /**
-   * Routes to the biometric-credential enrollment prompt when it should be offered after a
+   * Routes to the biometric credential enrollment prompt when it should be offered after a
    * completed auth flow. Returns `true` when the prompt was routed to.
    */
   @Suppress("ReturnCount")

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -63,8 +63,8 @@ private val authViewProcessIdentifier = UUID.randomUUID().toString()
  *
  * When using this as a non-dismissible root authentication view, observe
  * [Clerk.isAuthFlowCompleteFlow] to choose between this view and authenticated content. A session
- * can become active while post-auth steps — session tasks or the biometric-credential (biometric)
- * enrollment prompt — still need to be shown.
+ * can become active while post-auth steps — session tasks or the biometric credential enrollment
+ * prompt — still need to be shown.
  *
  * @param initialIdentifier Optional initial value for the identifier field. Phone-like values are
  *   routed to the phone number field automatically.

--- a/source/ui/src/main/java/com/clerk/ui/auth/biometriccredential/BiometricCredentialEnrollmentPrompt.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/biometriccredential/BiometricCredentialEnrollmentPrompt.kt
@@ -8,13 +8,13 @@ import com.clerk.api.log.ClerkLog
 import com.clerk.api.session.Session
 import com.clerk.api.user.User
 
-/** Decides whether the post-auth biometric-credential enrollment prompt should be offered. */
+/** Decides whether the post-auth biometric credential enrollment prompt should be offered. */
 internal object BiometricCredentialEnrollmentPrompt {
 
   /**
    * Returns whether the enrollment prompt should be offered after a completed auth flow.
    *
-   * The prompt is offered when the biometric-credential feature and the matching prompt setting are
+   * The prompt is offered when the biometric sign-in feature and the matching prompt setting are
    * enabled, the device supports biometric authentication, the session allows enrollment, and this
    * device doesn't already hold a usable credential for the user.
    */
@@ -61,7 +61,7 @@ internal object BiometricCredentialEnrollmentPrompt {
   }
 
   private fun skip(reason: String): Boolean {
-    ClerkLog.d("Biometric-credential enrollment prompt not offered: $reason")
+    ClerkLog.d("Biometric credential enrollment prompt not offered: $reason")
     return false
   }
 

--- a/source/ui/src/main/java/com/clerk/ui/auth/biometriccredential/BiometricCredentialEnrollmentViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/biometriccredential/BiometricCredentialEnrollmentViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-/** ViewModel driving the post-auth biometric-credential enrollment prompt. */
+/** ViewModel driving the post-auth biometric credential enrollment prompt. */
 internal class BiometricCredentialEnrollmentViewModel : ViewModel() {
 
   private val _state = MutableStateFlow<State>(State.Idle)

--- a/source/ui/src/main/java/com/clerk/ui/userprofile/security/delete/DeleteAccountViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/security/delete/DeleteAccountViewModel.kt
@@ -30,20 +30,20 @@ internal class DeleteAccountViewModel : ViewModel() {
             _state.value = State.Error(it.errorMessage)
           }
           .onSuccess {
-            forgetBiometricCredentialLocalCredentials(deletedUserId)
+            forgetBiometricLocalCredentials(deletedUserId)
             _state.value = State.Success
           }
       }
     }
   }
 
-  private fun forgetBiometricCredentialLocalCredentials(deletedUserId: String) {
+  private fun forgetBiometricLocalCredentials(deletedUserId: String) {
     runCatching {
         Clerk.biometricCredentials.forgetLocalCredentialsAfterAccountDeletion(deletedUserId)
       }
       .onFailure {
         ClerkLog.e(
-          "Failed to delete biometric-credential local credentials after account deletion. " +
+          "Failed to delete biometric local credentials after account deletion. " +
             "This is non-critical."
         )
       }


### PR DESCRIPTION
### What & why

- Follow-up cleanup to the biometric credential rename that removes redundant internal naming and terminology.
- Renames the internal local credential storage types:
  - `BiometricCredentialLocalCredential` → `BiometricCredentialLocalRecord`
  - `BiometricCredentialLocalCredentialStore` → `BiometricCredentialLocalStore`
- Simplifies documentation, logs, and error messages from “biometric-credential sign-in” to “biometric sign-in.”
- Preserves all public APIs, deprecated compatibility shims, persisted storage keys, Keystore aliases, and backend wire identifiers.
- Verified with API/UI tests, Paparazzi, Spotless, and Detekt.

### What to focus on

- Confirm the internal record/store naming is clear and consistent with the iOS implementation.
- Verify that compatibility-sensitive trusted-device storage and wire identifiers remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized terminology for biometric sign-in, credential enrollment, availability, and verification.
  * Clarified descriptions of locally enrolled biometric credentials.

* **Bug Fixes**
  * Improved naming and messaging for local biometric credential storage and cleanup.
  * Updated related error and log messages for clearer biometric authentication feedback.
  * Refined biometric credential enrollment and sign-in descriptions without changing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->