### PR TITLE
fix(android): narrow consumer shrinker rules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,8 +95,8 @@ tasks.register("verifyPublishedArtifacts") {
 
   val apiConsumerRules = file("source/api/consumer-rules.pro")
   val uiConsumerRules = file("source/ui/consumer-rules.pro")
-  val apiPublication = layout.projectDirectory.dir("source/api/build/publications/maven")
-  val uiPublication = layout.projectDirectory.dir("source/ui/build/publications/maven")
+  val apiPublication = project(":source:api").layout.buildDirectory.dir("publications/maven")
+  val uiPublication = project(":source:ui").layout.buildDirectory.dir("publications/maven")
   inputs.files(apiConsumerRules, uiConsumerRules)
   inputs.dir(apiPublication)
   inputs.dir(uiPublication)
@@ -121,8 +121,14 @@ tasks.register("verifyPublishedArtifacts") {
           "\\\"group\\\"\\s*:\\s*\\\"${Regex.escape(group)}\\\"\\s*,\\s*" +
             "\\\"module\\\"\\s*:\\s*\\\"${Regex.escape(artifact)}\\\""
         )
-      val publicationMetadata =
-        directory.walkTopDown().filter(File::isFile).joinToString("\n") { it.readText() }
+      val metadataFiles =
+        listOf(directory.resolve("pom-default.xml"), directory.resolve("module.json"))
+      metadataFiles.forEach { metadataFile ->
+        check(metadataFile.isFile) {
+          "Expected publication metadata file ${metadataFile.relativeTo(rootDir)} to exist."
+        }
+      }
+      val publicationMetadata = metadataFiles.joinToString("\n") { it.readText() }
       check(!pomPattern.containsMatchIn(publicationMetadata)) {
         "$coordinate must not be published from ${directory.relativeTo(rootDir)}."
       }
@@ -154,7 +160,7 @@ tasks.register("verifyPublishedArtifacts") {
     )
 
     listOf("com.google.devtools.ksp:symbol-processing-api").forEach {
-      assertCoordinateIsNotPublished(apiPublication.asFile, it)
+      assertCoordinateIsNotPublished(apiPublication.get().asFile, it)
     }
     listOf(
         "androidx.compose.ui:ui-tooling",
@@ -162,7 +168,7 @@ tasks.register("verifyPublishedArtifacts") {
         "androidx.compose.ui:ui-tooling-preview-android",
         "androidx.test:core-ktx",
       )
-      .forEach { assertCoordinateIsNotPublished(uiPublication.asFile, it) }
+      .forEach { assertCoordinateIsNotPublished(uiPublication.get().asFile, it) }
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,91 @@ dependencies {
   dokka(project(":source:ui"))
 }
 
+tasks.register("verifyPublishedArtifacts") {
+  group = "verification"
+  description = "Checks consumer rules and published dependency metadata for forbidden entries."
+  dependsOn(
+    ":source:api:generateMetadataFileForMavenPublication",
+    ":source:api:generatePomFileForMavenPublication",
+    ":source:ui:generateMetadataFileForMavenPublication",
+    ":source:ui:generatePomFileForMavenPublication",
+  )
+
+  val apiConsumerRules = file("source/api/consumer-rules.pro")
+  val uiConsumerRules = file("source/ui/consumer-rules.pro")
+  val apiPublication = layout.projectDirectory.dir("source/api/build/publications/maven")
+  val uiPublication = layout.projectDirectory.dir("source/ui/build/publications/maven")
+  inputs.files(apiConsumerRules, uiConsumerRules)
+  inputs.dir(apiPublication)
+  inputs.dir(uiPublication)
+
+  doLast {
+    fun assertRulesDoNotContain(file: File, forbiddenRules: List<String>) {
+      val rules = file.readText()
+      forbiddenRules.forEach { rule ->
+        check(rule !in rules) { "${file.relativeTo(rootDir)} must not contain '$rule'." }
+      }
+    }
+
+    fun assertCoordinateIsNotPublished(directory: File, coordinate: String) {
+      val (group, artifact) = coordinate.split(":", limit = 2)
+      val pomPattern =
+        Regex(
+          "<groupId>\\s*${Regex.escape(group)}\\s*</groupId>\\s*" +
+            "<artifactId>\\s*${Regex.escape(artifact)}\\s*</artifactId>"
+        )
+      val modulePattern =
+        Regex(
+          "\\\"group\\\"\\s*:\\s*\\\"${Regex.escape(group)}\\\"\\s*,\\s*" +
+            "\\\"module\\\"\\s*:\\s*\\\"${Regex.escape(artifact)}\\\""
+        )
+      val publicationMetadata =
+        directory.walkTopDown().filter(File::isFile).joinToString("\n") { it.readText() }
+      check(!pomPattern.containsMatchIn(publicationMetadata)) {
+        "$coordinate must not be published from ${directory.relativeTo(rootDir)}."
+      }
+      check(!modulePattern.containsMatchIn(publicationMetadata)) {
+        "$coordinate must not be published from ${directory.relativeTo(rootDir)}."
+      }
+    }
+
+    assertRulesDoNotContain(
+      apiConsumerRules,
+      listOf(
+        "-keep class com.clerk.api.**",
+        "-keep class com.clerk.sdk.**",
+        "-keep class com.auth0.android.jwt.**",
+        "-keep class com.google.android.gms.**",
+        "-keep class androidx.credentials.**",
+        "-keepclassmembers enum *",
+      ),
+    )
+    assertRulesDoNotContain(
+      uiConsumerRules,
+      listOf(
+        "-keep class com.clerk.ui.**",
+        "-keep class androidx.compose.runtime.**",
+        "class * extends androidx.lifecycle.ViewModel",
+        "-keep class androidx.compose.material3.**",
+        "-keep class coil3.**",
+      ),
+    )
+
+    listOf("com.google.devtools.ksp:symbol-processing-api").forEach {
+      assertCoordinateIsNotPublished(apiPublication.asFile, it)
+    }
+    listOf(
+        "androidx.compose.ui:ui-tooling",
+        "androidx.compose.ui:ui-tooling-preview",
+        "androidx.compose.ui:ui-tooling-preview-android",
+        "androidx.test:core-ktx",
+      )
+      .forEach { assertCoordinateIsNotPublished(uiPublication.asFile, it) }
+  }
+}
+
+tasks.named("check") { dependsOn("verifyPublishedArtifacts") }
+
 subprojects {
   plugins.withType<JavaPlugin> {
     the<JavaPluginExtension>().toolchain {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,7 +81,6 @@ kotlinx-coroutines-test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0"
 kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.8.0-0.6.x-compat"
 kotlinx-immutable = "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.5.2"
 kotlinx-serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0"
-ksp-api = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "ksp" }
 ktor-client-core = "io.ktor:ktor-client-core:3.5.2"
 ktor-client-negototiation = "io.ktor:ktor-client-content-negotiation:3.5.2"
 ktor-client-okhttp = "io.ktor:ktor-client-okhttp:3.5.2"

--- a/source/api/build.gradle.kts
+++ b/source/api/build.gradle.kts
@@ -105,7 +105,6 @@ dependencies {
   implementation(libs.jwt.decode)
   implementation(libs.kotlinx.coroutines)
   implementation(libs.kotlinx.datetime)
-  implementation(libs.ksp.api)
   implementation(libs.okhttp)
   implementation(libs.okhttp.logging)
   implementation(libs.retrofit)

--- a/source/api/consumer-rules.pro
+++ b/source/api/consumer-rules.pro
@@ -1,71 +1,9 @@
 # Clerk Android SDK Consumer ProGuard Rules
 # These rules are bundled with the SDK and automatically applied to consumer apps
 
-# Keep Clerk API classes
--keep class com.clerk.api.** { *; }
--keep class com.clerk.sdk.** { *; }
-
-# Keep Kotlin serialization
--keepattributes *Annotation*, InnerClasses
--dontnote kotlinx.serialization.AnnotationsKt
-
--keepclassmembers class kotlinx.serialization.json.** {
+# Keep serializer accessors for reachable Clerk models. Kotlinx serialization and Retrofit ship
+# the remaining reflection rules required by their runtimes.
+-keepclassmembers,allowoptimization,allowobfuscation class com.clerk.api.** {
     *** Companion;
-}
--keepclasseswithmembers class kotlinx.serialization.json.** {
     kotlinx.serialization.KSerializer serializer(...);
-}
-
--keep,includedescriptorclasses class com.clerk.api.**$$serializer { *; }
--keepclassmembers class com.clerk.api.** {
-    *** Companion;
-}
--keepclasseswithmembers class com.clerk.api.** {
-    kotlinx.serialization.KSerializer serializer(...);
-}
-
-# Retrofit
--keepattributes Signature, Exceptions
--keepclassmembers,allowshrinking,allowobfuscation interface * {
-    @retrofit2.http.* <methods>;
-}
--dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
--dontwarn javax.annotation.**
--dontwarn kotlin.Unit
--dontwarn retrofit2.KotlinExtensions
--dontwarn retrofit2.KotlinExtensions$*
--if interface * { @retrofit2.http.* <methods>; }
--keep,allowobfuscation interface <1>
--if interface * { @retrofit2.http.* <methods>; }
--keep,allowobfuscation interface * extends <1>
--keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
-
-# OkHttp
--dontwarn okhttp3.internal.platform.**
--dontwarn org.conscrypt.**
--dontwarn org.bouncycastle.**
--dontwarn org.openjsse.**
-
-# Kotlinx coroutines
--keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
--keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
--keepclassmembers class kotlinx.coroutines.** {
-    volatile <fields>;
-}
--keepclassmembers class kotlin.coroutines.SafeContinuation {
-    volatile <fields>;
-}
--dontwarn java.lang.invoke.StringConcatFactory
-
-# JWT Decode
--keep class com.auth0.android.jwt.** { *; }
-
-# Google Play Services / Credentials
--keep class com.google.android.gms.** { *; }
--keep class androidx.credentials.** { *; }
-
-# Keep enum classes
--keepclassmembers enum * {
-    public static **[] values();
-    public static ** valueOf(java.lang.String);
 }

--- a/source/ui/build.gradle.kts
+++ b/source/ui/build.gradle.kts
@@ -111,15 +111,16 @@ dependencies {
   implementation(libs.androidx.navigation3.runtime)
   implementation(libs.androidx.navigation3.ui)
   implementation(libs.androidx.ui)
-  implementation(libs.androidx.ui.tooling)
-  implementation(libs.androidx.ui.tooling.preview.android)
   implementation(libs.coil)
   implementation(libs.coil.okhttp)
-  implementation(libs.core.ktx)
   implementation(libs.google.libphonenumber)
   implementation(libs.kotlinx.immutable)
   implementation(libs.material3)
   implementation(libs.materialKolor)
+
+  debugImplementation(libs.androidx.ui.tooling)
+
+  compileOnly(libs.androidx.ui.tooling.preview.android)
 
   testImplementation(libs.androidx.core)
   testImplementation(libs.junit)

--- a/source/ui/consumer-rules.pro
+++ b/source/ui/consumer-rules.pro
@@ -1,22 +1,7 @@
 # Clerk Android UI Consumer ProGuard Rules
 # These rules are bundled with the SDK and automatically applied to consumer apps
 
-# Keep Clerk UI classes
--keep class com.clerk.ui.** { *; }
-
-# Keep Compose runtime classes used by the SDK
--keep class androidx.compose.runtime.** { *; }
--dontwarn androidx.compose.runtime.**
-
-# Keep ViewModel classes
--keep class * extends androidx.lifecycle.ViewModel { *; }
--keepclassmembers class * extends androidx.lifecycle.ViewModel {
+# Clerk ViewModels are instantiated by the lifecycle ViewModel factory.
+-keepclassmembers,allowoptimization,allowobfuscation class com.clerk.ui.** extends androidx.lifecycle.ViewModel {
     <init>(...);
 }
-
-# Keep Material Design 3 components
--keep class androidx.compose.material3.** { *; }
-
-# Keep Coil image loading
--keep class coil3.** { *; }
--dontwarn coil3.**


### PR DESCRIPTION
Removes blanket consumer keep rules for Clerk and third-party packages, retaining scoped serialization and ViewModel constructor rules.

Moves Compose preview/tooling, AndroidX test, and KSP tooling out of published runtime metadata. Adds a verification task for generated POM and Gradle module metadata.

Closes #922.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of published API and UI packages, including dependency metadata and runtime protection settings.
  * Refined release configurations to reduce unnecessary packaged dependencies and improve compatibility with code shrinking and obfuscation.
* **Chores**
  * Removed unused symbol-processing and core Android extension dependencies.
  * Limited UI preview tooling to development environments, reducing its impact on release builds.
  * Added automated checks to ensure published package metadata is complete and accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->