### PR TITLE
fix(ui): preserve sign-in after SSO cancellation

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/signin/SignInRedirect.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/SignInRedirect.kt
@@ -9,15 +9,11 @@ import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.OAuthResult
 
 internal suspend fun authenticateWithRedirect(
-  signIn: SignIn?,
+  signIn: SignIn,
   provider: OAuthProvider,
   transferable: Boolean,
 ): ClerkResult<OAuthResult, ClerkErrorResponse> {
   val params = SignIn.AuthenticateWithRedirectParams.OAuth(provider)
-  if (signIn == null) {
-    return SignIn.authenticateWithRedirect(params, transferable)
-  }
-
   return when (
     val prepareResult =
       signIn.prepareFirstFactor(

--- a/source/ui/src/main/java/com/clerk/ui/signin/SignInRedirect.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/SignInRedirect.kt
@@ -1,0 +1,34 @@
+package com.clerk.ui.signin
+
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signin.authenticateWithPreparedRedirect
+import com.clerk.api.signin.prepareFirstFactor
+import com.clerk.api.sso.OAuthProvider
+import com.clerk.api.sso.OAuthResult
+
+internal suspend fun authenticateWithRedirect(
+  signIn: SignIn?,
+  provider: OAuthProvider,
+  transferable: Boolean,
+): ClerkResult<OAuthResult, ClerkErrorResponse> {
+  val params = SignIn.AuthenticateWithRedirectParams.OAuth(provider)
+  if (signIn == null) {
+    return SignIn.authenticateWithRedirect(params, transferable)
+  }
+
+  return when (
+    val prepareResult =
+      signIn.prepareFirstFactor(
+        SignIn.PrepareFirstFactorParams.OAuth(
+          strategy = provider.strategy,
+          redirectUrl = params.redirectUrl,
+        )
+      )
+  ) {
+    is ClerkResult.Failure -> prepareResult
+    is ClerkResult.Success ->
+      prepareResult.value.authenticateWithPreparedRedirect(transferable = transferable)
+  }
+}

--- a/source/ui/src/main/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModel.kt
@@ -6,6 +6,7 @@ import com.clerk.api.Clerk
 import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
+import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.ResultType
 import com.clerk.ui.auth.AuthenticationViewState
@@ -20,14 +21,18 @@ internal class AlternativeMethodsViewModel : ViewModel() {
   private val _state = MutableStateFlow<AuthenticationViewState>(AuthenticationViewState.Idle)
   val state = _state.asStateFlow()
 
-  fun signInWithProvider(provider: OAuthProvider, transferable: Boolean = true) {
+  fun signInWithProvider(
+    provider: OAuthProvider,
+    transferable: Boolean = true,
+    signIn: SignIn? = Clerk.auth.currentSignIn,
+  ) {
     _state.value = AuthenticationViewState.Loading
     viewModelScope.launch {
-      authenticateWithRedirect(
-          signIn = Clerk.auth.currentSignIn,
-          provider = provider,
-          transferable = transferable,
-        )
+      if (signIn == null) {
+        _state.value = AuthenticationViewState.NotStarted
+        return@launch
+      }
+      authenticateWithRedirect(signIn = signIn, provider = provider, transferable = transferable)
         .onSuccess {
           _state.value =
             when (it.resultType) {

--- a/source/ui/src/main/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModel.kt
@@ -2,14 +2,15 @@ package com.clerk.ui.signin.alternativemethods
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.clerk.api.Clerk
 import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
-import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.ResultType
 import com.clerk.ui.auth.AuthenticationViewState
 import com.clerk.ui.auth.isSSOCancellation
+import com.clerk.ui.signin.authenticateWithRedirect
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -22,8 +23,9 @@ internal class AlternativeMethodsViewModel : ViewModel() {
   fun signInWithProvider(provider: OAuthProvider, transferable: Boolean = true) {
     _state.value = AuthenticationViewState.Loading
     viewModelScope.launch {
-      SignIn.authenticateWithRedirect(
-          SignIn.AuthenticateWithRedirectParams.OAuth(provider),
+      authenticateWithRedirect(
+          signIn = Clerk.auth.currentSignIn,
+          provider = provider,
           transferable = transferable,
         )
         .onSuccess {
@@ -37,7 +39,7 @@ internal class AlternativeMethodsViewModel : ViewModel() {
         .onFailure {
           _state.value =
             if (it.isSSOCancellation) {
-              AuthenticationViewState.NotStarted
+              AuthenticationViewState.Idle
             } else {
               AuthenticationViewState.Error(it.errorMessage)
             }

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModel.kt
@@ -8,10 +8,10 @@ import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
 import com.clerk.api.resetPasswordFactor
-import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.ResultType
 import com.clerk.ui.auth.isSSOCancellation
+import com.clerk.ui.signin.authenticateWithRedirect
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,8 +29,9 @@ internal class ForgotPasswordViewModel(
   fun signInWithProvider(provider: OAuthProvider, transferable: Boolean = true) {
     _state.value = ResetPasswordViewState.Loading
     viewModelScope.launch(ioDispatcher) {
-      SignIn.authenticateWithRedirect(
-          SignIn.AuthenticateWithRedirectParams.OAuth(provider),
+      authenticateWithRedirect(
+          signIn = Clerk.auth.currentSignIn,
+          provider = provider,
           transferable = transferable,
         )
         .onSuccess {
@@ -46,7 +47,7 @@ internal class ForgotPasswordViewModel(
           withContext(Dispatchers.Main) {
             _state.value =
               if (it.isSSOCancellation) {
-                ResetPasswordViewState.NotStarted
+                ResetPasswordViewState.Idle
               } else {
                 ResetPasswordViewState.Error(it.errorMessage)
               }

--- a/source/ui/src/main/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModel.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModel.kt
@@ -8,6 +8,7 @@ import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
 import com.clerk.api.resetPasswordFactor
+import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.ResultType
 import com.clerk.ui.auth.isSSOCancellation
@@ -26,14 +27,18 @@ internal class ForgotPasswordViewModel(
   private val _state = MutableStateFlow<ResetPasswordViewState>(ResetPasswordViewState.Idle)
   val state = _state.asStateFlow()
 
-  fun signInWithProvider(provider: OAuthProvider, transferable: Boolean = true) {
+  fun signInWithProvider(
+    provider: OAuthProvider,
+    transferable: Boolean = true,
+    signIn: SignIn? = Clerk.auth.currentSignIn,
+  ) {
     _state.value = ResetPasswordViewState.Loading
     viewModelScope.launch(ioDispatcher) {
-      authenticateWithRedirect(
-          signIn = Clerk.auth.currentSignIn,
-          provider = provider,
-          transferable = transferable,
-        )
+      if (signIn == null) {
+        withContext(Dispatchers.Main) { _state.value = ResetPasswordViewState.NotStarted }
+        return@launch
+      }
+      authenticateWithRedirect(signIn = signIn, provider = provider, transferable = transferable)
         .onSuccess {
           withContext(Dispatchers.Main) {
             if (it.resultType == ResultType.SIGN_IN) {

--- a/source/ui/src/test/java/com/clerk/ui/signin/SignInRedirectTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/SignInRedirectTest.kt
@@ -10,7 +10,6 @@ import com.clerk.api.sso.OAuthProvider
 import com.clerk.api.sso.OAuthResult
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
@@ -29,7 +28,6 @@ class SignInRedirectTest {
 
   @Test
   fun `redirect reuses the current sign in attempt`() = runTest {
-    mockkObject(SignIn.Companion)
     mockkStatic("com.clerk.api.signin.SignInKt")
     mockkStatic("com.clerk.api.signin.SignInExtensionsKt")
     val currentSignIn =
@@ -67,6 +65,5 @@ class SignInRedirectTest {
     assertEquals(OAuthProvider.GITHUB.strategy, prepareParams.captured.strategy)
     coVerify(exactly = 1) { currentSignIn.prepareFirstFactor(any()) }
     coVerify(exactly = 1) { preparedSignIn.authenticateWithPreparedRedirect(transferable = true) }
-    coVerify(exactly = 0) { SignIn.authenticateWithRedirect(any(), any()) }
   }
 }

--- a/source/ui/src/test/java/com/clerk/ui/signin/SignInRedirectTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/SignInRedirectTest.kt
@@ -1,0 +1,72 @@
+package com.clerk.ui.signin
+
+import com.clerk.api.network.model.factor.Factor
+import com.clerk.api.network.model.verification.Verification
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signin.authenticateWithPreparedRedirect
+import com.clerk.api.signin.prepareFirstFactor
+import com.clerk.api.sso.OAuthProvider
+import com.clerk.api.sso.OAuthResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class SignInRedirectTest {
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `redirect reuses the current sign in attempt`() = runTest {
+    mockkObject(SignIn.Companion)
+    mockkStatic("com.clerk.api.signin.SignInKt")
+    mockkStatic("com.clerk.api.signin.SignInExtensionsKt")
+    val currentSignIn =
+      SignIn(
+        id = "sign_in_existing",
+        status = SignIn.Status.NEEDS_FIRST_FACTOR,
+        identifier = "user@example.com",
+        supportedFirstFactors = listOf(Factor(strategy = "password")),
+      )
+    val externalRedirectUrl = "https://oauth.example.com/start"
+    val preparedSignIn =
+      currentSignIn.copy(
+        firstFactorVerification =
+          Verification(
+            strategy = OAuthProvider.GITHUB.strategy,
+            externalVerificationRedirectUrl = externalRedirectUrl,
+          )
+      )
+    val oauthResult = OAuthResult(signIn = preparedSignIn)
+    val prepareParams = slot<SignIn.PrepareFirstFactorParams>()
+
+    coEvery { currentSignIn.prepareFirstFactor(capture(prepareParams)) } returns
+      ClerkResult.success(preparedSignIn)
+    coEvery { preparedSignIn.authenticateWithPreparedRedirect(transferable = true) } returns
+      ClerkResult.success(oauthResult)
+
+    val result =
+      authenticateWithRedirect(
+        signIn = currentSignIn,
+        provider = OAuthProvider.GITHUB,
+        transferable = true,
+      )
+
+    assertSame(oauthResult, (result as ClerkResult.Success).value)
+    assertEquals(OAuthProvider.GITHUB.strategy, prepareParams.captured.strategy)
+    coVerify(exactly = 1) { currentSignIn.prepareFirstFactor(any()) }
+    coVerify(exactly = 1) { preparedSignIn.authenticateWithPreparedRedirect(transferable = true) }
+    coVerify(exactly = 0) { SignIn.authenticateWithRedirect(any(), any()) }
+  }
+}

--- a/source/ui/src/test/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModelTest.kt
@@ -33,7 +33,7 @@ class AlternativeMethodsViewModelTest {
   }
 
   @Test
-  fun `OAuth cancellation returns to auth start`() = runTest {
+  fun `OAuth cancellation leaves alternative methods idle`() = runTest {
     coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
       ClerkResult.unknownFailure(ssoCancellation())
     val viewModel = AlternativeMethodsViewModel()
@@ -41,7 +41,7 @@ class AlternativeMethodsViewModelTest {
     viewModel.signInWithProvider(OAuthProvider.GITHUB)
     advanceUntilIdle()
 
-    assertEquals(AuthenticationViewState.NotStarted, viewModel.state.value)
+    assertEquals(AuthenticationViewState.Idle, viewModel.state.value)
   }
 
   private fun ssoCancellation(): Throwable =

--- a/source/ui/src/test/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/alternativemethods/AlternativeMethodsViewModelTest.kt
@@ -4,9 +4,11 @@ import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
 import com.clerk.ui.auth.AuthenticationViewState
+import com.clerk.ui.signin.authenticateWithRedirect
 import com.clerk.ui.userprofile.MainDispatcherRule
 import io.mockk.coEvery
-import io.mockk.mockkObject
+import io.mockk.coVerify
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -24,7 +26,7 @@ class AlternativeMethodsViewModelTest {
 
   @Before
   fun setUp() {
-    mockkObject(SignIn.Companion)
+    mockkStatic("com.clerk.ui.signin.SignInRedirectKt")
   }
 
   @After
@@ -34,14 +36,26 @@ class AlternativeMethodsViewModelTest {
 
   @Test
   fun `OAuth cancellation leaves alternative methods idle`() = runTest {
-    coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
+    val signIn = SignIn(id = "sign_in_existing", status = SignIn.Status.NEEDS_FIRST_FACTOR)
+    coEvery { authenticateWithRedirect(signIn, OAuthProvider.GITHUB, true) } returns
       ClerkResult.unknownFailure(ssoCancellation())
     val viewModel = AlternativeMethodsViewModel()
 
-    viewModel.signInWithProvider(OAuthProvider.GITHUB)
+    viewModel.signInWithProvider(OAuthProvider.GITHUB, signIn = signIn)
     advanceUntilIdle()
 
     assertEquals(AuthenticationViewState.Idle, viewModel.state.value)
+  }
+
+  @Test
+  fun `missing sign in returns to auth start`() = runTest {
+    val viewModel = AlternativeMethodsViewModel()
+
+    viewModel.signInWithProvider(OAuthProvider.GITHUB, signIn = null)
+    advanceUntilIdle()
+
+    assertEquals(AuthenticationViewState.NotStarted, viewModel.state.value)
+    coVerify(exactly = 0) { authenticateWithRedirect(any(), any(), any()) }
   }
 
   private fun ssoCancellation(): Throwable =

--- a/source/ui/src/test/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModelTest.kt
@@ -34,7 +34,7 @@ class ForgotPasswordViewModelTest {
   }
 
   @Test
-  fun `OAuth cancellation returns to auth start`() =
+  fun `OAuth cancellation leaves forgot password idle`() =
     runTest(testDispatcher) {
       coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
         ClerkResult.unknownFailure(ssoCancellation())
@@ -43,7 +43,7 @@ class ForgotPasswordViewModelTest {
       viewModel.signInWithProvider(OAuthProvider.GITHUB)
       advanceUntilIdle()
 
-      assertEquals(ResetPasswordViewState.NotStarted, viewModel.state.value)
+      assertEquals(ResetPasswordViewState.Idle, viewModel.state.value)
     }
 
   private fun ssoCancellation(): Throwable =

--- a/source/ui/src/test/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModelTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/signin/password/forgot/ForgotPasswordViewModelTest.kt
@@ -3,9 +3,11 @@ package com.clerk.ui.signin.password.forgot
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.signin.SignIn
 import com.clerk.api.sso.OAuthProvider
+import com.clerk.ui.signin.authenticateWithRedirect
 import com.clerk.ui.userprofile.MainDispatcherRule
 import io.mockk.coEvery
-import io.mockk.mockkObject
+import io.mockk.coVerify
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -25,7 +27,7 @@ class ForgotPasswordViewModelTest {
 
   @Before
   fun setUp() {
-    mockkObject(SignIn.Companion)
+    mockkStatic("com.clerk.ui.signin.SignInRedirectKt")
   }
 
   @After
@@ -36,14 +38,27 @@ class ForgotPasswordViewModelTest {
   @Test
   fun `OAuth cancellation leaves forgot password idle`() =
     runTest(testDispatcher) {
-      coEvery { SignIn.authenticateWithRedirect(any(), any()) } returns
+      val signIn = SignIn(id = "sign_in_existing", status = SignIn.Status.NEEDS_FIRST_FACTOR)
+      coEvery { authenticateWithRedirect(signIn, OAuthProvider.GITHUB, true) } returns
         ClerkResult.unknownFailure(ssoCancellation())
       val viewModel = ForgotPasswordViewModel(ioDispatcher = testDispatcher)
 
-      viewModel.signInWithProvider(OAuthProvider.GITHUB)
+      viewModel.signInWithProvider(OAuthProvider.GITHUB, signIn = signIn)
       advanceUntilIdle()
 
       assertEquals(ResetPasswordViewState.Idle, viewModel.state.value)
+    }
+
+  @Test
+  fun `missing sign in returns to auth start`() =
+    runTest(testDispatcher) {
+      val viewModel = ForgotPasswordViewModel(ioDispatcher = testDispatcher)
+
+      viewModel.signInWithProvider(OAuthProvider.GITHUB, signIn = null)
+      advanceUntilIdle()
+
+      assertEquals(ResetPasswordViewState.NotStarted, viewModel.state.value)
+      coVerify(exactly = 0) { authenticateWithRedirect(any(), any(), any()) }
     }
 
   private fun ssoCancellation(): Throwable =


### PR DESCRIPTION
Preserves the active sign-in attempt when launching OAuth from the alternative-method and forgot-password screens. SSO cancellation now leaves the current screen, identifier, and available factors intact.

Fixes #923.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redirect authentication now continues existing sign-in attempts after preparing the selected OAuth provider and transferability settings.

* **Bug Fixes**
  * OAuth cancellation consistently returns sign-in and password recovery flows to an idle state.
  * Authentication no longer starts a redirect when no sign-in attempt is available.
  * Preparation failures continue to be returned without alteration.

* **Tests**
  * Added coverage for prepared redirects, missing sign-in attempts, and OAuth cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->