### PR TITLE
feat(api): add Google Play restore credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ clerk-android/
 
 4. **Authentication Features:**
    - `passkeys/` - WebAuthn/Passkey via Google Credential Manager
+   - `restorecredentials/` - Google Play restore-key creation, sign-in, and cleanup through Credential Manager; currently reuses passkey endpoints and requires backend compatibility and device restore validation before release
    - `sso/` - OAuth/SSO providers (Google One Tap, enterprise SSO)
    - `organizations/` - Multi-tenant organization support
    - `session/` - JWT token caching and refresh

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -34,6 +34,7 @@ import com.clerk.api.network.model.factor.isResetFactor
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.organizations.Organization
 import com.clerk.api.organizations.OrganizationMembership
+import com.clerk.api.restorecredentials.RestoreCredentials
 import com.clerk.api.session.Session
 import com.clerk.api.session.SessionTokenFetcher
 import com.clerk.api.session.SessionTokensCache
@@ -742,6 +743,14 @@ object Clerk {
    */
   val biometricCredentials: BiometricCredentials = BiometricCredentials
 
+  /**
+   * The main entry point for Google Play Restore Credentials operations.
+   *
+   * Use this to create a restore key for the signed-in user, redeem a restored key on a new device,
+   * or explicitly clear the restore key.
+   */
+  val restoreCredentials: RestoreCredentials = RestoreCredentials
+
   // endregion
 
   // region Public Methods
@@ -1029,14 +1038,14 @@ object Clerk {
   private fun cacheStateIfReady() {
     val cachedEnvironment = environment
     val cachedClient = _clientFlow.value
-    val cachedResources = cachedClient?.let { client ->
-      cachedEnvironment?.let { environment -> client to environment }
-    }
+    val cachedResources =
+      cachedClient?.let { client ->
+        cachedEnvironment?.let { environment -> client to environment }
+      }
     val cachedPublishableKey = publishableKey
     val cachedBaseUrl = runCatching { baseUrl }.getOrNull()
-    val cachedConfiguration = cachedPublishableKey?.let { key ->
-      cachedBaseUrl?.let { url -> key to url }
-    }
+    val cachedConfiguration =
+      cachedPublishableKey?.let { key -> cachedBaseUrl?.let { url -> key to url } }
     val cachedServerFetchAtMillis = lastClientServerFetchAtMillis
     val state =
       if (
@@ -1142,9 +1151,8 @@ object Clerk {
   }
 
   private fun Client.withResolvedActiveSession(previousSession: Session?): Client {
-    val currentActiveSessionId = lastActiveSessionId?.takeIf { activeSessionId ->
-      sessions.any { it.id == activeSessionId }
-    }
+    val currentActiveSessionId =
+      lastActiveSessionId?.takeIf { activeSessionId -> sessions.any { it.id == activeSessionId } }
     val resolvedActiveSessionId =
       currentActiveSessionId
         ?: previousSession?.id?.takeIf { previousSessionId ->
@@ -1353,9 +1361,8 @@ fun Map<String, UserSettings.SocialConfig>.toOAuthProvidersList(): List<OAuthPro
     .filter { it.enabled && it.authenticatable }
     .map { OAuthProvider.fromStrategy(it.strategy) }
 
-fun SignIn.identifyingFirstFactor(strategy: String): Factor? = supportedFirstFactors?.firstOrNull {
-  it.strategy == strategy && it.safeIdentifier == identifier
-}
+fun SignIn.identifyingFirstFactor(strategy: String): Factor? =
+  supportedFirstFactors?.firstOrNull { it.strategy == strategy && it.safeIdentifier == identifier }
 
 val SignIn.resetPasswordFactor: Factor?
   get() =

--- a/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/Clerk.kt
@@ -1038,14 +1038,14 @@ object Clerk {
   private fun cacheStateIfReady() {
     val cachedEnvironment = environment
     val cachedClient = _clientFlow.value
-    val cachedResources =
-      cachedClient?.let { client ->
-        cachedEnvironment?.let { environment -> client to environment }
-      }
+    val cachedResources = cachedClient?.let { client ->
+      cachedEnvironment?.let { environment -> client to environment }
+    }
     val cachedPublishableKey = publishableKey
     val cachedBaseUrl = runCatching { baseUrl }.getOrNull()
-    val cachedConfiguration =
-      cachedPublishableKey?.let { key -> cachedBaseUrl?.let { url -> key to url } }
+    val cachedConfiguration = cachedPublishableKey?.let { key ->
+      cachedBaseUrl?.let { url -> key to url }
+    }
     val cachedServerFetchAtMillis = lastClientServerFetchAtMillis
     val state =
       if (
@@ -1151,8 +1151,9 @@ object Clerk {
   }
 
   private fun Client.withResolvedActiveSession(previousSession: Session?): Client {
-    val currentActiveSessionId =
-      lastActiveSessionId?.takeIf { activeSessionId -> sessions.any { it.id == activeSessionId } }
+    val currentActiveSessionId = lastActiveSessionId?.takeIf { activeSessionId ->
+      sessions.any { it.id == activeSessionId }
+    }
     val resolvedActiveSessionId =
       currentActiveSessionId
         ?: previousSession?.id?.takeIf { previousSessionId ->
@@ -1361,8 +1362,9 @@ fun Map<String, UserSettings.SocialConfig>.toOAuthProvidersList(): List<OAuthPro
     .filter { it.enabled && it.authenticatable }
     .map { OAuthProvider.fromStrategy(it.strategy) }
 
-fun SignIn.identifyingFirstFactor(strategy: String): Factor? =
-  supportedFirstFactors?.firstOrNull { it.strategy == strategy && it.safeIdentifier == identifier }
+fun SignIn.identifyingFirstFactor(strategy: String): Factor? = supportedFirstFactors?.firstOrNull {
+  it.strategy == strategy && it.safeIdentifier == identifier
+}
 
 val SignIn.resetPasswordFactor: Factor?
   get() =

--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -765,10 +765,9 @@ class Auth internal constructor() {
       // Fetched client is missing the target session entirely (e.g. cleared sessions list);
       // splice it back in from the fallback and force it active.
       !targetInFetchedSessions && targetInFallbackSessions -> {
-        val missingFallbackSessions =
-          fallbackSessions.filterNot { fallbackSession ->
-            sessions.any { it.id == fallbackSession.id }
-          }
+        val missingFallbackSessions = fallbackSessions.filterNot { fallbackSession ->
+          sessions.any { it.id == fallbackSession.id }
+        }
         copy(
           sessions = sessions + missingFallbackSessions,
           lastActiveSessionId = activeSessionFallbackId,

--- a/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/auth/Auth.kt
@@ -30,6 +30,7 @@ import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.errorMessage
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.passkeys.PasskeyService
+import com.clerk.api.restorecredentials.RestoreCredentials
 import com.clerk.api.session.GetTokenOptions
 import com.clerk.api.session.Session
 import com.clerk.api.session.fetchToken
@@ -364,6 +365,18 @@ class Auth internal constructor() {
   }
 
   /**
+   * Silently signs in with a Google Play restore credential transferred from another device.
+   *
+   * When no restore credential is available, the returned failure can be ignored and the app can
+   * continue with its normal sign-in experience.
+   */
+  suspend fun signInWithRestoreCredential(): ClerkResult<SignIn, ClerkErrorResponse> {
+    val result = RestoreCredentials.signIn()
+    result.onFailure { emitAuthError(it) }
+    return result
+  }
+
+  /**
    * Signs in with a locally enrolled biometric credential.
    *
    * The biometric-credential domain owns local credential selection, key access, challenge signing,
@@ -677,6 +690,7 @@ class Auth internal constructor() {
         when (val result = ClerkApi.session.removeSession(sessionId)) {
           is ClerkResult.Success -> {
             removeSessionLocally(sessionId)
+            RestoreCredentials.clearSilently()
             refreshClientAfterSessionMutation()
             ClerkResult.success(Unit)
           }
@@ -751,9 +765,10 @@ class Auth internal constructor() {
       // Fetched client is missing the target session entirely (e.g. cleared sessions list);
       // splice it back in from the fallback and force it active.
       !targetInFetchedSessions && targetInFallbackSessions -> {
-        val missingFallbackSessions = fallbackSessions.filterNot { fallbackSession ->
-          sessions.any { it.id == fallbackSession.id }
-        }
+        val missingFallbackSessions =
+          fallbackSessions.filterNot { fallbackSession ->
+            sessions.any { it.id == fallbackSession.id }
+          }
         copy(
           sessions = sessions + missingFallbackSessions,
           lastActiveSessionId = activeSessionFallbackId,

--- a/source/api/src/main/kotlin/com/clerk/api/restorecredentials/RestoreCredentialManager.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/restorecredentials/RestoreCredentialManager.kt
@@ -1,0 +1,47 @@
+package com.clerk.api.restorecredentials
+
+import android.content.Context
+import androidx.credentials.ClearCredentialStateRequest
+import androidx.credentials.CreateRestoreCredentialRequest
+import androidx.credentials.CreateRestoreCredentialResponse
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+
+/** Testable wrapper around the Android Credential Manager restore-credential operations. */
+internal interface RestoreCredentialManager {
+
+  suspend fun createCredential(
+    context: Context,
+    request: CreateRestoreCredentialRequest,
+  ): CreateRestoreCredentialResponse
+
+  suspend fun getCredential(context: Context, request: GetCredentialRequest): GetCredentialResponse
+
+  suspend fun clearCredentialState(context: Context, request: ClearCredentialStateRequest)
+}
+
+internal class RestoreCredentialManagerImpl : RestoreCredentialManager {
+
+  override suspend fun createCredential(
+    context: Context,
+    request: CreateRestoreCredentialRequest,
+  ): CreateRestoreCredentialResponse {
+    return CredentialManager.create(context).createCredential(context, request)
+      as CreateRestoreCredentialResponse
+  }
+
+  override suspend fun getCredential(
+    context: Context,
+    request: GetCredentialRequest,
+  ): GetCredentialResponse {
+    return CredentialManager.create(context).getCredential(context, request)
+  }
+
+  override suspend fun clearCredentialState(
+    context: Context,
+    request: ClearCredentialStateRequest,
+  ) {
+    CredentialManager.create(context).clearCredentialState(request)
+  }
+}

--- a/source/api/src/main/kotlin/com/clerk/api/restorecredentials/RestoreCredentials.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/restorecredentials/RestoreCredentials.kt
@@ -1,0 +1,219 @@
+package com.clerk.api.restorecredentials
+
+import android.os.Build
+import androidx.annotation.VisibleForTesting
+import androidx.credentials.ClearCredentialStateRequest
+import androidx.credentials.CreateRestoreCredentialRequest
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetRestoreCredentialOption
+import androidx.credentials.RestoreCredential
+import androidx.credentials.exceptions.ClearCredentialException
+import androidx.credentials.exceptions.CreateCredentialException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.restorecredential.E2eeUnavailableException
+import com.clerk.api.Clerk
+import com.clerk.api.Constants.Strategy.PASSKEY
+import com.clerk.api.credentials.CredentialFlowException
+import com.clerk.api.credentials.classifyCreateCredentialFailure
+import com.clerk.api.credentials.classifyGetCredentialFailure
+import com.clerk.api.log.ClerkLog
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.model.error.ClerkErrorResponse
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.signin.SignIn
+import com.clerk.api.signin.attemptFirstFactor
+
+/**
+ * The main entry point for Google Play Restore Credentials operations.
+ *
+ * Access via [Clerk.restoreCredentials]. Restore credentials use Android Credential Manager to
+ * create a system-managed restore key for the current user and silently redeem that key after the
+ * app is transferred to a new Android device.
+ */
+@Suppress("ReturnCount")
+object RestoreCredentials {
+
+  @VisibleForTesting
+  internal var credentialManager: RestoreCredentialManager = RestoreCredentialManagerImpl()
+
+  /**
+   * Creates a restore credential for the current signed-in user.
+   *
+   * Cloud backup is attempted by default. If the device does not have end-to-end encrypted backup
+   * available, creation is retried automatically with device-to-device restore support only.
+   *
+   * @param isCloudBackupEnabled Whether Google Password Manager should back up the restore key to
+   *   the cloud when end-to-end encrypted backup is available.
+   */
+  suspend fun create(isCloudBackupEnabled: Boolean = true): ClerkResult<Unit, ClerkErrorResponse> {
+    if (!isSupportedAndroidVersion) return unsupportedPlatformFailure()
+    if (Clerk.activeSession == null || Clerk.user == null) {
+      return ClerkResult.unknownFailure(
+        IllegalStateException("A signed-in user is required to create a restore credential.")
+      )
+    }
+    val context =
+      Clerk.applicationContext?.get()
+        ?: return ClerkResult.unknownFailure(
+          IllegalStateException("Clerk must be initialized before creating a restore credential.")
+        )
+
+    return when (val prepareResult = ClerkApi.user.createPasskey()) {
+      is ClerkResult.Failure -> prepareResult
+      is ClerkResult.Success -> {
+        val nonce =
+          prepareResult.value.verification?.nonce?.takeIf { it.isNotBlank() }
+            ?: return ClerkResult.unknownFailure(
+              IllegalStateException("Restore credential registration did not return a challenge.")
+            )
+
+        val response =
+          try {
+            createCredentialWithCloudFallback(context, nonce, isCloudBackupEnabled)
+          } catch (e: CreateCredentialException) {
+            ClerkLog.e("Restore credential creation failed: ${e.message}")
+            return classifyCreateCredentialFailure(e)
+          } catch (e: Exception) {
+            ClerkLog.e("Restore credential creation failed: ${e.message}")
+            return ClerkResult.unknownFailure(e)
+          }
+
+        when (
+          val verificationResult =
+            ClerkApi.user.attemptPasskeyVerification(
+              passkeyId = prepareResult.value.id,
+              strategy = PASSKEY,
+              publicKeyCredential = response.responseJson,
+            )
+        ) {
+          is ClerkResult.Success -> ClerkResult.success(Unit)
+          is ClerkResult.Failure -> verificationResult
+        }
+      }
+    }
+  }
+
+  /**
+   * Silently signs in with a restore credential transferred by Android device setup.
+   *
+   * This method does not display credential-selection UI. When no restore credential is available,
+   * it returns a credential-flow failure so the host app can continue with its normal sign-in UI.
+   */
+  suspend fun signIn(): ClerkResult<SignIn, ClerkErrorResponse> {
+    if (!isSupportedAndroidVersion) return unsupportedPlatformFailure()
+    if (Clerk.activeSession != null) {
+      return ClerkResult.unknownFailure(
+        IllegalStateException("Restore credential sign-in requires a signed-out client.")
+      )
+    }
+    val context =
+      Clerk.applicationContext?.get()
+        ?: return ClerkResult.unknownFailure(
+          IllegalStateException("Clerk must be initialized before restore credential sign-in.")
+        )
+
+    val signIn =
+      when (
+        val createResult =
+          ClerkApi.signIn.createSignIn(
+            mapOf("strategy" to PASSKEY, "locale" to Clerk.locale.value.orEmpty())
+          )
+      ) {
+        is ClerkResult.Success -> createResult.value
+        is ClerkResult.Failure -> return createResult
+      }
+
+    val nonce =
+      signIn.firstFactorVerification?.nonce?.takeIf { it.isNotBlank() }
+        ?: return ClerkResult.unknownFailure(
+            IllegalStateException("Restore credential sign-in did not return a challenge.")
+          )
+          .also { clearSignInAttempt(signIn) }
+
+    return try {
+      val request = GetCredentialRequest(listOf(GetRestoreCredentialOption(nonce)))
+      val credential = credentialManager.getCredential(context, request).credential
+      if (credential !is RestoreCredential) {
+        ClerkResult.unknownFailure(
+            IllegalStateException("Credential Manager returned a non-restore credential.")
+          )
+          .also { clearSignInAttempt(signIn) }
+      } else {
+        signIn.attemptFirstFactor(
+          SignIn.AttemptFirstFactorParams.Passkey(credential.authenticationResponseJson)
+        )
+      }
+    } catch (e: GetCredentialException) {
+      ClerkLog.d("Restore credential sign-in is unavailable: ${e.message}")
+      classifyGetCredentialFailure(e, listOf(SignIn.CredentialType.PASSKEY)).also {
+        clearSignInAttempt(signIn)
+      }
+    } catch (e: Exception) {
+      ClerkLog.e("Restore credential sign-in failed: ${e.message}")
+      ClerkResult.unknownFailure(e).also { clearSignInAttempt(signIn) }
+    }
+  }
+
+  /** Deletes the app's restore credential from this device and its cloud backup. */
+  suspend fun clear(): ClerkResult<Unit, ClerkErrorResponse> {
+    if (!isSupportedAndroidVersion) return ClerkResult.success(Unit)
+    val context =
+      Clerk.applicationContext?.get()
+        ?: return ClerkResult.unknownFailure(
+          IllegalStateException("Clerk must be initialized before clearing a restore credential.")
+        )
+
+    return try {
+      credentialManager.clearCredentialState(
+        context,
+        ClearCredentialStateRequest(ClearCredentialStateRequest.TYPE_CLEAR_RESTORE_CREDENTIAL),
+      )
+      ClerkResult.success(Unit)
+    } catch (e: ClearCredentialException) {
+      ClerkLog.w("Failed to clear restore credential: ${e.message}")
+      ClerkResult.unknownFailure(e)
+    } catch (e: Exception) {
+      ClerkLog.w("Failed to clear restore credential: ${e.message}")
+      ClerkResult.unknownFailure(e)
+    }
+  }
+
+  internal suspend fun clearSilently() {
+    if (clear() is ClerkResult.Failure) {
+      ClerkLog.w("Restore credential cleanup did not complete.")
+    }
+  }
+
+  private suspend fun createCredentialWithCloudFallback(
+    context: android.content.Context,
+    requestJson: String,
+    isCloudBackupEnabled: Boolean,
+  ) =
+    try {
+      credentialManager.createCredential(
+        context,
+        CreateRestoreCredentialRequest(requestJson, isCloudBackupEnabled),
+      )
+    } catch (e: E2eeUnavailableException) {
+      if (!isCloudBackupEnabled) throw e
+      ClerkLog.d(
+        "Encrypted cloud backup is unavailable; retrying restore credential creation without it."
+      )
+      credentialManager.createCredential(
+        context,
+        CreateRestoreCredentialRequest(requestJson, isCloudBackupEnabled = false),
+      )
+    }
+
+  private fun clearSignInAttempt(signIn: SignIn) {
+    if (!Clerk.clientInitialized || Clerk.client.signIn?.id != signIn.id) return
+    Clerk.updateClient(Clerk.client.copy(signIn = null))
+  }
+
+  private val isSupportedAndroidVersion: Boolean
+    get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+
+  private fun <T : Any> unsupportedPlatformFailure(): ClerkResult<T, ClerkErrorResponse> {
+    return ClerkResult.unknownFailure(CredentialFlowException.ProviderUnavailable())
+  }
+}

--- a/source/api/src/main/kotlin/com/clerk/api/signout/SignOutService.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/signout/SignOutService.kt
@@ -7,6 +7,7 @@ import com.clerk.api.network.model.client.Client
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.serialization.ClerkResult
 import com.clerk.api.network.serialization.errorMessage
+import com.clerk.api.restorecredentials.RestoreCredentials
 import com.clerk.api.storage.StorageHelper
 import com.clerk.api.storage.StorageKey
 
@@ -44,6 +45,7 @@ internal object SignOutService {
       serverError = e
     } finally {
       // Always clear local credentials regardless of server response
+      RestoreCredentials.clearSilently()
       StorageHelper.deleteValue(StorageKey.DEVICE_TOKEN)
       Clerk.updateClient(Client())
 

--- a/source/api/src/main/kotlin/com/clerk/api/user/User.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/user/User.kt
@@ -22,6 +22,7 @@ import com.clerk.api.organizations.UserOrganizationInvitation
 import com.clerk.api.passkeys.Passkey
 import com.clerk.api.passkeys.PasskeyService
 import com.clerk.api.phonenumber.PhoneNumber
+import com.clerk.api.restorecredentials.RestoreCredentials
 import com.clerk.api.session.Session
 import com.clerk.api.session.SessionTaskKey
 import com.clerk.api.session.pendingTaskKey
@@ -744,6 +745,20 @@ suspend fun User.createPasskey(): ClerkResult<Passkey, ClerkErrorResponse> {
 }
 
 /**
+ * Creates a Google Play restore credential for this signed-in user.
+ *
+ * Cloud backup is attempted by default and automatically falls back to device-to-device transfer
+ * when end-to-end encrypted cloud backup is unavailable.
+ *
+ * @param isCloudBackupEnabled Whether to back up the restore credential to encrypted cloud backup.
+ */
+suspend fun User.createRestoreCredential(
+  isCloudBackupEnabled: Boolean = true
+): ClerkResult<Unit, ClerkErrorResponse> {
+  return RestoreCredentials.create(isCloudBackupEnabled)
+}
+
+/**
  * Adds an external account for the user. A new [ExternalAccount] will be created and associated
  * with the user. This method is useful if you want to allow an already signed-in user to connect
  * their account with an external provider, such as Facebook, GitHub, etc., so that they can sign in
@@ -929,11 +944,12 @@ private fun User.hasAlternativeFirstFactorIdentification(excludingPhoneId: Strin
     emailAddresses.orEmpty().any { email ->
       email.verification?.status == Verification.Status.VERIFIED
     }
-  val hasAnotherVerifiedNonReservedPhone = phoneNumbers.any { phone ->
-    phone.id != excludingPhoneId &&
-      !phone.reservedForSecondFactor &&
-      phone.verification?.status == Verification.Status.VERIFIED
-  }
+  val hasAnotherVerifiedNonReservedPhone =
+    phoneNumbers.any { phone ->
+      phone.id != excludingPhoneId &&
+        !phone.reservedForSecondFactor &&
+        phone.verification?.status == Verification.Status.VERIFIED
+    }
   return hasUsername || hasVerifiedEmail || hasAnotherVerifiedNonReservedPhone
 }
 

--- a/source/api/src/main/kotlin/com/clerk/api/user/User.kt
+++ b/source/api/src/main/kotlin/com/clerk/api/user/User.kt
@@ -944,12 +944,11 @@ private fun User.hasAlternativeFirstFactorIdentification(excludingPhoneId: Strin
     emailAddresses.orEmpty().any { email ->
       email.verification?.status == Verification.Status.VERIFIED
     }
-  val hasAnotherVerifiedNonReservedPhone =
-    phoneNumbers.any { phone ->
-      phone.id != excludingPhoneId &&
-        !phone.reservedForSecondFactor &&
-        phone.verification?.status == Verification.Status.VERIFIED
-    }
+  val hasAnotherVerifiedNonReservedPhone = phoneNumbers.any { phone ->
+    phone.id != excludingPhoneId &&
+      !phone.reservedForSecondFactor &&
+      phone.verification?.status == Verification.Status.VERIFIED
+  }
   return hasUsername || hasVerifiedEmail || hasAnotherVerifiedNonReservedPhone
 }
 

--- a/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
+++ b/source/api/src/test/java/com/clerk/api/auth/AuthTest.kt
@@ -16,6 +16,7 @@ import com.clerk.api.network.model.environment.UserSettings
 import com.clerk.api.network.model.error.ClerkErrorResponse
 import com.clerk.api.network.model.error.Error
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.restorecredentials.RestoreCredentials
 import com.clerk.api.session.Session
 import com.clerk.api.signin.SignIn
 import com.clerk.api.signup.SignUp
@@ -73,6 +74,19 @@ class AuthTest {
     assertTrue(result is ClerkResult.Success)
     assertSame(oauthResult, (result as ClerkResult.Success).value)
     coVerify(exactly = 1) { SignIn.authenticateWithGoogleOneTap(true) }
+  }
+
+  @Test
+  fun `signInWithRestoreCredential delegates to restore credentials`() = runTest {
+    mockkObject(RestoreCredentials)
+    val signIn = mockk<SignIn>(relaxed = true)
+    coEvery { RestoreCredentials.signIn() } returns ClerkResult.success(signIn)
+
+    val result = Auth().signInWithRestoreCredential()
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(signIn, (result as ClerkResult.Success).value)
+    coVerify(exactly = 1) { RestoreCredentials.signIn() }
   }
 
   @Test
@@ -236,8 +250,10 @@ class AuthTest {
     val sessionApi = mockk<SessionApi>()
     val clientApi = mockk<ClientApi>()
     mockkObject(ClerkApi)
+    mockkObject(RestoreCredentials)
     every { ClerkApi.session } returns sessionApi
     every { ClerkApi.client } returns clientApi
+    coEvery { RestoreCredentials.clearSilently() } returns Unit
     coEvery { sessionApi.removeSession(firstSession.id) } returns ClerkResult.success(firstSession)
     coEvery { clientApi.get() } returns
       ClerkResult.apiFailure(ClerkErrorResponse(errors = emptyList()))
@@ -256,6 +272,7 @@ class AuthTest {
     assertEquals(secondSession.id, Clerk.client.lastActiveSessionId)
     assertEquals(secondSession, Clerk.sessionFlow.value)
     coVerify(exactly = 1) { sessionApi.removeSession(firstSession.id) }
+    coVerify(exactly = 1) { RestoreCredentials.clearSilently() }
   }
 
   @Test

--- a/source/api/src/test/java/com/clerk/api/restorecredentials/RestoreCredentialsTest.kt
+++ b/source/api/src/test/java/com/clerk/api/restorecredentials/RestoreCredentialsTest.kt
@@ -1,0 +1,269 @@
+package com.clerk.api.restorecredentials
+
+import android.content.Context
+import androidx.credentials.ClearCredentialStateRequest
+import androidx.credentials.CreateRestoreCredentialRequest
+import androidx.credentials.CreateRestoreCredentialResponse
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.GetRestoreCredentialOption
+import androidx.credentials.RestoreCredential
+import androidx.credentials.exceptions.NoCredentialException
+import androidx.credentials.exceptions.restorecredential.E2eeUnavailableException
+import com.clerk.api.Clerk
+import com.clerk.api.credentials.CredentialFlowException
+import com.clerk.api.network.ClerkApi
+import com.clerk.api.network.api.SignInApi
+import com.clerk.api.network.api.UserApi
+import com.clerk.api.network.model.verification.Verification
+import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.passkeys.Passkey
+import com.clerk.api.session.Session
+import com.clerk.api.signin.SignIn
+import com.clerk.api.user.User
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import java.lang.ref.WeakReference
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class RestoreCredentialsTest {
+
+  private lateinit var context: Context
+  private lateinit var credentialManager: RestoreCredentialManager
+  private lateinit var userApi: UserApi
+  private lateinit var signInApi: SignInApi
+  private lateinit var session: Session
+
+  @Before
+  fun setup() {
+    context = RuntimeEnvironment.getApplication()
+    credentialManager = mockk()
+    userApi = mockk()
+    signInApi = mockk()
+    session =
+      Session(
+        id = "session_1",
+        status = Session.SessionStatus.ACTIVE,
+        expireAt = 0,
+        lastActiveAt = 0,
+        createdAt = 0,
+        updatedAt = 0,
+      )
+
+    mockkObject(Clerk)
+    every { Clerk.applicationContext } returns WeakReference(context)
+    every { Clerk.activeSession } returns session
+    every { Clerk.session } returns session
+    every { Clerk.user } returns mockk<User>(relaxed = true)
+    every { Clerk.locale } returns MutableStateFlow(null)
+    every { Clerk.clientInitialized } returns false
+
+    mockkObject(ClerkApi)
+    every { ClerkApi.user } returns userApi
+    every { ClerkApi.signIn } returns signInApi
+
+    RestoreCredentials.credentialManager = credentialManager
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+    RestoreCredentials.credentialManager = RestoreCredentialManagerImpl()
+  }
+
+  @Test
+  fun `create registers and verifies a cloud-backed restore credential`() = runTest {
+    val request = slot<CreateRestoreCredentialRequest>()
+    val preparedPasskey = preparedPasskey()
+    val credentialResponse = CreateRestoreCredentialResponse(REGISTRATION_RESPONSE_JSON)
+
+    coEvery { userApi.createPasskey(any()) } returns ClerkResult.success(preparedPasskey)
+    coEvery { credentialManager.createCredential(eq(context), capture(request)) } returns
+      credentialResponse
+    coEvery {
+      userApi.attemptPasskeyVerification(
+        passkeyId = preparedPasskey.id,
+        strategy = "passkey",
+        publicKeyCredential = REGISTRATION_RESPONSE_JSON,
+        sessionId = session.id,
+      )
+    } returns ClerkResult.success(preparedPasskey)
+
+    val result = RestoreCredentials.create()
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(REGISTRATION_REQUEST_JSON, request.captured.requestJson)
+    assertTrue(request.captured.isCloudBackupEnabled)
+    coVerify(exactly = 1) {
+      userApi.attemptPasskeyVerification(
+        passkeyId = preparedPasskey.id,
+        strategy = "passkey",
+        publicKeyCredential = REGISTRATION_RESPONSE_JSON,
+        sessionId = session.id,
+      )
+    }
+  }
+
+  @Test
+  fun `create retries without cloud backup when encrypted backup is unavailable`() = runTest {
+    val preparedPasskey = preparedPasskey()
+    val credentialResponse = CreateRestoreCredentialResponse(REGISTRATION_RESPONSE_JSON)
+    val cloudBackupValues = mutableListOf<Boolean>()
+
+    coEvery { userApi.createPasskey(any()) } returns ClerkResult.success(preparedPasskey)
+    coEvery { credentialManager.createCredential(eq(context), any()) } answers
+      {
+        val request = secondArg<CreateRestoreCredentialRequest>()
+        cloudBackupValues += request.isCloudBackupEnabled
+        if (request.isCloudBackupEnabled) {
+          throw E2eeUnavailableException("Encrypted backup unavailable")
+        }
+        credentialResponse
+      }
+    coEvery { userApi.attemptPasskeyVerification(any(), any(), any(), any()) } returns
+      ClerkResult.success(preparedPasskey)
+
+    val result = RestoreCredentials.create()
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(listOf(true, false), cloudBackupValues)
+  }
+
+  @Test
+  fun `signIn requests only the restore credential and attempts passkey verification`() = runTest {
+    every { Clerk.activeSession } returns null
+    every { Clerk.session } returns null
+    every { Clerk.user } returns null
+    val request = slot<GetCredentialRequest>()
+    val attemptParams = slot<Map<String, String>>()
+    val restoreCredential = mockk<RestoreCredential>()
+    val pendingSignIn = pendingSignIn()
+    val completedSignIn = SignIn(id = pendingSignIn.id, status = SignIn.Status.COMPLETE)
+
+    every { restoreCredential.authenticationResponseJson } returns AUTHENTICATION_RESPONSE_JSON
+    coEvery { signInApi.createSignIn(any()) } returns ClerkResult.success(pendingSignIn)
+    coEvery { credentialManager.getCredential(eq(context), capture(request)) } returns
+      GetCredentialResponse(restoreCredential)
+    coEvery { signInApi.attemptFirstFactor(pendingSignIn.id, capture(attemptParams)) } returns
+      ClerkResult.success(completedSignIn)
+
+    val result = RestoreCredentials.signIn()
+
+    assertTrue(result is ClerkResult.Success)
+    assertSame(completedSignIn, (result as ClerkResult.Success).value)
+    val options = request.captured.credentialOptions
+    assertEquals(1, options.size)
+    assertTrue(options.single() is GetRestoreCredentialOption)
+    assertEquals(
+      AUTHENTICATION_REQUEST_JSON,
+      (options.single() as GetRestoreCredentialOption).requestJson,
+    )
+    assertEquals("passkey", attemptParams.captured["strategy"])
+    assertEquals(AUTHENTICATION_RESPONSE_JSON, attemptParams.captured["public_key_credential"])
+  }
+
+  @Test
+  fun `signIn classifies a missing restore credential without attempting verification`() = runTest {
+    every { Clerk.activeSession } returns null
+    every { Clerk.session } returns null
+    every { Clerk.user } returns null
+    val pendingSignIn = pendingSignIn()
+
+    coEvery { signInApi.createSignIn(any()) } returns ClerkResult.success(pendingSignIn)
+    coEvery { credentialManager.getCredential(eq(context), any()) } throws
+      NoCredentialException("No restore credential")
+
+    val result = RestoreCredentials.signIn()
+
+    assertTrue(result is ClerkResult.Failure)
+    assertTrue(
+      (result as ClerkResult.Failure).throwable is CredentialFlowException.NoSavedCredential
+    )
+    coVerify(exactly = 0) { signInApi.attemptFirstFactor(any(), any()) }
+  }
+
+  @Test
+  fun `clear deletes only the restore credential state`() = runTest {
+    val request = slot<ClearCredentialStateRequest>()
+    coEvery { credentialManager.clearCredentialState(eq(context), capture(request)) } returns Unit
+
+    val result = RestoreCredentials.clear()
+
+    assertTrue(result is ClerkResult.Success)
+    assertEquals(
+      ClearCredentialStateRequest.TYPE_CLEAR_RESTORE_CREDENTIAL,
+      request.captured.requestType,
+    )
+  }
+
+  @Test
+  @Config(sdk = [27])
+  fun `create reports restore credentials unavailable before Android 9`() = runTest {
+    val result = RestoreCredentials.create()
+
+    assertTrue(result is ClerkResult.Failure)
+    assertTrue(
+      (result as ClerkResult.Failure).throwable is CredentialFlowException.ProviderUnavailable
+    )
+    coVerify(exactly = 0) { userApi.createPasskey(any()) }
+    coVerify(exactly = 0) { credentialManager.createCredential(any(), any()) }
+  }
+
+  @Test
+  fun `create rejects signed-out clients before preparing a server credential`() = runTest {
+    every { Clerk.activeSession } returns null
+    every { Clerk.session } returns null
+    every { Clerk.user } returns null
+
+    val result = RestoreCredentials.create()
+
+    assertTrue(result is ClerkResult.Failure)
+    assertFalse(result is ClerkResult.Success)
+    coVerify(exactly = 0) { userApi.createPasskey(any()) }
+  }
+
+  private fun preparedPasskey(): Passkey {
+    return Passkey(
+      id = "passkey_1",
+      name = "Restore credential",
+      verification = Verification(nonce = REGISTRATION_REQUEST_JSON),
+      createdAt = 0,
+      updatedAt = 0,
+    )
+  }
+
+  private fun pendingSignIn(): SignIn {
+    return SignIn(
+      id = "sign_in_1",
+      status = SignIn.Status.NEEDS_FIRST_FACTOR,
+      firstFactorVerification = Verification(nonce = AUTHENTICATION_REQUEST_JSON),
+    )
+  }
+
+  private companion object {
+    const val REGISTRATION_REQUEST_JSON = """{"challenge":"challenge","user":{"id":"dXNlcl8x"}}"""
+    const val REGISTRATION_RESPONSE_JSON =
+      """{"id":"credential_1","type":"public-key","response":{}}"""
+    const val AUTHENTICATION_REQUEST_JSON = """{"challenge":"challenge"}"""
+    const val AUTHENTICATION_RESPONSE_JSON =
+      """{"id":"credential_1","type":"public-key","response":{}}"""
+  }
+}

--- a/source/api/src/test/java/com/clerk/api/signout/SignOutServiceTest.kt
+++ b/source/api/src/test/java/com/clerk/api/signout/SignOutServiceTest.kt
@@ -10,6 +10,7 @@ import com.clerk.api.network.model.environment.DisplayConfig
 import com.clerk.api.network.model.environment.Environment
 import com.clerk.api.network.model.environment.UserSettings
 import com.clerk.api.network.serialization.ClerkResult
+import com.clerk.api.restorecredentials.RestoreCredentials
 import com.clerk.api.session.Session
 import com.clerk.api.storage.StorageHelper
 import com.clerk.api.storage.StorageKey
@@ -17,8 +18,10 @@ import com.clerk.api.user.User
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.runs
 import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -160,6 +163,19 @@ class SignOutServiceTest {
     assertNull("Session should be cleared on failure", Clerk.session)
     assertNull("User should be cleared on failure", Clerk.user)
     assertFalse("isSignedIn should be false on failure", Clerk.isSignedIn)
+  }
+
+  @Test
+  fun `signOut clears restore credential even when server sign-out fails`() = runTest {
+    setupActiveSession()
+    mockkObject(RestoreCredentials)
+    coEvery { RestoreCredentials.clearSilently() } just runs
+    coEvery { mockSessionApi.deleteSessions() } throws Exception("Network error")
+    coEvery { mockClientApi.getSkippingClientId(any()) } returns ClerkResult.success(Client())
+
+    SignOutService.signOut()
+
+    coVerify(exactly = 1) { RestoreCredentials.clearSilently() }
   }
 
   @Test


### PR DESCRIPTION
### What & why
Adds Google Play restore-credential creation, sign-in, cloud-backup fallback, and sign-out cleanup for [MOBILE-632](https://linear.app/clerk/issue/MOBILE-632/google-play-restore-credentials-support).

### What to focus on
Currently reuses passkey endpoints; backend compatibility with silent restore and real-device backup/restore testing remain unresolved.

### Screenshots / video
N/A — API-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Play restore credential support for creating, restoring, and clearing credentials.
  * Added silent sign-in using transferred restore credentials.
  * Added optional encrypted cloud backup, with fallback when unavailable.
  * Restore credentials are cleared during sign-out, including when server sign-out fails.

* **Bug Fixes**
  * Added validation and error handling for unsupported devices, invalid credentials, unavailable restore states, and signed-in or signed-out state requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->