### PR TITLE
fix(android): keep Retrofit services and generic result types under R8 full mode

### DIFF
--- a/source/api/consumer-rules.pro
+++ b/source/api/consumer-rules.pro
@@ -7,3 +7,14 @@
     *** Companion;
     kotlinx.serialization.KSerializer serializer(...);
 }
+
+# Retrofit creates the service interfaces through java.lang.reflect.Proxy, so R8 full mode sees no instantiation of a
+# service whose methods the consuming app never calls and rewrites the cast in ClerkApi.configure into an unconditional
+# ClassCastException. Retrofit's own conditional keep only fires for interfaces with live annotated methods.
+-keep,allowobfuscation interface com.clerk.api.network.api.*
+
+# ClerkApiResultCallAdapterFactory and ClerkApiResultConverterFactory read these as ParameterizedType; R8 full mode strips
+# the generic signature of any class that is not kept, which reduces them to raw types and breaks converter lookup.
+-keep,allowobfuscation,allowshrinking class com.clerk.api.network.serialization.ClerkResult
+-keep,allowobfuscation,allowshrinking class com.clerk.api.network.ClerkPaginatedResponse
+-keep,allowobfuscation,allowshrinking class com.clerk.api.network.model.response.ClientPiggybackedResponse


### PR DESCRIPTION
### What & why

1.1.5 (#926) dropped the blanket `-keep class com.clerk.api.** { *; }` and relies on Retrofit's bundled rules, but Retrofit's conditional keep only protects service interfaces whose annotated methods are live. In an R8 full-mode consumer that never calls `UserApi` (an auth-only integration), R8 sees no possible instance of the interface and compiles the checkcast after `retrofit.create(UserApi::class.java)` in `ClerkApi.configure` into an unconditional `throw new ClassCastException()`, so the app crashes in `Application.onCreate`. Once past that, the client/environment refresh fails with `Unable to create converter for interface ClerkResult`, because R8 full mode strips the generic signatures of non-kept classes and the service methods' `Continuation<ClerkResult<S, E>>` collapses to a raw type. Full analysis with the disassembly is in #941.

This adds the minimal rules the SDK's own reflection needs, mirroring Retrofit's `retrofit2.pro`: pin the service interfaces (obfuscation still allowed), and keep the generic signatures of the module's three generic types (`ClerkResult`, `ClientPiggybackedResponse`, `ClerkPaginatedResponse`) with `allowshrinking,allowobfuscation`, so nothing is pinned or left unshrunk beyond that.

Verified in an R8 full-mode consumer (AGP 9.3.1, Retrofit 3.0.0, Kotlin 2.4.10): the minified build launches, `/v1/client` and `/v1/environment` load, and an email-code sign-in completes. APK size is unchanged. The interface rule alone is not sufficient (converter failure above).

Closes #941

### What to focus on

- `allowshrinking` on the three generic types keeps only their `Signature` attribute; a consumer that never references them still has them removed.
- The service-interface rule intentionally has no `allowshrinking`: a shrinkable keep does not stop R8's "no instantiation" reasoning. It is the same shape as Retrofit's own `-keep,allowobfuscation interface <1>`.
- There is no minified consumer build in this repo's CI, so this cannot be regression-tested here yet. A small R8 full-mode smoke app would be a good follow-up.

### Screenshots / video

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android release compatibility by preserving required API type information during code optimization.
  * Prevented runtime failures in API configuration and response conversion when applications use aggressive R8 optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->