### PR TITLE
fix(ui): respect preferred sign-in strategy

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/network/model/factor/FactorComparators.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/factor/FactorComparators.kt
@@ -8,12 +8,14 @@ internal object FactorComparators {
     listOf(
       Constants.Strategy.PASSKEY,
       Constants.Strategy.PASSWORD,
+      Constants.Strategy.EMAIL_LINK,
       Constants.Strategy.EMAIL_CODE,
       Constants.Strategy.PHONE_CODE,
     )
 
   val strategySortOrderOtpPref =
     listOf(
+      Constants.Strategy.EMAIL_LINK,
       Constants.Strategy.EMAIL_CODE,
       Constants.Strategy.PHONE_CODE,
       Constants.Strategy.PASSKEY,
@@ -22,6 +24,7 @@ internal object FactorComparators {
 
   val strategySortOrderAllStrategies =
     listOf(
+      Constants.Strategy.EMAIL_LINK,
       Constants.Strategy.EMAIL_CODE,
       Constants.Strategy.PHONE_CODE,
       Constants.Strategy.PASSKEY,

--- a/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signin/SignInExtensions.kt
@@ -38,14 +38,13 @@ import com.clerk.api.sso.SSOService
  *   no suitable alternatives are found or if [SignIn.supportedFirstFactors] is null.
  */
 fun SignIn.alternativeFirstFactors(factor: Factor? = null): List<Factor> {
-  val firstFactors =
-    supportedFirstFactors?.filter {
-      it != factor &&
-        !it.isResetFactor() &&
-        !it.strategy.contains("oauth") &&
-        it.strategy != "enterprise_sso" &&
-        it.strategy != "saml"
-    }
+  val firstFactors = supportedFirstFactors?.filter {
+    it != factor &&
+      !it.isResetFactor() &&
+      !it.strategy.contains("oauth") &&
+      it.strategy != "enterprise_sso" &&
+      it.strategy != "saml"
+  }
   return (firstFactors ?: emptyList()).sortedWith(FactorComparators.allStrategiesButtonsComparator)
 }
 
@@ -82,15 +81,11 @@ fun SignIn.alternativeSecondFactors(factor: Factor): List<Factor> {
  *   is found.
  */
 val SignIn.startingFirstFactor: Factor?
-  get() {
-    preparedFirstFactor?.let {
-      return it
-    }
-    return when (Clerk.environment?.displayConfig?.preferredSignInStrategy) {
+  get() =
+    when (Clerk.environment?.displayConfig?.preferredSignInStrategy) {
       PreferredSignInStrategy.PASSWORD -> this.factorWhenPasswordIsPreferred
       else -> this.factorWhenOtpIsPreferred
     }
-  }
 
 val SignIn.startingSecondFactor: Factor?
   get() {
@@ -111,10 +106,6 @@ private val SignIn.factorWhenPasswordIsPreferred: Factor?
   get() {
     val availableFirstFactors = supportedFirstFactors ?: return null
 
-    availableFirstFactors.emailLinkFactorForIdentifier(identifier)?.let {
-      return it
-    }
-
     // Prefer passkey
     availableFirstFactors
       .firstOrNull { it.strategy == "passkey" }
@@ -129,6 +120,10 @@ private val SignIn.factorWhenPasswordIsPreferred: Factor?
         return it
       }
 
+    availableFirstFactors.emailLinkFactorForIdentifier(identifier)?.let {
+      return it
+    }
+
     // Then: sort by password-pref comparator, but first try to match current identifier
     val sorted = availableFirstFactors.sortedWith(FactorComparators.passwordPrefComparator)
     return availableFirstFactors.firstOrNull { it.safeIdentifier == identifier }
@@ -139,10 +134,6 @@ private val SignIn.factorWhenOtpIsPreferred: Factor?
   get() {
     val availableFirstFactors = supportedFirstFactors ?: return null
 
-    availableFirstFactors.emailLinkFactorForIdentifier(identifier)?.let {
-      return it
-    }
-
     // Prefer passkey
     availableFirstFactors
       .firstOrNull { it.strategy == "passkey" }
@@ -150,19 +141,13 @@ private val SignIn.factorWhenOtpIsPreferred: Factor?
         return it
       }
 
+    availableFirstFactors.emailLinkFactorForIdentifier(identifier)?.let {
+      return it
+    }
+
     // Then: sort by OTP-pref comparator; prefer matching identifier if present
     val sorted = availableFirstFactors.sortedWith(FactorComparators.otpPrefComparator)
     return sorted.firstOrNull { it.safeIdentifier == identifier } ?: sorted.firstOrNull()
-  }
-
-private val SignIn.preparedFirstFactor: Factor?
-  get() {
-    val preparedStrategy = firstFactorVerification?.strategy ?: return null
-    val availableFirstFactors = supportedFirstFactors ?: return null
-
-    return availableFirstFactors.firstOrNull {
-      it.strategy == preparedStrategy && it.safeIdentifier == identifier
-    } ?: availableFirstFactors.singleOrNull { it.strategy == preparedStrategy }
   }
 
 private fun List<Factor>.emailLinkFactorForIdentifier(identifier: String?): Factor? {

--- a/source/api/src/test/java/com/clerk/api/signin/SignInExtensionsTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signin/SignInExtensionsTest.kt
@@ -35,7 +35,7 @@ class SignInExtensionsTest {
   }
 
   @Test
-  fun `startingFirstFactor prefers email_link for email identifier when password is preferred`() {
+  fun `startingFirstFactor prefers password for email identifier when password is preferred`() {
     every { displayConfig.preferredSignInStrategy } returns PreferredSignInStrategy.PASSWORD
     val signIn =
       SignIn(
@@ -51,7 +51,7 @@ class SignInExtensionsTest {
 
     val factor = signIn.startingFirstFactor
 
-    assertEquals("email_link", factor?.strategy)
+    assertEquals("password", factor?.strategy)
   }
 
   @Test
@@ -93,7 +93,7 @@ class SignInExtensionsTest {
   }
 
   @Test
-  fun `startingFirstFactor chooses email_link matching the email factor identity`() {
+  fun `startingFirstFactor chooses matching email_link when preferred password is unavailable`() {
     every { displayConfig.preferredSignInStrategy } returns PreferredSignInStrategy.PASSWORD
     val signIn =
       SignIn(
@@ -108,7 +108,6 @@ class SignInExtensionsTest {
               safeIdentifier = "user@example.com",
             ),
             Factor(strategy = "email_link", emailAddressId = "email_123"),
-            Factor(strategy = "password", safeIdentifier = "user@example.com"),
           ),
       )
 
@@ -167,14 +166,15 @@ class SignInExtensionsTest {
   }
 
   @Test
-  fun `startingFirstFactor returns prepared email_code when verification is already prepared`() {
-    every { displayConfig.preferredSignInStrategy } returns PreferredSignInStrategy.OTP
+  fun `startingFirstFactor uses preferred password over prepared email_code`() {
+    every { displayConfig.preferredSignInStrategy } returns PreferredSignInStrategy.PASSWORD
     val signIn =
       SignIn(
         id = "sign_in_123",
         identifier = "user@example.com",
         supportedFirstFactors =
           listOf(
+            Factor(strategy = "password", safeIdentifier = "user@example.com"),
             Factor(strategy = "email_code", emailAddressId = "email_123"),
             Factor(strategy = "email_link", emailAddressId = "email_123"),
           ),
@@ -184,6 +184,6 @@ class SignInExtensionsTest {
 
     val factor = signIn.startingFirstFactor
 
-    assertEquals("email_code", factor?.strategy)
+    assertEquals("password", factor?.strategy)
   }
 }

--- a/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorOneView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/SignInFactorOneView.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.clerk.api.Clerk
 import com.clerk.api.network.model.factor.Factor
 import com.clerk.api.network.model.factor.isResetFactor
-import com.clerk.api.signin.SignIn
 import com.clerk.api.signin.startingFirstFactor
 import com.clerk.api.ui.ClerkTheme
 import com.clerk.ui.auth.PreviewAuthStateProvider
@@ -58,20 +57,13 @@ internal fun resolveFirstFactor(fallback: Factor): Factor {
     } else {
       null
     }
-  val emailLinkFactor =
-    if (hasSignInContext) {
-      currentSignIn.preferredEmailLinkFactor(fallback, supportedFactors)
-    } else {
-      null
-    }
   val fallbackIsSupported = hasSignInContext && supportedFactors.hasStrategy(fallback.strategy)
 
   return if (!hasSignInContext) {
     fallback
   } else {
-    emailLinkFactor
-      ?: if (fallbackIsSupported) fallback
-      else preparedFactor ?: currentSignIn.startingFirstFactor ?: fallback
+    if (fallbackIsSupported) fallback
+    else preparedFactor ?: currentSignIn.startingFirstFactor ?: fallback
   }
 }
 
@@ -82,31 +74,6 @@ private fun List<Factor>.factorForStrategy(strategy: String?): Factor? {
 
 private fun List<Factor>.hasStrategy(strategy: String): Boolean {
   return any { it.strategy == strategy }
-}
-
-private fun SignIn.preferredEmailLinkFactor(
-  fallback: Factor,
-  supportedFactors: List<Factor>,
-): Factor? {
-  if (fallback.strategy != StrategyKeys.EMAIL_CODE) return null
-
-  return if (isEmailIdentifierSignIn(fallback, supportedFactors)) {
-    supportedFactors.firstOrNull { it.strategy == StrategyKeys.EMAIL_LINK }
-  } else {
-    null
-  }
-}
-
-private fun SignIn.isEmailIdentifierSignIn(
-  fallback: Factor,
-  supportedFactors: List<Factor>,
-): Boolean {
-  return (fallback.strategy == StrategyKeys.EMAIL_CODE && fallback.emailAddressId != null) ||
-    identifier?.contains("@") == true ||
-    supportedFactors.any {
-      (it.strategy == StrategyKeys.EMAIL_LINK || it.strategy == StrategyKeys.EMAIL_CODE) &&
-        it.safeIdentifier?.contains("@") == true
-    }
 }
 
 @PreviewLightDark

--- a/source/ui/src/test/java/com/clerk/ui/signin/SignInFactorOneViewTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/SignInFactorOneViewTest.kt
@@ -30,7 +30,7 @@ class SignInFactorOneViewTest {
   }
 
   @Test
-  fun resolveFirstFactorShouldPreferEmailLinkWhenFallbackEmailCodeHasEmailAddressId() {
+  fun resolveFirstFactorShouldKeepSelectedEmailCodeWhenEmailLinkIsSupported() {
     every { mockAuth.currentSignIn } returns
       SignIn(
         id = "sign_in_123",
@@ -45,7 +45,7 @@ class SignInFactorOneViewTest {
     val resolved =
       resolveFirstFactor(Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123"))
 
-    assertEquals(StrategyKeys.EMAIL_LINK, resolved.strategy)
+    assertEquals(StrategyKeys.EMAIL_CODE, resolved.strategy)
   }
 
   @Test
@@ -65,7 +65,7 @@ class SignInFactorOneViewTest {
   }
 
   @Test
-  fun resolveFirstFactorShouldPreferEmailLinkOverPreparedEmailCodeForEmailIdentifier() {
+  fun resolveFirstFactorShouldKeepPreparedEmailCodeSelectionForEmailIdentifier() {
     every { mockAuth.currentSignIn } returns
       SignIn(
         id = "sign_in_123",
@@ -85,7 +85,7 @@ class SignInFactorOneViewTest {
     val resolved =
       resolveFirstFactor(Factor(strategy = StrategyKeys.EMAIL_CODE, emailAddressId = "email_123"))
 
-    assertEquals(StrategyKeys.EMAIL_LINK, resolved.strategy)
+    assertEquals(StrategyKeys.EMAIL_CODE, resolved.strategy)
   }
 
   @Test


### PR DESCRIPTION
Fixes #917.

Honor `preferredSignInStrategy` when choosing password or email-link first factors in `AuthView`, while preserving explicit email-code selections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated sign-in factor selection to better respect the user’s preferred method.
  * Password sign-in is now prioritized when selected, with email link as a fallback when password is unavailable.
  * Email link is supported in OTP and available-strategy ordering.
  * Explicitly selected or prepared email-code sign-in remains selected when email link is also available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->