### PR TITLE
fix(ui): use new-password autofill hints for password reset

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/signin/password/reset/SignInSetNewPasswordView.kt
@@ -168,7 +168,7 @@ private fun PasswordInputs(authState: AuthState, passwordsMatch: Boolean, onSubm
     onValueChange = { authState.signInNewPassword = it },
     visualTransformation = PasswordVisualTransformation(),
     label = stringResource(R.string.new_password),
-    inputContentType = ContentType.Password,
+    inputContentType = ContentType.NewPassword,
     keyboardOptions =
       KeyboardOptions(
         keyboardType = KeyboardType.Password,
@@ -184,7 +184,7 @@ private fun PasswordInputs(authState: AuthState, passwordsMatch: Boolean, onSubm
     onValueChange = { authState.signInConfirmNewPassword = it },
     label = stringResource(R.string.confirm_password),
     visualTransformation = PasswordVisualTransformation(),
-    inputContentType = ContentType.Password,
+    inputContentType = ContentType.NewPassword,
     isError = showPasswordMismatchError,
     supportingText =
       if (showPasswordMismatchError) stringResource(R.string.passwords_dont_match) else null,


### PR DESCRIPTION
### What & why
Use `ContentType.NewPassword` for both reset-password fields so autofill treats them as new passwords, matching the profile screen.

Fixes [MOBILE-611](https://linear.app/clerk/issue/MOBILE-611/spike-reset-password-fields-use-old-password-autofill-hints).

### Screenshots / video
Not applicable; this change only updates autofill hints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved autofill behavior for sign-in password reset forms by correctly identifying both new-password fields as intended for new passwords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
