### PR TITLE
feat(api): decode commerce settings from environment

### DIFF
--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -24,6 +24,7 @@ import com.clerk.api.locale.LocaleProvider
 import com.clerk.api.log.ClerkLog
 import com.clerk.api.network.ClerkApi
 import com.clerk.api.network.model.client.Client
+import com.clerk.api.network.model.environment.CommerceSettings
 import com.clerk.api.network.model.environment.Environment
 import com.clerk.api.network.model.environment.InstanceEnvironmentType
 import com.clerk.api.network.model.environment.UserSettings
@@ -402,6 +403,15 @@ object Clerk {
 
   val organizationDefaultRoleKey: String?
     get() = environment?.organizationSettings?.domains?.defaultRole
+
+  /**
+   * Billing flags from `/v1/environment`.
+   *
+   * Defaults to disabled billing when the SDK has not fetched environment yet, or when the payload
+   * omits `commerce_settings`.
+   */
+  val commerceSettings: CommerceSettings
+    get() = environment?.commerceSettings ?: CommerceSettings()
 
   private val _organizationLogoUrlFlow = MutableStateFlow<String?>(null)
 

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/CommerceSettings.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/CommerceSettings.kt
@@ -1,0 +1,21 @@
+package com.clerk.api.network.model.environment
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Billing configuration from `/v1/environment`.
+ *
+ * Mirrors clerk-js `CommerceSettingsResource`. Apps read this through
+ * [com.clerk.api.Clerk.commerceSettings].
+ */
+@Serializable
+data class CommerceSettings(val billing: Billing = Billing()) {
+  @Serializable
+  data class Billing(
+    val stripePublishableKey: String? = null,
+    val organization: Payer = Payer(),
+    val user: Payer = Payer(),
+  ) {
+    @Serializable data class Payer(val enabled: Boolean = false, val hasPaidPlans: Boolean = false)
+  }
+}

--- a/source/api/src/main/kotlin/com/clerk/api/network/model/environment/Environment.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/network/model/environment/Environment.kt
@@ -13,6 +13,7 @@ internal data class Environment(
   @SerialName("user_settings") val userSettings: UserSettings,
   @SerialName("organization_settings")
   val organizationSettings: OrganizationSettings = OrganizationSettings(),
+  @SerialName("commerce_settings") val commerceSettings: CommerceSettings = CommerceSettings(),
 ) {
   val passkeyIsEnabled: Boolean
     get() = userSettings.attributes.any { (key, value) -> key == "passkey" && value.enabled }

--- a/source/api/src/test/java/com/clerk/api/integration/EnvironmentIntegrationTests.kt
+++ b/source/api/src/test/java/com/clerk/api/integration/EnvironmentIntegrationTests.kt
@@ -22,5 +22,9 @@ class EnvironmentIntegrationTests {
       Clerk.applicationName,
     )
     assertTrue("applicationName should not be blank", Clerk.applicationName!!.isNotBlank())
+    assertNotNull(
+      "commerceSettings should be present after environment is fetched",
+      Clerk.commerceSettings,
+    )
   }
 }

--- a/source/api/src/test/java/com/clerk/api/network/model/environment/CommerceSettingsTest.kt
+++ b/source/api/src/test/java/com/clerk/api/network/model/environment/CommerceSettingsTest.kt
@@ -1,0 +1,143 @@
+package com.clerk.api.network.model.environment
+
+import com.clerk.api.network.ClerkApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CommerceSettingsTest {
+
+  @Test
+  fun `decodes enabled user billing`() {
+    val settings =
+      ClerkApi.json.decodeFromString<CommerceSettings>(
+        """
+        {
+          "billing": {
+            "stripe_publishable_key": "pk_test_123",
+            "user": { "enabled": true, "has_paid_plans": true },
+            "organization": { "enabled": false, "has_paid_plans": false }
+          }
+        }
+        """
+          .trimIndent()
+      )
+
+    assertTrue(settings.billing.user.enabled)
+    assertTrue(settings.billing.user.hasPaidPlans)
+    assertFalse(settings.billing.organization.enabled)
+    assertEquals("pk_test_123", settings.billing.stripePublishableKey)
+  }
+
+  @Test
+  fun `decodes enabled organization billing`() {
+    val settings =
+      ClerkApi.json.decodeFromString<CommerceSettings>(
+        """
+        {
+          "billing": {
+            "stripe_publishable_key": "pk_live_abc",
+            "user": { "enabled": false, "has_paid_plans": false },
+            "organization": { "enabled": true, "has_paid_plans": true }
+          }
+        }
+        """
+          .trimIndent()
+      )
+
+    assertTrue(settings.billing.organization.enabled)
+    assertTrue(settings.billing.organization.hasPaidPlans)
+    assertFalse(settings.billing.user.enabled)
+    assertEquals("pk_live_abc", settings.billing.stripePublishableKey)
+  }
+
+  @Test
+  fun `decodes missing commerce settings key with defaults`() {
+    val environment =
+      ClerkApi.json.decodeFromString<Environment>(environmentJson(commerceSettings = null))
+
+    assertFalse(environment.commerceSettings.billing.user.enabled)
+    assertFalse(environment.commerceSettings.billing.user.hasPaidPlans)
+    assertFalse(environment.commerceSettings.billing.organization.enabled)
+    assertFalse(environment.commerceSettings.billing.organization.hasPaidPlans)
+    assertNull(environment.commerceSettings.billing.stripePublishableKey)
+  }
+
+  @Test
+  fun `decodes null stripe publishable key`() {
+    val settings =
+      ClerkApi.json.decodeFromString<CommerceSettings>(
+        """
+        {
+          "billing": {
+            "stripe_publishable_key": null,
+            "user": { "enabled": true, "has_paid_plans": false },
+            "organization": { "enabled": false, "has_paid_plans": false }
+          }
+        }
+        """
+          .trimIndent()
+      )
+
+    assertNull(settings.billing.stripePublishableKey)
+    assertTrue(settings.billing.user.enabled)
+  }
+
+  @Test
+  fun `ignores leftover unknown commerce settings keys`() {
+    val settings =
+      ClerkApi.json.decodeFromString<CommerceSettings>(
+        """
+        {
+          "id": "commerce_settings_1",
+          "object": "commerce_settings",
+          "billing": {
+            "stripe_publishable_key": "pk_test_leftover",
+            "user": { "enabled": true, "has_paid_plans": false },
+            "organization": { "enabled": true, "has_paid_plans": false },
+            "future_flag": true
+          }
+        }
+        """
+          .trimIndent()
+      )
+
+    assertTrue(settings.billing.user.enabled)
+    assertTrue(settings.billing.organization.enabled)
+    assertEquals("pk_test_leftover", settings.billing.stripePublishableKey)
+  }
+
+  private fun environmentJson(commerceSettings: String?): String {
+    val commerceJson = commerceSettings?.let { """, "commerce_settings": $it""" }.orEmpty()
+    return """
+      {
+        "auth_config": { "single_session_mode": false },
+        "display_config": {
+          "application_name": "Test App",
+          "branded": true,
+          "logo_image_url": "https://example.com/logo.png",
+          "home_url": "/",
+          "privacy_policy_url": null,
+          "terms_url": null,
+          "google_one_tap_client_id": null
+        },
+        "user_settings": {
+          "attributes": {},
+          "sign_up": {
+            "custom_action_required": false,
+            "progressive": false,
+            "mode": "public",
+            "legal_consent_enabled": false
+          },
+          "social": {},
+          "actions": {},
+          "passkey_settings": null
+        }
+        $commerceJson
+      }
+    """
+      .trimIndent()
+  }
+}


### PR DESCRIPTION
### What & why

`/v1/environment` already returns `commerce_settings`. The Android SDK ignored it, and `Environment` is internal, so apps had nowhere to read Billing flags.

This decodes the key onto `Environment` and exposes `Clerk.commerceSettings` with the clerk-js shape (`stripePublishableKey`, `user.enabled`, `user.hasPaidPlans`, `organization.enabled`, `organization.hasPaidPlans`). Missing payloads default to disabled so older cached snapshots still load.

First PR in the native Billing read stack. No checkout or write APIs.

### What to focus on

- Public `Clerk.commerceSettings` (the only way apps can read this, because `Environment` stays internal).
- Defaults on `CommerceSettings` so existing `Environment(...)` test constructors keep compiling.
- `ignoreUnknownKeys` still swallows FAPI leftover fields like `id` and `object`.

### Proof

None. This PR only decodes environment.

Unit: `./gradlew :source:api:testDebugUnitTest --tests com.clerk.api.network.model.environment.CommerceSettingsTest`

Live lanes still need a Billing-enabled instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to commerce and billing settings provided by the environment.
  * Added support for Stripe configuration, organization billing, and user billing status.
  * Billing settings default to disabled when unavailable or before initialization.

* **Tests**
  * Added coverage for billing configuration decoding, defaults, optional Stripe keys, and unknown fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
