### PR TITLE
feat(protect): integrate mobile challenges

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ uiToolingPreviewAndroid = "1.11.4"
 kotlinStdlib = "2.4.10"
 kotlinTest = "2.4.10"
 paparazziPlugin = "2.0.0-alpha05"
+protect = "0.1.0-alpha.1"
 
 # Build Versions -- Do not delete
 jdk = "17"
@@ -63,6 +64,7 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 clerk-automap-annotations = { module = "com.clerk:automap-annotations", version.ref = "automap" }
 clerk-automap-processor = { module = "com.clerk:automap-processor", version.ref = "automap" }
+clerk-protect = { module = "com.clerk.protect:protect", version.ref = "protect" }
 coil = "io.coil-kt.coil3:coil-compose:3.5.0"
 coil-okhttp = "io.coil-kt.coil3:coil-network-okhttp:3.5.0"
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,12 @@ pluginManagement {
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
+    // Protect is developed in its private monorepo and currently publishes only
+    // to Maven local. Opt in explicitly while integrating it so a developer's
+    // local artifact can never shadow a released dependency by default.
+    if (providers.gradleProperty("clerkProtectMavenLocal").orNull == "true") {
+      mavenLocal { content { includeGroup("com.clerk.protect") } }
+    }
     google()
     mavenCentral()
   }

--- a/source/api/build.gradle.kts
+++ b/source/api/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
   implementation(libs.androidx.lifecycle.viewmodel)
   implementation(libs.androidx.playServicesAuth)
   implementation(libs.clerk.automap.annotations)
+  implementation(libs.clerk.protect)
   implementation(libs.google.identity)
   implementation(libs.google.playIntegrity)
   implementation(libs.jwt.decode)

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -34,6 +34,7 @@ import com.clerk.api.network.model.factor.isResetFactor
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.organizations.Organization
 import com.clerk.api.organizations.OrganizationMembership
+import com.clerk.api.protect.ClerkProtect
 import com.clerk.api.session.Session
 import com.clerk.api.session.SessionTokenFetcher
 import com.clerk.api.session.SessionTokensCache
@@ -846,6 +847,7 @@ object Clerk {
     SSOService.cancelPendingAuthentication()
     ExternalAccountService.cancelPendingExternalAccountConnection()
     DeviceAttestationHelper.clearCache()
+    ClerkProtect.reset()
     LocaleProvider.cleanup()
     ClerkApi.reset()
     environment = null
@@ -993,6 +995,16 @@ object Clerk {
     configurationManager.clearDeviceToken()
 
   /**
+   * Sets the customer-signed Protect assertion attached to Clerk requests, or clears it with null.
+   *
+   * This is intended for deterministic Protect coverage in application test suites. Assertions
+   * remain subject to the instance's Protect rules and do not directly choose a verdict.
+   */
+  fun setProtectAssertion(token: String?) {
+    ClerkProtect.setAssertion(token)
+  }
+
+  /**
    * Returns the current device token from encrypted storage, or null if unavailable.
    *
    * This is used by the Expo bridge to sync the native client token with the JS SDK.
@@ -1014,6 +1026,10 @@ object Clerk {
   internal fun updateEnvironment(environment: Environment) {
     val previousEnvironment = this.environment
     this.environment = environment
+    ClerkProtect.initialize(
+      environment = environment,
+      fapiOrigin = runCatching { baseUrl }.getOrNull()?.takeIf(String::isNotBlank),
+    )
     _organizationLogoUrlFlow.value = environment.displayConfig.logoImageUrl
     _multiSessionModeIsEnabled.value = !environment.authConfig.singleSessionMode
     sharedSessionSyncCoordinator?.handleEnvironmentChange(previousEnvironment, environment)
@@ -1029,14 +1045,14 @@ object Clerk {
   private fun cacheStateIfReady() {
     val cachedEnvironment = environment
     val cachedClient = _clientFlow.value
-    val cachedResources = cachedClient?.let { client ->
-      cachedEnvironment?.let { environment -> client to environment }
-    }
+    val cachedResources =
+      cachedClient?.let { client ->
+        cachedEnvironment?.let { environment -> client to environment }
+      }
     val cachedPublishableKey = publishableKey
     val cachedBaseUrl = runCatching { baseUrl }.getOrNull()
-    val cachedConfiguration = cachedPublishableKey?.let { key ->
-      cachedBaseUrl?.let { url -> key to url }
-    }
+    val cachedConfiguration =
+      cachedPublishableKey?.let { key -> cachedBaseUrl?.let { url -> key to url } }
     val cachedServerFetchAtMillis = lastClientServerFetchAtMillis
     val state =
       if (
@@ -1142,9 +1158,8 @@ object Clerk {
   }
 
   private fun Client.withResolvedActiveSession(previousSession: Session?): Client {
-    val currentActiveSessionId = lastActiveSessionId?.takeIf { activeSessionId ->
-      sessions.any { it.id == activeSessionId }
-    }
+    val currentActiveSessionId =
+      lastActiveSessionId?.takeIf { activeSessionId -> sessions.any { it.id == activeSessionId } }
     val resolvedActiveSessionId =
       currentActiveSessionId
         ?: previousSession?.id?.takeIf { previousSessionId ->
@@ -1353,9 +1368,8 @@ fun Map<String, UserSettings.SocialConfig>.toOAuthProvidersList(): List<OAuthPro
     .filter { it.enabled && it.authenticatable }
     .map { OAuthProvider.fromStrategy(it.strategy) }
 
-fun SignIn.identifyingFirstFactor(strategy: String): Factor? = supportedFirstFactors?.firstOrNull {
-  it.strategy == strategy && it.safeIdentifier == identifier
-}
+fun SignIn.identifyingFirstFactor(strategy: String): Factor? =
+  supportedFirstFactors?.firstOrNull { it.strategy == strategy && it.safeIdentifier == identifier }
 
 val SignIn.resetPasswordFactor: Factor?
   get() =

--- a/source/api/src/main/kotlin/com/clerk/api/network/ApiParams.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ApiParams.kt
@@ -29,6 +29,7 @@ internal object ApiParams {
   internal const val CODE_CHALLENGE = "code_challenge"
   internal const val CODE_CHALLENGE_METHOD = "code_challenge_method"
   internal const val CLERK_SESSION_ID = "_clerk_session_id"
+  internal const val PROOF_TOKEN = "proof_token"
 
   internal const val ROLE = "role"
 

--- a/source/api/src/main/kotlin/com/clerk/api/network/ApiPaths.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ApiPaths.kt
@@ -49,6 +49,7 @@ internal object ApiPaths {
       internal const val ATTEMPT_SECOND_FACTOR = "${WITH_ID}/attempt_second_factor"
       internal const val PREPARE_FIRST_FACTOR = "${WITH_ID}/prepare_first_factor"
       internal const val PREPARE_SECOND_FACTOR = "${WITH_ID}/prepare_second_factor"
+      internal const val PROTECT_CHECK = "${WITH_ID}/protect_check"
       internal const val RESET_PASSWORD = "${WITH_ID}/reset_password"
     }
 
@@ -69,6 +70,7 @@ internal object ApiPaths {
       internal const val WITH_ID = "${BASE}/{id}"
       internal const val PREPARE_VERIFICATION = "${WITH_ID}/prepare_verification"
       internal const val ATTEMPT_VERIFICATION = "${WITH_ID}/attempt_verification"
+      internal const val PROTECT_CHECK = "${WITH_ID}/protect_check"
     }
   }
 

--- a/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/ClerkApi.kt
@@ -19,6 +19,7 @@ import com.clerk.api.network.middleware.outgoing.UrlAppendingMiddleware
 import com.clerk.api.network.middleware.outgoing.VersioningUserAgentMiddleware
 import com.clerk.api.network.serialization.ClerkApiResultCallAdapterFactory
 import com.clerk.api.network.serialization.ClerkApiResultConverterFactory
+import com.clerk.protect.interceptor.ProtectOkHttpInterceptor
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
@@ -150,6 +151,8 @@ internal object ClerkApi {
               )
             )
           }
+
+          addInterceptor(ProtectOkHttpInterceptor())
         }
         .build()
 

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/SignInApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/SignInApi.kt
@@ -9,6 +9,7 @@ import retrofit2.http.Field
 import retrofit2.http.FieldMap
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -47,6 +48,13 @@ internal interface SignInApi {
   suspend fun fetchSignIn(
     @Path(ApiParams.ID) id: String,
     @Query("rotating_token_nonce") rotatingTokenNonce: String? = null,
+  ): ClerkResult<SignIn, ClerkErrorResponse>
+
+  @FormUrlEncoded
+  @PATCH(ApiPaths.Client.SignIn.PROTECT_CHECK)
+  suspend fun submitProtectCheck(
+    @Path(ApiParams.ID) id: String,
+    @Field(ApiParams.PROOF_TOKEN) proofToken: String,
   ): ClerkResult<SignIn, ClerkErrorResponse>
 
   @FormUrlEncoded

--- a/source/api/src/main/kotlin/com/clerk/api/network/api/SignUpApi.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/api/SignUpApi.kt
@@ -36,6 +36,13 @@ internal interface SignUpApi {
     @FieldMap fields: Map<String, String>,
   ): ClerkResult<SignUp, ClerkErrorResponse>
 
+  @FormUrlEncoded
+  @PATCH(ApiPaths.Client.SignUp.PROTECT_CHECK)
+  suspend fun submitProtectCheck(
+    @Path(ApiParams.ID) id: String,
+    @Field(ApiParams.PROOF_TOKEN) proofToken: String,
+  ): ClerkResult<SignUp, ClerkErrorResponse>
+
   /** @see [com.clerk.api.signup.prepareVerification] */
   @FormUrlEncoded
   @POST(ApiPaths.Client.SignUp.PREPARE_VERIFICATION)

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/DisplayConfig.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/DisplayConfig.kt
@@ -58,6 +58,9 @@ internal data class DisplayConfig(
 
   /** Google One Tap client ID for enhanced sign-in (optional) */
   @SerialName("google_one_tap_client_id") val googleOneTapClientId: String?,
+
+  /** Frontend API URL used as a fallback when configuring Clerk Protect. */
+  @SerialName("frontend_api_url") val frontendApiUrl: String? = null,
 )
 
 /**

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/Environment.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/Environment.kt
@@ -5,6 +5,7 @@ import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 @Serializable
 internal data class Environment(
@@ -13,6 +14,8 @@ internal data class Environment(
   @SerialName("user_settings") val userSettings: UserSettings,
   @SerialName("organization_settings")
   val organizationSettings: OrganizationSettings = OrganizationSettings(),
+  @SerialName("protect_config") val protectConfig: JsonObject? = null,
+  @SerialName("frontend_api") val frontendApi: String? = null,
 ) {
   val passkeyIsEnabled: Boolean
     get() = userSettings.attributes.any { (key, value) -> key == "passkey" && value.enabled }

--- a/source/api/src/main/kotlin/com/clerk/api/protect/ClerkProtect.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/protect/ClerkProtect.kt
@@ -1,0 +1,76 @@
+package com.clerk.api.protect
+
+import android.view.ViewGroup
+import androidx.annotation.RestrictTo
+import com.clerk.api.network.model.environment.Environment
+import com.clerk.protect.Protect
+import com.clerk.protect.ProtectCheck
+import com.clerk.protect.ProtectException
+import com.clerk.protect.asProtectHost
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.longOrNull
+
+/** Internal bridge between Clerk Android resources and the Protect dispatcher. */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object ClerkProtect {
+
+  /** Whether the latest Clerk environment enabled Protect. */
+  val isEnabled: Boolean
+    get() = Protect.isEnabled
+
+  /** Executes one Protect challenge inside [container] and returns its proof token. */
+  suspend fun executeProtectCheck(check: ProtectCheckResource, container: ViewGroup): String =
+    Protect.executeProtectCheck(check.toProtectCheck(), container.asProtectHost())
+
+  /** Returns Protect's stable error code for [throwable], if it originated in Protect. */
+  fun errorCode(throwable: Throwable): String? = (throwable as? ProtectException)?.code
+
+  internal fun initialize(environment: Environment, fapiOrigin: String?) {
+    val protectEnvironment =
+      buildMap<String, Any?> {
+        runCatching { environment.protectConfig }
+          .getOrNull()
+          ?.let { put("protect_config", it.toAnyMap()) }
+        runCatching { environment.displayConfig.frontendApiUrl }
+          .getOrNull()
+          ?.let { put("display_config", mapOf("frontend_api_url" to it)) }
+        runCatching { environment.frontendApi }.getOrNull()?.let { put("frontend_api", it) }
+      }
+    Protect.initialize(protectEnvironment, fapiOrigin)
+  }
+
+  internal fun reset() {
+    Protect.setAssertion(null)
+    Protect.initialize(emptyMap())
+  }
+
+  internal fun setAssertion(token: String?) {
+    Protect.setAssertion(token)
+  }
+}
+
+internal fun ProtectCheckResource.toProtectCheck(): ProtectCheck =
+  ProtectCheck.fromJson(raw.toAnyMap())
+
+private fun JsonObject.toAnyMap(): Map<String, Any?> = mapValues { (_, value) ->
+  value.toAnyValue()
+}
+
+private fun JsonElement.toAnyValue(): Any? =
+  when (this) {
+    is JsonObject -> toAnyMap()
+    is JsonArray -> map(JsonElement::toAnyValue)
+    is JsonNull -> null
+    is JsonPrimitive ->
+      if (isString) {
+        content
+      } else {
+        booleanOrNull ?: longOrNull ?: doubleOrNull ?: content
+      }
+  }

--- a/source/api/src/main/kotlin/com/clerk/api/protect/ProtectCheckResource.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/protect/ProtectCheckResource.kt
@@ -1,0 +1,39 @@
+package com.clerk.api.protect
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Opaque Protect challenge data returned by the Clerk API.
+ *
+ * The payload is intentionally preserved without interpreting its fields so newer Protect
+ * challenges remain compatible with older Clerk Android SDK versions.
+ */
+@Serializable(with = ProtectCheckResourceSerializer::class)
+class ProtectCheckResource internal constructor(internal val raw: JsonObject) {
+  override fun equals(other: Any?): Boolean =
+    this === other || (other is ProtectCheckResource && raw == other.raw)
+
+  override fun hashCode(): Int = raw.hashCode()
+
+  override fun toString(): String = "ProtectCheckResource([REDACTED])"
+}
+
+internal object ProtectCheckResourceSerializer : KSerializer<ProtectCheckResource> {
+  override val descriptor: SerialDescriptor =
+    SerialDescriptor(
+      "com.clerk.api.protect.ProtectCheckResource",
+      JsonObject.serializer().descriptor,
+    )
+
+  override fun serialize(encoder: Encoder, value: ProtectCheckResource) {
+    encoder.encodeSerializableValue(JsonObject.serializer(), value.raw)
+  }
+
+  override fun deserialize(decoder: Decoder): ProtectCheckResource =
+    ProtectCheckResource(decoder.decodeSerializableValue(JsonObject.serializer()))
+}

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignIn.kt
@@ -23,6 +23,7 @@ import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.passkeys.GoogleCredentialAuthenticationService
 import com.clerk.api.passkeys.PasskeyService
+import com.clerk.api.protect.ProtectCheckResource
 import com.clerk.api.sso.GoogleSignInService
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.OAuthResult
@@ -83,6 +84,7 @@ import kotlinx.serialization.encoding.Encoder
  * @property userData An object containing information about the user of the current sign-in.
  * @property createdSessionId The identifier of the session that was created upon completion of the
  *   current sign-in.
+ * @property protectCheck Opaque Protect challenge data when this sign-in requires a Protect check.
  */
 @Serializable(with = SignInSerializer::class)
 @ConsistentCopyVisibility
@@ -147,6 +149,9 @@ private constructor(
    */
   @SerialName("created_session_id") val createdSessionId: String? = null,
 
+  /** Opaque Protect challenge data when this sign-in requires a Protect check. */
+  @SerialName("protect_check") val protectCheck: ProtectCheckResource? = null,
+
   /** The status value exactly as returned by the Clerk API. */
   val statusRawValue: String,
 ) {
@@ -162,6 +167,7 @@ private constructor(
     secondFactorVerification: Verification? = null,
     userData: UserData? = null,
     createdSessionId: String? = null,
+    protectCheck: ProtectCheckResource? = null,
   ) : this(
     id = id,
     status = status,
@@ -173,6 +179,7 @@ private constructor(
     secondFactorVerification = secondFactorVerification,
     userData = userData,
     createdSessionId = createdSessionId,
+    protectCheck = protectCheck,
     statusRawValue = status.serializedValue,
   )
 
@@ -187,6 +194,7 @@ private constructor(
     secondFactorVerification: Verification? = this.secondFactorVerification,
     userData: UserData? = this.userData,
     createdSessionId: String? = this.createdSessionId,
+    protectCheck: ProtectCheckResource? = this.protectCheck,
   ): SignIn =
     SignIn(
       id = id,
@@ -199,6 +207,7 @@ private constructor(
       secondFactorVerification = secondFactorVerification,
       userData = userData,
       createdSessionId = createdSessionId,
+      protectCheck = protectCheck,
       statusRawValue = if (status == this.status) statusRawValue else status.serializedValue,
     )
 
@@ -254,6 +263,9 @@ private constructor(
 
     /** Device trust verification is required. */
     @SerialName("needs_client_trust") NEEDS_CLIENT_TRUST("needs_client_trust"),
+
+    /** A Protect challenge must be completed before the sign-in can continue. */
+    @SerialName("needs_protect_check") NEEDS_PROTECT_CHECK("needs_protect_check"),
 
     /** The sign-in process is in an unknown state. */
     UNKNOWN("unknown");
@@ -730,6 +742,7 @@ private constructor(
         secondFactorVerification = payload.secondFactorVerification,
         userData = payload.userData,
         createdSessionId = payload.createdSessionId,
+        protectCheck = payload.protectCheck,
         statusRawValue = payload.status,
       )
 
@@ -874,6 +887,7 @@ internal data class SignInPayload(
   @SerialName("second_factor_verification") val secondFactorVerification: Verification? = null,
   @SerialName("user_data") val userData: SignIn.UserData? = null,
   @SerialName("created_session_id") val createdSessionId: String? = null,
+  @SerialName("protect_check") val protectCheck: ProtectCheckResource? = null,
 )
 
 internal object SignInSerializer : KSerializer<SignIn> {
@@ -894,6 +908,7 @@ internal object SignInSerializer : KSerializer<SignIn> {
         secondFactorVerification = value.secondFactorVerification,
         userData = value.userData,
         createdSessionId = value.createdSessionId,
+        protectCheck = value.protectCheck,
       ),
     )
   }

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
@@ -22,6 +22,17 @@ import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.sso.OAuthResult
 import com.clerk.api.sso.SSOService
 
+/**
+ * Submits the proof produced by Protect for this sign-in.
+ *
+ * @param proofToken The proof token returned after completing the Protect challenge.
+ * @return A [ClerkResult] containing the updated [SignIn] object on success, or a
+ *   [ClerkErrorResponse] on failure.
+ */
+suspend fun SignIn.submitProtectCheck(proofToken: String): ClerkResult<SignIn, ClerkErrorResponse> {
+  return ClerkApi.signIn.submitProtectCheck(id = id, proofToken = proofToken)
+}
+
 // region Factor Selection Extensions
 
 /**

--- a/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signup/SignUp.kt
@@ -12,6 +12,7 @@ import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.verification.Verification
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.protect.ProtectCheckResource
 import com.clerk.api.sso.GoogleSignInService
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.OAuthResult
@@ -179,6 +180,9 @@ data class SignUp(
    * @return The abandonment timestamp in milliseconds since epoch, null if not abandoned.
    */
   @SerialName("abandoned_at") val abandonedAt: Long? = null,
+
+  /** Opaque Protect challenge data when this sign-up requires a Protect check. */
+  @SerialName("protect_check") val protectCheck: ProtectCheckResource? = null,
 ) {
   /**
    * Represents the current status of the sign-up process.

--- a/source/api/src/main/kotlin/com/clerk/api/signup/SignUpExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signup/SignUpExtensions.kt
@@ -11,6 +11,17 @@ import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
 
 /**
+ * Submits the proof produced by Protect for this sign-up.
+ *
+ * @param proofToken The proof token returned after completing the Protect challenge.
+ * @return A [ClerkResult] containing the updated [SignUp] object on success, or a
+ *   [ClerkErrorResponse] on failure.
+ */
+suspend fun SignUp.submitProtectCheck(proofToken: String): ClerkResult<SignUp, ClerkErrorResponse> {
+  return ClerkApi.signUp.submitProtectCheck(id = id, proofToken = proofToken)
+}
+
+/**
  * Sends a verification code to the specified email or phone.
  *
  * @param block Builder block to configure where to send the code.

--- a/source/api/src/test/java/com/clerk/api/network/api/ProtectCheckApiTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/api/ProtectCheckApiTest.kt
@@ -1,0 +1,118 @@
+package com.clerk.api.network.api
+
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.serialization.ClerkApiResultCallAdapterFactory
+import com.clerk.api.network.serialization.ClerkApiResultConverterFactory
+import com.clerk.api.network.serialization.ClerkResult
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import kotlinx.coroutines.test.runTest
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+class ProtectCheckApiTest {
+
+  @Test
+  fun `sign in protect check patches proof token`() = runTest {
+    val interceptor = CapturingInterceptor(wrapped(SIGN_IN_RESPONSE))
+    val api = retrofit(interceptor).create(SignInApi::class.java)
+
+    val result = api.submitProtectCheck(id = "sia_123", proofToken = "proof/+ token")
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals("PATCH", interceptor.method)
+    assertEquals("/v1/client/sign_ins/sia_123/protect_check", interceptor.path)
+    assertEquals("proof/+ token", interceptor.formBody["proof_token"])
+  }
+
+  @Test
+  fun `sign up protect check patches proof token`() = runTest {
+    val interceptor = CapturingInterceptor(wrapped(SIGN_UP_RESPONSE))
+    val api = retrofit(interceptor).create(SignUpApi::class.java)
+
+    val result = api.submitProtectCheck(id = "sua_123", proofToken = "proof-token")
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals("PATCH", interceptor.method)
+    assertEquals("/v1/client/sign_ups/sua_123/protect_check", interceptor.path)
+    assertEquals("proof-token", interceptor.formBody["proof_token"])
+  }
+
+  private fun retrofit(interceptor: CapturingInterceptor): Retrofit {
+    return Retrofit.Builder()
+      .baseUrl("https://example.com/v1/")
+      .client(OkHttpClient.Builder().addInterceptor(interceptor).build())
+      .addCallAdapterFactory(ClerkApiResultCallAdapterFactory)
+      .addConverterFactory(ClerkApiResultConverterFactory)
+      .addConverterFactory(
+        ClerkApi.json.asConverterFactory("application/json; charset=utf-8".toMediaType())
+      )
+      .build()
+  }
+
+  private class CapturingInterceptor(private val responseBody: String) : Interceptor {
+    lateinit var method: String
+    lateinit var path: String
+    lateinit var formBody: Map<String, String>
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+      val request = chain.request()
+      method = request.method
+      path = request.url.encodedPath
+      formBody = request.body.readFormBody()
+
+      return Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .body(responseBody.toResponseBody("application/json".toMediaType()))
+        .build()
+    }
+
+    private fun okhttp3.RequestBody?.readFormBody(): Map<String, String> {
+      if (this == null) return emptyMap()
+      val buffer = Buffer()
+      writeTo(buffer)
+      return buffer
+        .readUtf8()
+        .split("&")
+        .filter { it.isNotEmpty() }
+        .associate { pair ->
+          val (key, value) = pair.split("=", limit = 2) + listOf("")
+          URLDecoder.decode(key, StandardCharsets.UTF_8.name()) to
+            URLDecoder.decode(value, StandardCharsets.UTF_8.name())
+        }
+    }
+  }
+
+  private companion object {
+    fun wrapped(response: String): String = """{"response": $response, "client": null}"""
+
+    const val SIGN_IN_RESPONSE = """{"id":"sia_123","status":"needs_first_factor"}"""
+
+    const val SIGN_UP_RESPONSE =
+      """
+      {
+        "id": "sua_123",
+        "status": "complete",
+        "required_fields": [],
+        "optional_fields": [],
+        "missing_fields": [],
+        "unverified_fields": [],
+        "verifications": {},
+        "password_enabled": false
+      }
+      """
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/protect/ClerkProtectTest.kt
+++ b/source/api/src/test/java/com/clerk/api/protect/ClerkProtectTest.kt
@@ -1,0 +1,108 @@
+package com.clerk.api.protect
+
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.environment.AuthConfig
+import com.clerk.api.network.model.environment.DisplayConfig
+import com.clerk.api.network.model.environment.Environment
+import com.clerk.api.network.model.environment.UserSettings
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClerkProtectTest {
+
+  @After
+  fun tearDown() {
+    ClerkProtect.reset()
+  }
+
+  @Test
+  fun `environment configures Protect with native Specter origin`() {
+    ClerkProtect.initialize(
+      environment =
+        environment(
+          protectConfig =
+            buildJsonObject {
+              put(
+                "native",
+                buildJsonObject { put("specter_origin", "https://specter.example.com") },
+              )
+            }
+        ),
+      fapiOrigin = "https://fapi.example.com/path",
+    )
+
+    assertTrue(ClerkProtect.isEnabled)
+  }
+
+  @Test
+  fun `environment without Protect config disables Protect`() {
+    ClerkProtect.initialize(environment = environment(), fapiOrigin = "https://fapi.example.com")
+
+    assertFalse(ClerkProtect.isEnabled)
+  }
+
+  @Test
+  fun `resource converts recursively to the Protect check model`() {
+    val resource =
+      ClerkApi.json.decodeFromString<ProtectCheckResource>(
+        """
+        {
+          "status": "pending",
+          "token": " challenge-token ",
+          "sdk_url": "https://specter.example.com/challenge",
+          "expires_at": 1720000000000,
+          "ui_hints": {"reason": "device_new", "locale": "en-US"},
+          "runtime": "webview"
+        }
+        """
+          .trimIndent()
+      )
+
+    val check = resource.toProtectCheck()
+
+    assertEquals("pending", check.status)
+    assertEquals("challenge-token", check.token)
+    assertEquals("https://specter.example.com/challenge", check.sdkUrl.rawValue)
+    assertEquals(1720000000000, check.expiresAtMillis)
+    assertEquals(mapOf("reason" to "device_new", "locale" to "en-US"), check.uiHints)
+    assertEquals("webview", check.runtime)
+  }
+
+  private fun environment(
+    protectConfig: kotlinx.serialization.json.JsonObject? = null
+  ): Environment {
+    return Environment(
+      authConfig = AuthConfig(singleSessionMode = false),
+      displayConfig =
+        DisplayConfig(
+          applicationName = "Test App",
+          branded = true,
+          logoImageUrl = "https://example.com/logo.png",
+          homeUrl = "/",
+          privacyPolicyUrl = null,
+          termsUrl = null,
+          googleOneTapClientId = null,
+        ),
+      userSettings =
+        UserSettings(
+          attributes = emptyMap(),
+          signUp =
+            UserSettings.SignUpUserSettings(
+              customActionRequired = false,
+              progressive = false,
+              mode = "public",
+              legalConsentEnabled = false,
+            ),
+          social = emptyMap(),
+          actions = UserSettings.Actions(),
+          passkeySettings = null,
+        ),
+      protectConfig = protectConfig,
+    )
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/protect/ProtectCheckResourceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/protect/ProtectCheckResourceTest.kt
@@ -1,0 +1,62 @@
+package com.clerk.api.protect
+
+import com.clerk.api.network.ClerkApi
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class ProtectCheckResourceTest {
+
+  @Test
+  fun `resource preserves the complete opaque payload`() {
+    val payload =
+      """
+      {
+        "status": "pending",
+        "token": "challenge-token",
+        "sdk_url": "https://example.com/protect.js",
+        "expires_at": 1720000000000,
+        "ui_hints": {"theme": "dark"},
+        "future_field": {"nested": [1, true, null]}
+      }
+      """
+        .trimIndent()
+
+    val resource = ClerkApi.json.decodeFromString<ProtectCheckResource>(payload)
+    val encoded = ClerkApi.json.encodeToString(ProtectCheckResource.serializer(), resource)
+
+    assertEquals(ClerkApi.json.parseToJsonElement(payload).jsonObject, resource.raw)
+    assertEquals(
+      ClerkApi.json.parseToJsonElement(payload),
+      ClerkApi.json.parseToJsonElement(encoded),
+    )
+  }
+
+  @Test
+  fun `resource has structural equality`() {
+    val first =
+      ClerkApi.json.decodeFromString<ProtectCheckResource>(
+        """{"status":"pending","token":"token"}"""
+      )
+    val second =
+      ClerkApi.json.decodeFromString<ProtectCheckResource>(
+        """{"status":"pending","token":"token"}"""
+      )
+
+    assertEquals(first, second)
+    assertEquals(first.hashCode(), second.hashCode())
+  }
+
+  @Test
+  fun `resource redacts its payload from string output`() {
+    val resource =
+      ClerkApi.json.decodeFromString<ProtectCheckResource>(
+        """{"token":"sensitive-token","sdk_url":"https://example.com/protect.js"}"""
+      )
+
+    assertEquals("ProtectCheckResource([REDACTED])", resource.toString())
+    assertFalse(resource.toString().contains("sensitive-token"))
+    assertFalse(resource.toString().contains("protect.js"))
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/signin/SignInSerializationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signin/SignInSerializationTest.kt
@@ -23,6 +23,36 @@ class SignInSerializationTest {
   }
 
   @Test
+  fun `sign in decodes protect status and preserves the opaque challenge`() {
+    val signIn =
+      ClerkApi.json.decodeFromString<SignIn>(
+        """
+        {
+          "id": "sia_123",
+          "status": "needs_protect_check",
+          "protect_check": {
+            "status": "pending",
+            "token": "challenge-token",
+            "sdk_url": "https://example.com/protect.js",
+            "future_field": {"nested": true}
+          }
+        }
+        """
+          .trimIndent()
+      )
+
+    assertEquals(SignIn.Status.NEEDS_PROTECT_CHECK, signIn.status)
+    assertEquals("needs_protect_check", signIn.statusRawValue)
+
+    val copied = signIn.copy(identifier = "user@example.com")
+    val encoded = ClerkApi.json.encodeToString(SignIn.serializer(), copied)
+    val decoded = ClerkApi.json.decodeFromString<SignIn>(encoded)
+
+    assertEquals(signIn.protectCheck, decoded.protectCheck)
+    assertEquals("user@example.com", decoded.identifier)
+  }
+
+  @Test
   fun `sign in preserves unknown status values`() {
     val json =
       """

--- a/source/api/src/test/java/com/clerk/api/signup/SignUpSerializationTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signup/SignUpSerializationTest.kt
@@ -1,0 +1,45 @@
+package com.clerk.api.signup
+
+import com.clerk.api.network.ClerkApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class SignUpSerializationTest {
+
+  @Test
+  fun `sign up preserves protect check as a missing requirement`() {
+    val signUp =
+      ClerkApi.json.decodeFromString<SignUp>(
+        """
+        {
+          "id": "sua_123",
+          "status": "missing_requirements",
+          "required_fields": [],
+          "optional_fields": [],
+          "missing_fields": ["protect_check"],
+          "unverified_fields": [],
+          "verifications": {},
+          "password_enabled": false,
+          "protect_check": {
+            "status": "pending",
+            "token": "challenge-token",
+            "sdk_url": "https://example.com/protect.js",
+            "future_field": ["preserved"]
+          }
+        }
+        """
+          .trimIndent()
+      )
+
+    assertEquals(SignUp.Status.MISSING_REQUIREMENTS, signUp.status)
+    assertEquals(listOf("protect_check"), signUp.missingFields)
+    assertNotNull(signUp.protectCheck)
+
+    val encoded = ClerkApi.json.encodeToString(SignUp.serializer(), signUp)
+    val decoded = ClerkApi.json.decodeFromString<SignUp>(encoded)
+
+    assertEquals(signUp.protectCheck, decoded.protectCheck)
+    assertEquals(signUp.missingFields, decoded.missingFields)
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthState.kt
@@ -180,6 +180,11 @@ internal class AuthState(
     session: Session? = signIn.correspondingSession(),
     onAuthComplete: () -> Unit,
   ) {
+    if (signIn.protectCheck != null) {
+      routeToProtectCheck(AuthDestination.SignInProtectCheck)
+      return
+    }
+
     when (signIn.status) {
       SignIn.Status.COMPLETE -> {
         handlePostAuthCompletion(
@@ -196,6 +201,7 @@ internal class AuthState(
       SignIn.Status.NEEDS_SECOND_FACTOR -> routeToSecondFactorOrHelp(signIn)
       SignIn.Status.NEEDS_NEW_PASSWORD -> backStack.add(AuthDestination.SignInSetNewPassword)
       SignIn.Status.NEEDS_CLIENT_TRUST -> routeToClientTrustOrHelp(signIn)
+      SignIn.Status.NEEDS_PROTECT_CHECK -> routeToProtectCheck(AuthDestination.SignInProtectCheck)
       SignIn.Status.UNKNOWN -> Unit
     }
   }
@@ -295,6 +301,11 @@ internal class AuthState(
     session: Session? = signUp.correspondingSession(),
     onAuthComplete: () -> Unit,
   ) {
+    if (signUp.protectCheck != null) {
+      routeToProtectCheck(AuthDestination.SignUpProtectCheck)
+      return
+    }
+
     when (signUp.status) {
       SignUp.Status.ABANDONED -> resetToRoot()
       SignUp.Status.MISSING_REQUIREMENTS -> handleMissingRequirements(signUp)
@@ -307,13 +318,17 @@ internal class AuthState(
           completedWithSignUp = true,
           onAuthComplete = onAuthComplete,
         )
-        return
       }
-      SignUp.Status.UNKNOWN -> return
+      SignUp.Status.UNKNOWN -> Unit
     }
   }
 
   private fun handleMissingRequirements(signUp: SignUp) {
+    if (signUp.protectCheck != null || "protect_check" in signUp.missingFields) {
+      routeToProtectCheck(AuthDestination.SignUpProtectCheck)
+      return
+    }
+
     val firstFieldToCollect = signUp.firstFieldToCollect
     if (firstFieldToCollect != null) {
       handleFieldCollection(signUp)
@@ -323,6 +338,12 @@ internal class AuthState(
     val firstFieldToVerify = signUp.firstFieldToVerify
     if (firstFieldToVerify != null) {
       handleFieldVerification(signUp, firstFieldToVerify)
+    }
+  }
+
+  private fun routeToProtectCheck(destination: NavKey) {
+    if (backStack.lastOrNull() != destination) {
+      backStack.add(destination)
     }
   }
 

--- a/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt
@@ -35,6 +35,8 @@ import com.clerk.ui.core.footer.DevelopmentModeWarningBackground
 import com.clerk.ui.core.footer.DevelopmentModeWarningBox
 import com.clerk.ui.navigation.clerkNavigationForwardTransition
 import com.clerk.ui.navigation.clerkNavigationPopTransition
+import com.clerk.ui.protect.ProtectCheckFlow
+import com.clerk.ui.protect.ProtectCheckView
 import com.clerk.ui.sessiontask.mfa.SessionTaskMfaView
 import com.clerk.ui.sessiontask.organization.SessionTaskChooseOrganizationView
 import com.clerk.ui.sessiontask.organization.SessionTaskCreateOrganizationView
@@ -331,6 +333,9 @@ private fun authEntryProvider(backStack: NavBackStack<NavKey>, options: AuthNavO
     entry<AuthDestination.SignInClientTrust> {
       SignInClientTrustView(factor = it.factor, onAuthComplete = options.onAuthComplete)
     }
+    entry<AuthDestination.SignInProtectCheck> {
+      ProtectCheckView(flow = ProtectCheckFlow.SignIn, onAuthComplete = options.onAuthComplete)
+    }
     entry<AuthDestination.SignUpCollectField> {
       SignUpCollectFieldView(field = it.field, onAuthComplete = options.onAuthComplete)
     }
@@ -342,6 +347,9 @@ private fun authEntryProvider(backStack: NavBackStack<NavKey>, options: AuthNavO
     }
     entry<AuthDestination.SignUpCompleteProfile> {
       SignUpCompleteProfileView(onAuthComplete = options.onAuthComplete)
+    }
+    entry<AuthDestination.SignUpProtectCheck> {
+      ProtectCheckView(flow = ProtectCheckFlow.SignUp, onAuthComplete = options.onAuthComplete)
     }
     entry<AuthDestination.BiometricCredentialEnrollment> {
       BiometricCredentialEnrollmentView(onAuthComplete = options.onAuthComplete)
@@ -436,6 +444,8 @@ internal object AuthDestination {
 
   @Serializable data class SignInClientTrust(val factor: Factor) : NavKey
 
+  @Serializable data object SignInProtectCheck : NavKey
+
   @Serializable data class SignUpCollectField(val field: CollectField) : NavKey
 
   @Serializable data class SignUpCode(val field: SignUpCodeField) : NavKey
@@ -443,6 +453,8 @@ internal object AuthDestination {
   @Serializable data class SignUpEmailLink(val emailAddress: String) : NavKey
 
   @Serializable data class SignUpCompleteProfile(val progress: Int) : NavKey
+
+  @Serializable data object SignUpProtectCheck : NavKey
 
   @Serializable data object BiometricCredentialEnrollment : NavKey
 }

--- a/source/ui/src/main/java/com/clerk/ui/protect/ProtectCheckFlow.kt
+++ b/source/ui/src/main/java/com/clerk/ui/protect/ProtectCheckFlow.kt
@@ -1,0 +1,6 @@
+package com.clerk.ui.protect
+
+internal enum class ProtectCheckFlow {
+  SignIn,
+  SignUp,
+}

--- a/source/ui/src/main/java/com/clerk/ui/protect/ProtectCheckView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/protect/ProtectCheckView.kt
@@ -1,0 +1,281 @@
+package com.clerk.ui.protect
+
+import android.content.Context
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ProgressBar
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.clerk.api.Clerk
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.network.serialization.errorMessage
+import com.clerk.api.protect.ClerkProtect
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signin.get as reloadSignIn
+import com.clerk.api.signin.submitProtectCheck
+import com.clerk.api.signup.SignUp
+import com.clerk.api.signup.get as reloadSignUp
+import com.clerk.api.signup.submitProtectCheck
+import com.clerk.ui.R
+import com.clerk.ui.core.button.standard.ClerkButton
+import com.clerk.ui.core.composition.LocalAuthState
+import com.clerk.ui.core.scaffold.ClerkThemedAuthScaffold
+import kotlin.coroutines.cancellation.CancellationException
+
+@Suppress("LongMethod", "CyclomaticComplexMethod")
+@Composable
+internal fun ProtectCheckView(
+  flow: ProtectCheckFlow,
+  onAuthComplete: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val authState = LocalAuthState.current
+  val client = Clerk.clientFlow.collectAsStateWithLifecycle().value
+  val snackbarHostState = remember { SnackbarHostState() }
+  var challengeHost by remember { mutableStateOf<ProtectChallengeHost?>(null) }
+  var retryNonce by remember { mutableIntStateOf(0) }
+  var isRunning by remember { mutableStateOf(false) }
+  var errorMessage by remember { mutableStateOf<String?>(null) }
+  val fallbackError = stringResource(R.string.something_went_wrong_please_try_again)
+
+  LaunchedEffect(flow, challengeHost, retryNonce) {
+    val host = challengeHost ?: return@LaunchedEffect
+    val initialResource =
+      when (flow) {
+        ProtectCheckFlow.SignIn -> client?.signIn
+        ProtectCheckFlow.SignUp -> client?.signUp
+      }
+
+    if (initialResource == null) {
+      errorMessage = fallbackError
+      host.finish()
+      return@LaunchedEffect
+    }
+
+    isRunning = true
+    errorMessage = null
+    host.prepare()
+    val result =
+      when (initialResource) {
+        is SignIn -> resolveSignInProtectChecks(initialResource, host)
+        is SignUp -> resolveSignUpProtectChecks(initialResource, host)
+        else -> error("Unsupported Protect flow resource")
+      }
+    isRunning = false
+
+    when (result) {
+      is ProtectResolution.Success<*> -> {
+        when (val resource = result.resource) {
+          is SignIn -> authState.setToStepForStatus(resource, onAuthComplete = onAuthComplete)
+          is SignUp -> authState.setToStepForStatus(resource, onAuthComplete = onAuthComplete)
+        }
+      }
+      is ProtectResolution.Failure -> {
+        host.finish()
+        errorMessage = result.message ?: fallbackError
+        snackbarHostState.showSnackbar(errorMessage ?: fallbackError)
+      }
+    }
+  }
+
+  ClerkThemedAuthScaffold(
+    modifier = modifier,
+    snackbarHostState = snackbarHostState,
+    title = stringResource(R.string.security),
+    subtitle = stringResource(R.string.to_continue),
+    hasBackButton = false,
+  ) {
+    AndroidView(
+      modifier = Modifier.fillMaxWidth().height(if (errorMessage == null) 320.dp else 0.dp),
+      factory = { context -> ProtectChallengeHost(context).also { challengeHost = it } },
+      update = { host -> host.setRunning(isRunning) },
+    )
+    if (errorMessage != null) {
+      ClerkButton(
+        modifier = Modifier.fillMaxWidth(),
+        text = stringResource(R.string.try_again),
+        onClick = { retryNonce += 1 },
+      )
+    }
+  }
+}
+
+@Suppress("CyclomaticComplexMethod", "NestedBlockDepth", "ReturnCount")
+private suspend fun resolveSignInProtectChecks(
+  initial: SignIn,
+  host: ProtectChallengeHost,
+): ProtectResolution<SignIn> {
+  var current = initial
+  var reloads = 0
+  while (current.requiresProtectCheck()) {
+    val check = current.protectCheck ?: return ProtectResolution.Failure()
+    host.prepare()
+    val proof =
+      try {
+        ClerkProtect.executeProtectCheck(check, host.challengeContainer)
+      } catch (cancellation: CancellationException) {
+        throw cancellation
+      } catch (throwable: Throwable) {
+        if (ClerkProtect.errorCode(throwable) == PROTECT_CHECK_EXPIRED && reloads < MAX_RELOADS) {
+          reloads += 1
+          when (val refreshed = current.reloadSignIn()) {
+            is ClerkResult.Success -> {
+              current = refreshed.value
+              continue
+            }
+            is ClerkResult.Failure -> return refreshed.toProtectFailure()
+          }
+        }
+        return ProtectResolution.Failure()
+      }
+
+    when (val submitted = current.submitProtectCheck(proof)) {
+      is ClerkResult.Success -> current = submitted.value
+      is ClerkResult.Failure -> {
+        if (submitted.isAlreadyResolved() && reloads < MAX_RELOADS) {
+          reloads += 1
+          when (val refreshed = current.reloadSignIn()) {
+            is ClerkResult.Success -> current = refreshed.value
+            is ClerkResult.Failure -> return refreshed.toProtectFailure()
+          }
+        } else {
+          return submitted.toProtectFailure()
+        }
+      }
+    }
+  }
+  return ProtectResolution.Success(current)
+}
+
+@Suppress("CyclomaticComplexMethod", "NestedBlockDepth", "ReturnCount")
+private suspend fun resolveSignUpProtectChecks(
+  initial: SignUp,
+  host: ProtectChallengeHost,
+): ProtectResolution<SignUp> {
+  var current = initial
+  var reloads = 0
+  while (current.requiresProtectCheck()) {
+    val check = current.protectCheck ?: return ProtectResolution.Failure()
+    host.prepare()
+    val proof =
+      try {
+        ClerkProtect.executeProtectCheck(check, host.challengeContainer)
+      } catch (cancellation: CancellationException) {
+        throw cancellation
+      } catch (throwable: Throwable) {
+        if (ClerkProtect.errorCode(throwable) == PROTECT_CHECK_EXPIRED && reloads < MAX_RELOADS) {
+          reloads += 1
+          when (val refreshed = current.reloadSignUp()) {
+            is ClerkResult.Success -> {
+              current = refreshed.value
+              continue
+            }
+            is ClerkResult.Failure -> return refreshed.toProtectFailure()
+          }
+        }
+        return ProtectResolution.Failure()
+      }
+
+    when (val submitted = current.submitProtectCheck(proof)) {
+      is ClerkResult.Success -> current = submitted.value
+      is ClerkResult.Failure -> {
+        if (submitted.isAlreadyResolved() && reloads < MAX_RELOADS) {
+          reloads += 1
+          when (val refreshed = current.reloadSignUp()) {
+            is ClerkResult.Success -> current = refreshed.value
+            is ClerkResult.Failure -> return refreshed.toProtectFailure()
+          }
+        } else {
+          return submitted.toProtectFailure()
+        }
+      }
+    }
+  }
+  return ProtectResolution.Success(current)
+}
+
+private fun SignIn.requiresProtectCheck(): Boolean =
+  protectCheck != null || status == SignIn.Status.NEEDS_PROTECT_CHECK
+
+private fun SignUp.requiresProtectCheck(): Boolean =
+  protectCheck != null || PROTECT_CHECK_FIELD in missingFields
+
+private fun ClerkResult.Failure<ClerkErrorResponse>.isAlreadyResolved(): Boolean =
+  error?.errors?.firstOrNull()?.code == PROTECT_CHECK_ALREADY_RESOLVED
+
+private fun ClerkResult.Failure<ClerkErrorResponse>.toProtectFailure(): ProtectResolution.Failure =
+  ProtectResolution.Failure(errorMessage)
+
+private sealed interface ProtectResolution<out T : Any> {
+  data class Success<T : Any>(val resource: T) : ProtectResolution<T>
+
+  data class Failure(val message: String? = null) : ProtectResolution<Nothing>
+}
+
+private class ProtectChallengeHost(context: Context) : FrameLayout(context) {
+  private val progress = ProgressBar(context)
+  val challengeContainer: ViewGroup =
+    ChallengeContainer(context).apply {
+      visibilityCallback = { visible -> progress.visibility = if (visible) GONE else VISIBLE }
+    }
+
+  init {
+    addView(
+      progress,
+      LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT, Gravity.CENTER),
+    )
+    addView(challengeContainer, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+    prepare()
+  }
+
+  fun prepare() {
+    challengeContainer.removeAllViews()
+    challengeContainer.visibility = GONE
+    progress.visibility = VISIBLE
+  }
+
+  fun finish() {
+    challengeContainer.visibility = GONE
+    progress.visibility = GONE
+  }
+
+  fun setRunning(running: Boolean) {
+    if (!running) {
+      finish()
+    } else if (challengeContainer.visibility != VISIBLE) {
+      progress.visibility = VISIBLE
+    }
+  }
+}
+
+private class ChallengeContainer(context: Context) : FrameLayout(context) {
+  var visibilityCallback: ((Boolean) -> Unit)? = null
+
+  override fun onVisibilityChanged(changedView: View, visibility: Int) {
+    super.onVisibilityChanged(changedView, visibility)
+    if (changedView === this) {
+      visibilityCallback?.invoke(visibility == VISIBLE)
+    }
+  }
+}
+
+private const val MAX_RELOADS = 2
+private const val PROTECT_CHECK_ALREADY_RESOLVED = "protect_check_already_resolved"
+private const val PROTECT_CHECK_EXPIRED = "protect_check_expired"
+private const val PROTECT_CHECK_FIELD = "protect_check"

--- a/source/ui/src/test/java/com/clerk/ui/auth/AuthStateProtectRoutingTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/auth/AuthStateProtectRoutingTest.kt
@@ -1,0 +1,90 @@
+package com.clerk.ui.auth
+
+import androidx.navigation3.runtime.NavBackStack
+import com.clerk.api.protect.ProtectCheckResource
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signup.SignUp
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AuthStateProtectRoutingTest {
+
+  @Test
+  fun `protect-gated sign in routes to Protect check`() {
+    val authState = createAuthState()
+    val signIn = SignIn(id = "sia_123", status = SignIn.Status.NEEDS_PROTECT_CHECK)
+
+    authState.setToStepForStatus(signIn) {}
+
+    assertEquals(AuthDestination.SignInProtectCheck, authState.backStack.last())
+  }
+
+  @Test
+  fun `protect check resource is authoritative even under another sign in status`() {
+    val authState = createAuthState()
+    val signIn =
+      SignIn(
+        id = "sia_123",
+        status = SignIn.Status.NEEDS_FIRST_FACTOR,
+        protectCheck = protectCheck(),
+      )
+
+    authState.setToStepForStatus(signIn) {}
+
+    assertEquals(AuthDestination.SignInProtectCheck, authState.backStack.last())
+  }
+
+  @Test
+  fun `protect-gated sign up routes before other missing fields`() {
+    val authState = createAuthState()
+    val signUp =
+      SignUp(
+        id = "sua_123",
+        status = SignUp.Status.MISSING_REQUIREMENTS,
+        requiredFields = listOf("password"),
+        optionalFields = emptyList(),
+        missingFields = listOf("password", "protect_check"),
+        unverifiedFields = emptyList(),
+        verifications = emptyMap(),
+        passwordEnabled = false,
+      )
+
+    authState.setToStepForStatus(signUp) {}
+
+    assertEquals(AuthDestination.SignUpProtectCheck, authState.backStack.last())
+  }
+
+  @Test
+  fun `routing the same Protect check twice does not duplicate the destination`() {
+    val authState = createAuthState()
+    val signIn = SignIn(id = "sia_123", status = SignIn.Status.NEEDS_PROTECT_CHECK)
+
+    authState.setToStepForStatus(signIn) {}
+    authState.setToStepForStatus(signIn) {}
+
+    assertEquals(
+      listOf(AuthDestination.AuthStart, AuthDestination.SignInProtectCheck),
+      authState.backStack.toList(),
+    )
+  }
+
+  private fun createAuthState(): AuthState {
+    return AuthState(
+      backStack = NavBackStack(AuthDestination.AuthStart),
+      sharedPreferences = InMemorySharedPreferences(),
+    )
+  }
+
+  private fun protectCheck(): ProtectCheckResource =
+    Json.decodeFromString(
+      """
+      {
+        "status": "pending",
+        "token": "challenge-token",
+        "sdk_url": "https://specter.example.com/challenge"
+      }
+      """
+        .trimIndent()
+    )
+}


### PR DESCRIPTION
Initializes Protect from the Clerk environment and installs its OkHttp interceptor. Adds sign-in and sign-up challenge parsing, proof submission, chained challenge handling, and prebuilt UI routing. Consumes com.clerk.protect:protect:0.1.0-alpha.1 from Maven Local when clerkProtectMavenLocal is enabled. Depends on clerk/protect#1158.