### PR TITLE
fix(ui): stop decorative text-field icons consuming taps

### DIFF
--- a/source/ui/src/main/java/com/clerk/ui/core/input/ClerkTextField.kt
+++ b/source/ui/src/main/java/com/clerk/ui/core/input/ClerkTextField.kt
@@ -107,10 +107,7 @@ fun ClerkTextField(
       isError = isError,
       colors = textFieldColors,
       visualTransformation = resolvedVisualTransformation(isVisible, visualTransformation),
-      leadingIcon =
-        leadingIcon?.let { resId ->
-          { ClickableIcon(resId = resId, onClick = {}, contentDescription = null) }
-        },
+      leadingIcon = leadingIcon?.let { resId -> { TextFieldIcon(resId = resId) } },
       trailingIcon = {
         TrailingIcon(
           trailingIcon,
@@ -207,9 +204,9 @@ private fun TrailingIcon(
       }
     val tint =
       if (isError) ClerkMaterialTheme.colors.danger else ClerkMaterialTheme.colors.mutedForeground
-    ClickableIcon(
+    TextFieldIcon(
       resId = resId,
-      onClick = onClick,
+      onClick = onClick.takeIf { visualTransformation is PasswordVisualTransformation && !isError },
       tint = tint,
       contentDescription = contentDescription,
     )
@@ -230,22 +227,24 @@ private fun getTextFieldColors(): TextFieldColors =
   )
 
 /**
- * A clickable icon component used within the text field for leading and trailing icons.
+ * An icon used within the text field, optionally interactive for password visibility.
  *
  * @param resId The drawable resource ID for the icon
- * @param onClick Callback triggered when the icon is clicked
+ * @param onClick Optional callback; without one the icon is decorative
  * @param tint The color tint to apply to the icon, defaults to muted foreground color
  * @param contentDescription Content description for accessibility support
  */
 @Composable
-private fun ClickableIcon(
+private fun TextFieldIcon(
   @DrawableRes resId: Int,
-  onClick: () -> Unit,
+  onClick: (() -> Unit)? = null,
   tint: androidx.compose.ui.graphics.Color = ClerkMaterialTheme.colors.mutedForeground,
   contentDescription: String? = null,
 ) {
   Icon(
-    modifier = Modifier.size(dp24).clickable { onClick() },
+    modifier =
+      Modifier.size(dp24)
+        .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
     painter = painterResource(resId),
     contentDescription = contentDescription,
     tint = tint,

--- a/source/ui/src/test/java/com/clerk/ui/core/input/ClerkTextFieldTest.kt
+++ b/source/ui/src/test/java/com/clerk/ui/core/input/ClerkTextFieldTest.kt
@@ -1,0 +1,77 @@
+package com.clerk.ui.core.input
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import com.clerk.ui.R
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ClerkTextFieldTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun leadingIconTapFocusesField() {
+    composeTestRule.setContent {
+      ClerkTextField(value = "", onValueChange = {}, leadingIcon = R.drawable.ic_search)
+    }
+
+    composeTestRule.onAllNodes(hasClickAction(), useUnmergedTree = true).assertCountEquals(1)
+    composeTestRule.onNode(hasSetTextAction()).performTouchInput { click(Offset(24f, centerY)) }
+    composeTestRule.onNode(hasSetTextAction()).assertIsFocused()
+  }
+
+  @Test
+  fun customTrailingIconTapFocusesField() {
+    composeTestRule.setContent {
+      ClerkTextField(value = "", onValueChange = {}, trailingIcon = R.drawable.ic_cross)
+    }
+
+    composeTestRule.onAllNodes(hasClickAction(), useUnmergedTree = true).assertCountEquals(1)
+    composeTestRule.onNode(hasSetTextAction()).performTouchInput {
+      click(Offset(width - 24f, centerY))
+    }
+    composeTestRule.onNode(hasSetTextAction()).assertIsFocused()
+  }
+
+  @Test
+  fun passwordWarningIconIsDecorative() {
+    composeTestRule.setContent {
+      ClerkTextField(
+        value = "password",
+        onValueChange = {},
+        isError = true,
+        visualTransformation = PasswordVisualTransformation(),
+      )
+    }
+
+    composeTestRule.onAllNodes(hasClickAction(), useUnmergedTree = true).assertCountEquals(1)
+  }
+
+  @Test
+  fun passwordVisibilityToggleRemainsInteractive() {
+    composeTestRule.setContent {
+      ClerkTextField(
+        value = "password",
+        onValueChange = {},
+        visualTransformation = PasswordVisualTransformation(),
+      )
+    }
+
+    composeTestRule.onNodeWithContentDescription("Show password").performClick()
+    composeTestRule.onNodeWithContentDescription("Hide password").performClick()
+    composeTestRule.onNodeWithContentDescription("Show password").assertExists()
+  }
+}


### PR DESCRIPTION
### What & why
Remove click handling from decorative `ClerkTextField` icons so their taps can focus the input. Keep the password visibility toggle interactive and add regression coverage.

Fixes [MOBILE-615](https://linear.app/clerk/issue/MOBILE-615/spike-clerktextfield-icon-wrappers-consume-taps-with-no-api).

### What to focus on
Only the password visibility icon handles clicks; leading, custom trailing, and warning icons are decorative.

### Screenshots / video
Not included; the layout is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated text field icon behavior so leading, error, and standard trailing icons are decorative and do not trigger unintended interactions.
  - Preserved password visibility controls as interactive.

- **Tests**
  - Added coverage for text field focus behavior, decorative icons, and password visibility toggling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->