### PR TITLE
fix(ui): preserve add-email input across rotation

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileAddEmailView.kt
+++ b/source/ui/src/main/java/com/clerk/ui/userprofile/email/UserProfileAddEmailView.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.ContentType
@@ -46,7 +46,7 @@ private fun UserProfileAddEmailViewImpl(
   modifier: Modifier = Modifier,
   viewModel: AddEmailViewModel = viewModel(),
 ) {
-  var email by remember { mutableStateOf("") }
+  var email by rememberSaveable { mutableStateOf("") }
 
   val state by viewModel.state.collectAsStateWithLifecycle()
 

--- a/source/ui/src/test/java/com/clerk/ui/userprofile/email/UserProfileAddEmailViewTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/userprofile/email/UserProfileAddEmailViewTest.kt
@@ -1,0 +1,33 @@
+package com.clerk.ui.userprofile.email
+
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextInput
+import com.clerk.ui.theme.ClerkMaterialTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UserProfileAddEmailViewTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun emailInputSurvivesStateRestoration() {
+    val restorationTester = StateRestorationTester(composeTestRule)
+    restorationTester.setContent {
+      ClerkMaterialTheme {
+        UserProfileAddEmailViewBottomSheetContent(onDismiss = {}, onVerify = {})
+      }
+    }
+
+    composeTestRule.onNode(hasSetTextAction()).performTextInput("person@example.com")
+    restorationTester.emulateSavedInstanceStateRestore()
+
+    composeTestRule.onNodeWithText("person@example.com").assertExists()
+  }
+}


### PR DESCRIPTION
### What & why
Preserve the add-email sheet's input across rotation with `rememberSaveable`, matching the add-phone sheet. Add a regression test for saved-state restoration.

Fixes [MOBILE-614](https://linear.app/clerk/issue/MOBILE-614/spike-add-email-sheet-loses-input-on-rotation).

### Screenshots / video
Not included; the layout is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Email entered in the add-email form is now preserved when the screen is recreated or restored, preventing accidental loss of input.

- **Tests**
  - Added coverage to verify email input survives state restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->